### PR TITLE
Refactor event router to broadcast events

### DIFF
--- a/crates/vrrb_core/Cargo.toml
+++ b/crates/vrrb_core/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 tokio = { version = "1.21.2", features = ["full"] }
 telemetry = { path = "../telemetry" }
 anyhow = "1.0.65"
+thiserror = "1.0.37"

--- a/crates/vrrb_core/src/event_router.rs
+++ b/crates/vrrb_core/src/event_router.rs
@@ -1,9 +1,6 @@
-use std::collections::{hash_map::Entry, HashMap, HashSet};
-
-// use telemetry::tracing::subscriber;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-
 use crate::{Error, Result};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 pub type Subscriber = UnboundedSender<Event>;
 pub type Publisher = UnboundedSender<(Topic, Event)>;
@@ -35,8 +32,7 @@ pub enum Topic {
 pub struct EventRouter {
     /// Map of async transmitters to various runtime modules
     subscribers: HashMap<Topic, Vec<Subscriber>>,
-    // subs: HashMap<Topic, Vec<crossbeam::channel::Sender>>,
-    subs: HashMap<Topic, tokio::sync::broadcast::Sender<Event>>,
+    topics: HashMap<Topic, tokio::sync::broadcast::Sender<Event>>,
 }
 
 pub type DirectedEvent = (Topic, Event);
@@ -51,15 +47,22 @@ impl EventRouter {
     pub fn new() -> Self {
         Self {
             subscribers: HashMap::new(),
-            subs: HashMap::new(),
+            topics: HashMap::new(),
         }
+    }
+
+    pub fn add_topic(&mut self, topic: Topic, size: Option<usize>) {
+        let buffer = size.unwrap_or(1);
+        let (tx, _) = tokio::sync::broadcast::channel(buffer);
+
+        self.topics.insert(topic, tx);
     }
 
     pub fn subscribe(
         &self,
         topic: &Topic,
     ) -> std::result::Result<tokio::sync::broadcast::Receiver<Event>, Error> {
-        if let Some(sender) = self.subs.get(topic) {
+        if let Some(sender) = self.topics.get(topic) {
             Ok(sender.subscribe())
         } else {
             Err(Error::Other(format!("unable to subscriber to {topic:?}")))
@@ -96,8 +99,6 @@ impl EventRouter {
             for subscriber in subscriber_list {
                 //TODO: report errors
                 if let Err(err) = subscriber.send(event.clone()) {
-                    dbg!(&err);
-
                     telemetry::error!(
                         "failed to send event {:?} to topic {:?}. reason: {:?}",
                         event,
@@ -151,6 +152,39 @@ mod tests {
 
     #[tokio::test]
     async fn should_route_events() {
+        let (event_tx, mut event_rx) = unbounded_channel::<DirectedEvent>();
+        let mut router = EventRouter::new();
+
+        let (miner_event_tx, mut miner_event_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+        let (validator_event_tx, mut validator_event_rx) = unbounded_channel::<Event>();
+
+        router.add_subscriber(Topic::Control, miner_event_tx);
+        router.add_subscriber(Topic::Control, validator_event_tx.clone());
+        router.add_subscriber(Topic::Transactions, validator_event_tx);
+
+        let handle = tokio::spawn(async move {
+            router.start(&mut event_rx).await;
+        });
+
+        event_tx
+            .send((Topic::Transactions, Event::TxnCreated(Vec::new())))
+            .unwrap();
+
+        event_tx.send((Topic::Control, Event::Stop)).unwrap();
+
+        handle.await.unwrap();
+
+        assert_eq!(
+            validator_event_rx.recv().await.unwrap(),
+            Event::TxnCreated(Vec::new())
+        );
+
+        assert_eq!(validator_event_rx.recv().await.unwrap(), Event::Stop);
+        assert_eq!(miner_event_rx.recv().await.unwrap(), Event::Stop);
+    }
+
+    #[tokio::test]
+    async fn all_subscribers_should_receive_messages() {
         let (event_tx, mut event_rx) = unbounded_channel::<DirectedEvent>();
         let mut router = EventRouter::new();
 

--- a/crates/vrrb_core/src/result.rs
+++ b/crates/vrrb_core/src/result.rs
@@ -1,3 +1,7 @@
-pub type Error = anyhow::Error;
-
 pub type Result<T> = anyhow::Result<T>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Other(String),
+}


### PR DESCRIPTION
Changes the way EventRouter broadcasts events to all runtime module consumers.