### PR TITLE
Set Rust version to latest stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.63.0"


### PR DESCRIPTION
This will force cargo to compile the project using the latest stable Rust version to date (1.63.0)