### PR TITLE
Fixed most of cargo audit issues.

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -4,7 +4,7 @@ name: Rust
 
 jobs:
     cargo-test:
-        name: Setup job
+        name: Test
         runs-on: ubuntu-latest
         steps:
             - run: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev
@@ -25,7 +25,7 @@ jobs:
               with:
                   command: test
     cargo-audit:
-        name: Setup job
+        name: Audit
         runs-on: ubuntu-latest
         steps:
             - run: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -4,7 +4,7 @@ name: Rust
 
 jobs:
     cargo-test:
-        name: Test
+        name: cargo test
         runs-on: ubuntu-latest
         steps:
             - run: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev
@@ -25,7 +25,7 @@ jobs:
               with:
                   command: test
     cargo-audit:
-        name: Audit
+        name: cargo audit
         runs-on: ubuntu-latest
         steps:
             - run: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,10 +1,10 @@
 on: [pull_request]
 
-name: Run tests
+name: Rust
 
 jobs:
-    test:
-        name: Test Suite
+    cargo-test:
+        name: Setup job
         runs-on: ubuntu-latest
         steps:
             - run: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev
@@ -20,12 +20,28 @@ jobs:
                   toolchain: stable
                   override: true
 
-            - name: Run cargo test
+            - name: cargo test
               uses: actions-rs/cargo@v1
               with:
                   command: test
+    cargo-audit:
+        name: Setup job
+        runs-on: ubuntu-latest
+        steps:
+            - run: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev
+            - name: Checkout sources
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
 
-            - name: Run cargo audit
+            - name: Install stable toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: stable
+                  override: true
+
+            - name: cargo audit
               uses: actions-rs/cargo@v1
               with:
                   command: audit

--- a/accountable/Cargo.toml
+++ b/accountable/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accountable"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,12 +11,17 @@ sha256 = "1.0.2"
 rand = {version = "0.6", features = ["std"]}
 uuid = { version = "0.8.0", features = ["serde", "v4"] }
 bytebuffer = "0.2.1"
-chrono = "0.4.19"
+chrono = "0.4.20"
 serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
+<<<<<<< HEAD
 pickledb = "0.4.1"
+=======
+pickledb = "0.5.1"
+libp2p = "0.41.1"
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = {version = "1.12.0", features = ["full"]}

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-secp256k1 = {version = "0.20.2", features = ["rand"]}
+secp256k1 = { version = "0.20.2", features = ["rand"] }
 sha256 = "1.0.2"
-rand = {version = "0.6", features = ["std"]}
+rand = { version = "0.6", features = ["std"] }
 uuid = { version = "0.8.0", features = ["serde", "v4"] }
 bytebuffer = "0.2.1"
 chrono = "0.4.20"
@@ -16,25 +16,23 @@ serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
-<<<<<<< HEAD
-pickledb = "0.4.1"
-=======
 pickledb = "0.5.1"
-libp2p = "0.41.1"
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
-tokio = {version = "1.12.0", features = ["full"]}
+tokio = { version = "1.12.0", features = ["full"] }
 env_logger = "0.8.1"
 hex = "*"
 itertools = "0.10.1"
-crossterm = { version = "0.19", features = [ "serde" ] }
-tui = { version = "0.14", default-features = false, features = ['crossterm', 'serde'] }
+crossterm = { version = "0.19", features = ["serde"] }
+tui = { version = "0.14", default-features = false, features = [
+    'crossterm',
+    'serde',
+] }
 thiserror = "1.0"
 ctrlc = "3.2.0"
 simplelog = "0.10.0"
 log = "0.4.14"
-ritelinked = {version = "0.3.2", features = [ 'serde' ]}
+ritelinked = { version = "0.3.2", features = ['serde'] }
 claim = { path = "../claim" }
 reward = { path = "../reward" }
 txn = { path = "../txn" }

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-secp256k1 = {version = "0.20.2", features = ["rand"]}
+secp256k1 = { version = "0.20.2", features = ["rand"] }
 sha256 = "1.0.2"
-rand = {version = "0.6", features = ["std"]}
+rand = { version = "0.6", features = ["std"] }
 uuid = { version = "0.8.0", features = ["serde", "v4"] }
 bytebuffer = "0.2.1"
 chrono = "0.4.20"
@@ -16,25 +16,23 @@ serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
-<<<<<<< HEAD
-pickledb = "0.4.1"
-=======
 pickledb = "0.5.1"
-libp2p = "0.41.1"
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
-tokio = {version = "1.12.0", features = ["full"]}
+tokio = { version = "1.12.0", features = ["full"] }
 env_logger = "0.8.1"
 hex = "*"
 itertools = "0.10.1"
-crossterm = { version = "0.19", features = [ "serde" ] }
-tui = { version = "0.14", default-features = false, features = ['crossterm', 'serde'] }
+crossterm = { version = "0.19", features = ["serde"] }
+tui = { version = "0.14", default-features = false, features = [
+    'crossterm',
+    'serde',
+] }
 thiserror = "1.0"
 ctrlc = "3.2.0"
 simplelog = "0.10.0"
 log = "0.4.14"
-ritelinked = {version = "0.3.2", features = [ 'serde' ]}
+ritelinked = { version = "0.3.2", features = ['serde'] }
 strum = "0.21.0"
 strum_macros = "0.21.0"
 unicode-width = "0.1.9"

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blockchain"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,12 +11,17 @@ sha256 = "1.0.2"
 rand = {version = "0.6", features = ["std"]}
 uuid = { version = "0.8.0", features = ["serde", "v4"] }
 bytebuffer = "0.2.1"
-chrono = "0.4.19"
+chrono = "0.4.20"
 serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
+<<<<<<< HEAD
 pickledb = "0.4.1"
+=======
+pickledb = "0.5.1"
+libp2p = "0.41.1"
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = {version = "1.12.0", features = ["full"]}

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -90,16 +90,11 @@ impl Blockchain {
 
     /// Loads the chain from binary and returns a PickleDB instance
     pub fn get_chain_db(&self) -> PickleDb {
-<<<<<<< HEAD
-        // TODO: Need to replace PickleDB with a custom database with more functionality for our protocol purposes
-        match PickleDb::load_bin(self.chain_db.clone(), PickleDbDumpPolicy::DumpUponRequest) {
-=======
         match PickleDb::load(
             self.chain_db.clone(),
             PickleDbDumpPolicy::DumpUponRequest,
             SerializationMethod::Bin,
         ) {
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
             Ok(nst) => nst,
             Err(_) => PickleDb::new(
                 self.chain_db.clone(),
@@ -207,7 +202,10 @@ impl Blockchain {
         }
         if let Some(genesis_block) = &self.genesis {
             if let Some(last_block) = &self.child {
-                if let Err(e) = block.valid(&last_block, &(network_state.to_owned(), reward_state.to_owned())) {
+                if let Err(e) = block.valid(
+                    &last_block,
+                    &(network_state.to_owned(), reward_state.to_owned()),
+                ) {
                     self.future_blocks
                         .insert(block.clone().header.last_hash, block.clone());
                     return Err(e);
@@ -227,7 +225,10 @@ impl Blockchain {
                     return Ok(());
                 }
             } else {
-                if let Err(e) = block.valid(&genesis_block, &(network_state.to_owned(), reward_state.to_owned())) {
+                if let Err(e) = block.valid(
+                    &genesis_block,
+                    &(network_state.to_owned(), reward_state.to_owned()),
+                ) {
                     return Err(e);
                 } else {
                     self.child = Some(block.clone());
@@ -241,7 +242,9 @@ impl Blockchain {
         } else {
             // check that this is a valid genesis block.
             if block.header.block_height == 0 {
-                if let Ok(true) = block.valid_genesis(&(network_state.to_owned(), reward_state.to_owned())) {
+                if let Ok(true) =
+                    block.valid_genesis(&(network_state.to_owned(), reward_state.to_owned()))
+                {
                     self.genesis = Some(block.clone());
                     self.child = Some(block.clone());
                     self.block_cache.insert(block.hash.clone(), block.clone());
@@ -429,11 +432,7 @@ impl Blockchain {
 
         None
     }
-<<<<<<< HEAD
     /// Checks if the chain is missing the current network state
-=======
-
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
     pub fn check_missing_state(&self) -> Option<ComponentTypes> {
         if !self
             .components_received
@@ -448,10 +447,6 @@ impl Blockchain {
     /// Creates vector of all components missing from the chain.
     pub fn check_missing_components(&self) -> Vec<ComponentTypes> {
         let mut missing = vec![];
-<<<<<<< HEAD
-=======
-
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
         if let Some(component) = self.check_missing_genesis() {
             missing.push(component);
         }

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -90,8 +90,16 @@ impl Blockchain {
 
     /// Loads the chain from binary and returns a PickleDB instance
     pub fn get_chain_db(&self) -> PickleDb {
+<<<<<<< HEAD
         // TODO: Need to replace PickleDB with a custom database with more functionality for our protocol purposes
         match PickleDb::load_bin(self.chain_db.clone(), PickleDbDumpPolicy::DumpUponRequest) {
+=======
+        match PickleDb::load(
+            self.chain_db.clone(),
+            PickleDbDumpPolicy::DumpUponRequest,
+            SerializationMethod::Bin,
+        ) {
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
             Ok(nst) => nst,
             Err(_) => PickleDb::new(
                 self.chain_db.clone(),
@@ -152,7 +160,11 @@ impl Blockchain {
     pub fn chain_db_from_bytes(&self, data: &[u8]) -> PickleDb {
         let db_map = serde_json::from_slice::<LinkedHashMap<String, Block>>(data).unwrap();
 
-        let mut db = PickleDb::new_bin(self.clone().chain_db, PickleDbDumpPolicy::DumpUponRequest);
+        let mut db = PickleDb::new(
+            self.clone().chain_db,
+            PickleDbDumpPolicy::DumpUponRequest,
+            SerializationMethod::Bin,
+        );
 
         db_map.iter().for_each(|(k, v)| {
             if let Err(e) = db.set(&k, &v) {
@@ -417,7 +429,11 @@ impl Blockchain {
 
         None
     }
+<<<<<<< HEAD
     /// Checks if the chain is missing the current network state
+=======
+
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
     pub fn check_missing_state(&self) -> Option<ComponentTypes> {
         if !self
             .components_received
@@ -432,6 +448,10 @@ impl Blockchain {
     /// Creates vector of all components missing from the chain.
     pub fn check_missing_components(&self) -> Vec<ComponentTypes> {
         let mut missing = vec![];
+<<<<<<< HEAD
+=======
+
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
         if let Some(component) = self.check_missing_genesis() {
             missing.push(component);
         }

--- a/claim/Cargo.toml
+++ b/claim/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "claim"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/claim_concept/Cargo.toml
+++ b/claim_concept/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "claim_concept"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/commands/Cargo.toml
+++ b/commands/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "commands"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,12 +11,17 @@ sha256 = "1.0.2"
 rand = { version = "0.6", features = ["std"] }
 uuid = { version = "0.8.0", features = ["serde", "v4"] }
 bytebuffer = "0.2.1"
-chrono = "0.4.19"
+chrono = "0.4.20"
 serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
+<<<<<<< HEAD
 pickledb = "0.4.1"
+=======
+pickledb = "0.5.1"
+libp2p = "0.41.1"
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/commands/Cargo.toml
+++ b/commands/Cargo.toml
@@ -16,12 +16,7 @@ serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
-<<<<<<< HEAD
-pickledb = "0.4.1"
-=======
 pickledb = "0.5.1"
-libp2p = "0.41.1"
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = { version = "1.12.0", features = ["full"] }
@@ -44,4 +39,3 @@ index_list = "0.2.7"
 clipboard = "0.5.0"
 messages = { path = "../messages" }
 udp2p = { git = "https://github.com/ASmithOWL/udp2p", branch = "main" }
-

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -6,10 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-<<<<<<< HEAD
-=======
-libp2p = "0.41.1"
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 hex = "*"
 sha256 = "1.0.2"
 ritelinked = { version = "0.3.2", features = ['serde'] }
@@ -17,4 +13,3 @@ serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 log = "0.4.14"
 messages = { path = "../messages" }
-

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "events"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+<<<<<<< HEAD
+=======
+libp2p = "0.41.1"
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 hex = "*"
 sha256 = "1.0.2"
 ritelinked = { version = "0.3.2", features = ['serde'] }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ledger"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "messages"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miner"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "network"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+<<<<<<< HEAD
+=======
+libp2p = "0.41.1"
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 hex = "*"
 sha256 = "1.0.2"
 ritelinked = {version = "0.3.2", features = [ 'serde' ]}

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -6,17 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-<<<<<<< HEAD
-=======
-libp2p = "0.41.1"
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 hex = "*"
 sha256 = "1.0.2"
-ritelinked = {version = "0.3.2", features = [ 'serde' ]}
+ritelinked = { version = "0.3.2", features = ['serde'] }
 serde_json = "1.0.64"
 serde = { version = "1.0.136", features = ["derive"] }
 log = "0.4.14"
-tokio = {version = "1.12.0", features = ["full"]}
+tokio = { version = "1.12.0", features = ["full"] }
 udp2p = { git = "https://github.com/ASmithOWL/udp2p", branch = "main" }
 rand = "0.8.4"
 commands = { path = "../commands" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,12 +15,7 @@ serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
-<<<<<<< HEAD
-pickledb = "0.4.1"
-=======
 pickledb = "0.5.1"
-libp2p = "0.41.1"
->>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "node"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,12 +10,17 @@ secp256k1 = { version = "0.20.2", features = ["rand"] }
 sha256 = "1.0.2"
 rand = { version = "0.6", features = ["std"] }
 bytebuffer = "0.2.1"
-chrono = "0.4.19"
+chrono = "0.4.20"
 serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
+<<<<<<< HEAD
 pickledb = "0.4.1"
+=======
+pickledb = "0.5.1"
+libp2p = "0.41.1"
+>>>>>>> b1bb0da (Fixed most of cargo audit issues.)
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/noncing/Cargo.toml
+++ b/noncing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "noncing"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ownable/Cargo.toml
+++ b/ownable/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ownable"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pool"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/quorum/Cargo.toml
+++ b/quorum/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quorum"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/reward/Cargo.toml
+++ b/reward/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reward"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "state"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/txn/Cargo.toml
+++ b/txn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "txn"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/updateable/Cargo.toml
+++ b/updateable/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "updateable"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "validator"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/verifiable/Cargo.toml
+++ b/verifiable/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verifiable"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/vrrb_cli/Cargo.toml
+++ b/vrrb_cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vrrb_cli"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/vrrb_gui/Cargo.toml
+++ b/vrrb_gui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vrrb_gui"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/vrrb_lib/Cargo.toml
+++ b/vrrb_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vrrb_lib"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,12 +11,13 @@ sha256 = "1.0.2"
 rand = {version = "0.6", features = ["std"]}
 uuid = { version = "0.8.0", features = ["serde", "v4"] }
 bytebuffer = "0.2.1"
-chrono = "0.4.19"
+chrono = "0.4.20"
 serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
-pickledb = "0.4.1"
+pickledb = "0.5.1"
+libp2p = "0.41.1"
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = {version = "1.12.0", features = ["full"]}

--- a/vrrb_lib/Cargo.toml
+++ b/vrrb_lib/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-secp256k1 = {version = "0.20.2", features = ["rand"]}
+secp256k1 = { version = "0.20.2", features = ["rand"] }
 sha256 = "1.0.2"
-rand = {version = "0.6", features = ["std"]}
+rand = { version = "0.6", features = ["std"] }
 uuid = { version = "0.8.0", features = ["serde", "v4"] }
 bytebuffer = "0.2.1"
 chrono = "0.4.20"
@@ -17,20 +17,22 @@ serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
 pickledb = "0.5.1"
-libp2p = "0.41.1"
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
-tokio = {version = "1.12.0", features = ["full"]}
+tokio = { version = "1.12.0", features = ["full"] }
 env_logger = "0.8.1"
 hex = "*"
 itertools = "0.10.1"
-crossterm = { version = "0.19", features = [ "serde" ] }
-tui = { version = "0.14", default-features = false, features = ['crossterm', 'serde'] }
+crossterm = { version = "0.19", features = ["serde"] }
+tui = { version = "0.14", default-features = false, features = [
+    'crossterm',
+    'serde',
+] }
 thiserror = "1.0"
 ctrlc = "3.2.0"
 simplelog = "0.10.0"
 log = "0.4.14"
-ritelinked = {version = "0.3.2", features = [ 'serde' ]}
+ritelinked = { version = "0.3.2", features = ['serde'] }
 strum = "0.21.0"
 strum_macros = "0.21.0"
 index_list = "0.2.7"

--- a/vrrb_lib/src/utils.rs
+++ b/vrrb_lib/src/utils.rs
@@ -10,12 +10,17 @@ pub fn decay_calculator(initial: u128, epochs: u128) -> f64 {
 }
 
 pub fn restore_db(path: &str) -> PickleDb {
-    let db = match PickleDb::load_bin(path, PickleDbDumpPolicy::DumpUponRequest) {
+    let db = match PickleDb::load(
+        path,
+        PickleDbDumpPolicy::DumpUponRequest,
+        SerializationMethod::Bin,
+    ) {
         Ok(nst) => nst,
         Err(_) => PickleDb::new(
             path,
             PickleDbDumpPolicy::DumpUponRequest,
             SerializationMethod::Bin,
-        )};
+        ),
+    };
     db
 }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wallet"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,12 +11,12 @@ sha256 = "1.0.2"
 rand = {version = "0.6", features = ["std"]}
 uuid = { version = "0.8.0", features = ["serde", "v4"] }
 bytebuffer = "0.2.1"
-chrono = "0.4.19"
+chrono = "0.4.20"
 serde_json = "1.0.64"
 serde = { version = "1.0.101", features = ["derive"] }
 blake3 = "0.3.8"
 bip39 = "1.0.1"
-pickledb = "0.4.1"
+pickledb = "0.5.1"
 futures = "0.3.1"
 async-std = { version = "1", features = ["attributes", "tokio1"] }
 tokio = {version = "1.12.0", features = ["full"]}


### PR DESCRIPTION
Bumped crates versions, changed Rust edition to newest. 

Still 3 issues exist:
- time crate version - never directly used, **chrono** crate is using old version, nothing we can do with that.
- owning_ref (libp2p dep) has unfixed problem - again, nothing we can do.
- xcb crate version - also never directly used, **clipboard** crate is using old version, we'll update if new version will arise