### PR TITLE
Feat adapt rpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "crates/storage/utils",
     "crates/syncing",
     "crates/telemetry",
+    "crates/utils"
 ]
 
 [workspace.dependencies]

--- a/crates/block/src/header.rs
+++ b/crates/block/src/header.rs
@@ -1,4 +1,5 @@
 // FEATURE TAG(S): Block Structure, Rewards
+use chrono;
 use primitives::{Epoch, SecretKey, SerializedSecretKey};
 use reward::reward::Reward;
 use secp256k1::{
@@ -10,7 +11,6 @@ use sha256::digest;
 use utils::{create_payload, hash_data};
 use vrrb_core::{claim::Claim, keypair::KeyPair};
 use vrrb_vrf::{vrng::VRNG, vvrf::VVRF};
-use chrono;
 
 use crate::{
     block::Block,

--- a/crates/block/src/header.rs
+++ b/crates/block/src/header.rs
@@ -7,9 +7,10 @@ use secp256k1::{
 };
 use serde::{Deserialize, Serialize};
 use sha256::digest;
-use utils::{create_payload, hash_data, timestamp};
+use utils::{create_payload, hash_data};
 use vrrb_core::{claim::Claim, keypair::KeyPair};
 use vrrb_vrf::{vrng::VRNG, vvrf::VVRF};
+use chrono;
 
 use crate::{
     block::Block,
@@ -64,7 +65,7 @@ impl BlockHeader {
 
         let next_block_seed = vrf.generate_u64_in_range(u32::MAX as u64, u64::MAX);
 
-        let timestamp = timestamp!();
+        let timestamp = chrono::Utc::now().timestamp();
         let txn_hash = hash_data!("Genesis_Txn_Hash");
         let block_reward = Reward::genesis(Some(miner_claim.address.clone()));
         let block_height = 0;
@@ -142,7 +143,7 @@ impl BlockHeader {
         let next_block_seed = vrf.generate_u64_in_range(u32::MAX as u64, u64::MAX);
 
         // generate timestamp
-        let timestamp = timestamp!();
+        let timestamp = chrono::Utc::now().timestamp();
 
         // Get current block reward, which is last_block.next_block_reward
         let mut block_reward = last_block.get_next_block_reward();

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,8 @@ sha256 = { workspace = true }
 secp256k1 = { workspace = true }
 serde = { workspace = true }
 config = { workspace = true }
+wallet = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -15,9 +15,7 @@ pub async fn exec(args: Args) -> Result<()> {
 
     match cmd {
         Some(Commands::Node(node_args)) => node::exec(node_args).await,
-        Some(Commands::Wallet(wallet_args)) => {
-            wallet::exec(wallet_args).await
-        },
+        Some(Commands::Wallet(wallet_args)) => wallet::exec(wallet_args).await,
         None => Err(CliError::NoSubcommand),
         _ => Err(CliError::InvalidCommand(format!("{:?}", cmd))),
     }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -15,7 +15,9 @@ pub async fn exec(args: Args) -> Result<()> {
 
     match cmd {
         Some(Commands::Node(node_args)) => node::exec(node_args).await,
-        Some(Commands::Wallet(wallet_args)) => wallet::exec(wallet_args).await,
+        Some(Commands::Wallet(wallet_args)) => {
+            wallet::exec(wallet_args).await
+        },
         None => Err(CliError::NoSubcommand),
         _ => Err(CliError::InvalidCommand(format!("{:?}", cmd))),
     }

--- a/crates/cli/src/commands/wallet/get.rs
+++ b/crates/cli/src/commands/wallet/get.rs
@@ -1,24 +1,22 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use primitives::Address;
 use vrrb_core::account::Account;
 use wallet::v2::Wallet;
-use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+
 use crate::result::CliError;
 
 pub async fn exec(address: Address) -> Option<Account> {
+    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9293);
 
-    let rpc_server = SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9293
-    );
+    let res = Wallet::new(rpc_server)
+        .await
+        .map_err(|err| CliError::Other(err.to_string()));
 
-    let res = Wallet::new(rpc_server).await.map_err(|err| {
-        CliError::Other(err.to_string())
-    }); 
-    
     if let Ok(mut wallet) = res {
         let opt = wallet.get_account(address).await;
-        return opt 
+        return opt;
     }
-    
-    return None
-    
+
+    return None;
 }

--- a/crates/cli/src/commands/wallet/get.rs
+++ b/crates/cli/src/commands/wallet/get.rs
@@ -1,1 +1,24 @@
+use primitives::Address;
+use vrrb_core::account::Account;
+use wallet::v2::Wallet;
+use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+use crate::result::CliError;
 
+pub async fn exec(address: Address) -> Option<Account> {
+
+    let rpc_server = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9293
+    );
+
+    let res = Wallet::new(rpc_server).await.map_err(|err| {
+        CliError::Other(err.to_string())
+    }); 
+    
+    if let Ok(mut wallet) = res {
+        let opt = wallet.get_account(address).await;
+        return opt 
+    }
+    
+    return None
+    
+}

--- a/crates/cli/src/commands/wallet/info.rs
+++ b/crates/cli/src/commands/wallet/info.rs
@@ -1,6 +1,14 @@
-use crate::result::Result;
+use crate::result::{Result, CliError};
+use wallet::v2::Wallet;
+use std::net::{SocketAddr, IpAddr, Ipv4Addr};
 
 pub async fn exec() -> Result<()> {
-    println!("wallet::info");
+    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0,0,0,0)), 9293);
+
+    let wallet: Wallet = Wallet::new(rpc_server).await.map_err(
+        |err| CliError::Other(format!("unable to create wallet: {:?}", err).to_string())
+    )?;
+    
+    println!("{:?}", wallet);
     Ok(())
 }

--- a/crates/cli/src/commands/wallet/info.rs
+++ b/crates/cli/src/commands/wallet/info.rs
@@ -1,14 +1,16 @@
-use crate::result::{Result, CliError};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use wallet::v2::Wallet;
-use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+
+use crate::result::{CliError, Result};
 
 pub async fn exec() -> Result<()> {
-    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0,0,0,0)), 9293);
+    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9293);
 
-    let wallet: Wallet = Wallet::new(rpc_server).await.map_err(
-        |err| CliError::Other(format!("unable to create wallet: {:?}", err).to_string())
-    )?;
-    
+    let wallet: Wallet = Wallet::new(rpc_server).await.map_err(|err| {
+        CliError::Other(format!("unable to create wallet: {:?}", err).to_string())
+    })?;
+
     println!("{:?}", wallet);
     Ok(())
 }

--- a/crates/cli/src/commands/wallet/mod.rs
+++ b/crates/cli/src/commands/wallet/mod.rs
@@ -42,7 +42,7 @@ pub enum WalletCmd {
     /// Gets information about an account
     Get {
         #[clap(short, long)]
-        address: String
+        address: String,
     },
 }
 
@@ -54,11 +54,14 @@ pub async fn exec(args: WalletOpts) -> Result<()> {
     match sub_cmd {
         WalletCmd::Info => info::exec().await,
         WalletCmd::Transfer {
-            address_number, to, amount, token 
-        } => { 
-                transfer::exec(address_number, to, amount, token).await?;
+            address_number,
+            to,
+            amount,
+            token,
+        } => {
+            transfer::exec(address_number, to, amount, token).await?;
 
-                Ok(())
+            Ok(())
         },
         WalletCmd::New { address, account } => {
             let address = if let Ok(addr) = serde_json::from_str(&address) {
@@ -70,7 +73,7 @@ pub async fn exec(args: WalletOpts) -> Result<()> {
             let account = if let Ok(acct) = serde_json::from_str(&account) {
                 acct
             } else {
-                return Err(CliError::Other("invalid account".to_string()))
+                return Err(CliError::Other("invalid account".to_string()));
             };
 
             new::exec(address, account).await?;
@@ -93,5 +96,3 @@ pub async fn exec(args: WalletOpts) -> Result<()> {
         _ => Err(CliError::InvalidCommand(format!("{:?}", sub_cmd))),
     }
 }
-
-

--- a/crates/cli/src/commands/wallet/mod.rs
+++ b/crates/cli/src/commands/wallet/mod.rs
@@ -4,6 +4,7 @@ mod new;
 mod transfer;
 
 use clap::{Parser, Subcommand};
+use serde_json;
 
 use crate::result::{CliError, Result};
 
@@ -19,20 +20,78 @@ pub enum WalletCmd {
     Info,
 
     /// Transfer objects between accounts
-    Transfer,
+    Transfer {
+        #[clap(short, long)]
+        address_number: u32,
+        #[clap(short, long)]
+        to: String,
+        #[clap(short, long)]
+        amount: u128,
+        #[clap(short, long)]
+        token: Option<String>,
+    },
 
     /// Create a new account on the network
-    New,
+    New {
+        #[clap(short, long)]
+        address: String,
+        #[clap(short, long)]
+        account: String,
+    },
 
     /// Gets information about an account
-    Get,
+    Get {
+        #[clap(short, long)]
+        address: String
+    },
 }
 
+
+#[allow(unreachable_patterns)]
 pub async fn exec(args: WalletOpts) -> Result<()> {
     let sub_cmd = args.subcommand;
 
     match sub_cmd {
         WalletCmd::Info => info::exec().await,
+        WalletCmd::Transfer {
+            address_number, to, amount, token 
+        } => { 
+                transfer::exec(address_number, to, amount, token).await?;
+
+                Ok(())
+        },
+        WalletCmd::New { address, account } => {
+            let address = if let Ok(addr) = serde_json::from_str(&address) {
+                addr
+            } else {
+                return Err(CliError::Other("invalid address".to_string()));
+            };
+
+            let account = if let Ok(acct) = serde_json::from_str(&account) {
+                acct
+            } else {
+                return Err(CliError::Other("invalid account".to_string()))
+            };
+
+            new::exec(address, account).await?;
+
+            Ok(())
+        },
+        WalletCmd::Get { address } => {
+            let address = if let Ok(addr) = serde_json::from_str(&address) {
+                addr
+            } else {
+                return Err(CliError::Other("invalid address".to_string()));
+            };
+
+            if let Some(acct) = get::exec(address).await {
+                println!("{:?}", acct);
+            };
+
+            Ok(())
+        },
         _ => Err(CliError::InvalidCommand(format!("{:?}", sub_cmd))),
     }
 }
+
+

--- a/crates/cli/src/commands/wallet/new.rs
+++ b/crates/cli/src/commands/wallet/new.rs
@@ -1,1 +1,20 @@
+use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+use primitives::Address;
+use vrrb_core::account::Account;
+use wallet::v2::Wallet;
+use crate::result::CliError;
 
+pub async fn exec(address: Address, account: Account) -> Result<(), CliError> {
+   
+    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0,0,0,0)), 9293);
+
+    let mut wallet = Wallet::new(rpc_server).await.map_err(
+        |err| CliError::Other("unable to create wallet".to_string())
+    )?;
+    
+    wallet.create_account().await.map_err(|err| {
+        CliError::Other("unable to create account in state".to_string())
+    })?;
+   
+    Ok(())
+}

--- a/crates/cli/src/commands/wallet/new.rs
+++ b/crates/cli/src/commands/wallet/new.rs
@@ -1,20 +1,22 @@
-use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use primitives::Address;
 use vrrb_core::account::Account;
 use wallet::v2::Wallet;
+
 use crate::result::CliError;
 
 pub async fn exec(address: Address, account: Account) -> Result<(), CliError> {
-   
-    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0,0,0,0)), 9293);
+    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9293);
 
-    let mut wallet = Wallet::new(rpc_server).await.map_err(
-        |err| CliError::Other("unable to create wallet".to_string())
-    )?;
-    
-    wallet.create_account().await.map_err(|err| {
-        CliError::Other("unable to create account in state".to_string())
-    })?;
-   
+    let mut wallet = Wallet::new(rpc_server)
+        .await
+        .map_err(|err| CliError::Other("unable to create wallet".to_string()))?;
+
+    wallet
+        .create_account()
+        .await
+        .map_err(|err| CliError::Other("unable to create account in state".to_string()))?;
+
     Ok(())
 }

--- a/crates/cli/src/commands/wallet/transfer.rs
+++ b/crates/cli/src/commands/wallet/transfer.rs
@@ -1,32 +1,32 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use primitives::digest::TransactionDigest;
 use vrrb_core::txn::TxToken;
 use wallet::v2::Wallet;
+
 use crate::result::CliError;
-use primitives::digest::TransactionDigest;
-use std::net::{SocketAddr, IpAddr, Ipv4Addr};
 
 pub async fn exec(
     address_number: u32,
     to: String,
     amount: u128,
-    token: Option<TxToken>
+    token: Option<TxToken>,
 ) -> Result<TransactionDigest, CliError> {
-    
-    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0,0,0,0)), 9293);
+    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9293);
 
-    let mut wallet = Wallet::new(rpc_server).await.map_err(
-        |err| CliError::Other(err.to_string())
-    )?;
-    
-    wallet.create_account().await.map_err(|err| {
-        CliError::Other(err.to_string())
-    })?;
+    let mut wallet = Wallet::new(rpc_server)
+        .await
+        .map_err(|err| CliError::Other(err.to_string()))?;
 
-    // TODO: We need a faucet to first receive tokens from 
+    wallet
+        .create_account()
+        .await
+        .map_err(|err| CliError::Other(err.to_string()))?;
+
+    // TODO: We need a faucet to first receive tokens from
     // or we need to initialize accounts with tokens on testnet
-    wallet.send_txn(
-        address_number,
-        to,
-        amount,
-        token 
-    ).await.map_err(|err| CliError::Other(err.to_string()))
+    wallet
+        .send_txn(address_number, to, amount, token)
+        .await
+        .map_err(|err| CliError::Other(err.to_string()))
 }

--- a/crates/cli/src/commands/wallet/transfer.rs
+++ b/crates/cli/src/commands/wallet/transfer.rs
@@ -1,1 +1,32 @@
+use vrrb_core::txn::TxToken;
+use wallet::v2::Wallet;
+use crate::result::CliError;
+use primitives::digest::TransactionDigest;
+use std::net::{SocketAddr, IpAddr, Ipv4Addr};
 
+pub async fn exec(
+    address_number: u32,
+    to: String,
+    amount: u128,
+    token: Option<TxToken>
+) -> Result<TransactionDigest, CliError> {
+    
+    let rpc_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0,0,0,0)), 9293);
+
+    let mut wallet = Wallet::new(rpc_server).await.map_err(
+        |err| CliError::Other(err.to_string())
+    )?;
+    
+    wallet.create_account().await.map_err(|err| {
+        CliError::Other(err.to_string())
+    })?;
+
+    // TODO: We need a faucet to first receive tokens from 
+    // or we need to initialize accounts with tokens on testnet
+    wallet.send_txn(
+        address_number,
+        to,
+        amount,
+        token 
+    ).await.map_err(|err| CliError::Other(err.to_string()))
+}

--- a/crates/cli/src/result.rs
+++ b/crates/cli/src/result.rs
@@ -23,6 +23,9 @@ pub enum CliError {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 
+    #[error("opts error: {0}")]
+    OptsError(String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/cli/tests/node_cli.rs
+++ b/crates/cli/tests/node_cli.rs
@@ -23,5 +23,3 @@ SUBCOMMANDS:
 
     cmd.arg("--help").assert().stdout(help_text).success();
 }
-
-

--- a/crates/cli/tests/node_cli.rs
+++ b/crates/cli/tests/node_cli.rs
@@ -23,3 +23,5 @@ SUBCOMMANDS:
 
     cmd.arg("--help").assert().stdout(help_text).success();
 }
+
+

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -530,7 +530,7 @@ mod tests {
         let block_seed = 34_989_333;
         let next_block_seed = 839_999_843;
         let block_height = 29_999_998;
-        let timestamp = chrono::Utc::now().timestamp(); 
+        let timestamp = chrono::Utc::now().timestamp();
         let txn_hash = "abcdef01234567890".to_string();
 
         let miner_claim = create_claim(&mpk1, &addr.to_string(), 1);

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -15,39 +15,30 @@ pub mod v2 {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, mem, str::FromStr};
+    use std::{collections::HashMap, str::FromStr};
 
     use block::{header::BlockHeader, Block, ConvergenceBlock};
     use bulldag::{graph::BullDag, vertex::Vertex};
-    use primitives::{PublicKey, SecretKey, Signature};
+    use primitives::{PublicKey, Signature};
     use reward::reward::Reward;
     use ritelinked::{LinkedHashMap, LinkedHashSet};
     use secp256k1::{
         hashes::{sha256 as s256, Hash},
-        rand,
         Message,
     };
     use sha256::digest;
     use utils::{create_payload, hash_data};
-    use vrrb_core::{
-        keypair::{Keypair, SecretKeys},
-        txn::Txn,
-    };
+    use vrrb_core::txn::Txn;
 
     use super::test_helpers::create_txns;
-    use crate::{
-        test_helpers::{
-            build_proposal_block,
-            create_claim,
-            create_keypair,
-            create_miner,
-            mine_convergence_block,
-            mine_convergence_block_epoch_change,
-            mine_genesis,
-        },
-        MineArgs,
-        Miner,
-        MinerConfig,
+    use crate::test_helpers::{
+        build_proposal_block,
+        create_claim,
+        create_keypair,
+        create_miner,
+        mine_convergence_block,
+        mine_convergence_block_epoch_change,
+        mine_genesis,
     };
 
     #[test]
@@ -428,7 +419,7 @@ mod tests {
         let block_seed = 34_989_333;
         let next_block_seed = 839_999_843;
         let block_height = 29_999_998;
-        let timestamp = utils::timestamp!();
+        let timestamp = chrono::Utc::now().timestamp();
         let txn_hash = "abcdef01234567890".to_string();
         let miner_claim = miner.generate_claim(nonce);
         let claim_list_hash = "01234567890abcdef".to_string();
@@ -539,7 +530,7 @@ mod tests {
         let block_seed = 34_989_333;
         let next_block_seed = 839_999_843;
         let block_height = 29_999_998;
-        let timestamp = utils::timestamp!();
+        let timestamp = chrono::Utc::now().timestamp(); 
         let txn_hash = "abcdef01234567890".to_string();
 
         let miner_claim = create_claim(&mpk1, &addr.to_string(), 1);

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -5,12 +5,8 @@
 //FEATURE TAG(S): Block Structure, VRF for Next Block Seed, Rewards
 use std::{
     cmp::Ordering,
-    collections::{BTreeSet, HashMap, HashSet},
-    error::Error,
-    fmt,
+    collections::{HashMap, HashSet},
     mem,
-    ptr::addr_of,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use block::{
@@ -34,8 +30,7 @@ use bulldag::{
     graph::BullDag,
     vertex::{Direction, Vertex},
 };
-use mempool::LeftRightMempool;
-use primitives::{Address, Epoch, PublicKey, SecretKey, SerializedSecretKey, Signature};
+use primitives::{Address, Epoch, PublicKey, SecretKey, Signature};
 use reward::reward::Reward;
 use ritelinked::{LinkedHashMap, LinkedHashSet};
 use secp256k1::{
@@ -44,12 +39,10 @@ use secp256k1::{
 };
 use serde::{Deserialize, Serialize};
 use sha256::digest;
-use state::{state::NetworkState, NodeStateReadHandle};
-use utils::{create_payload, hash_data, timestamp};
+use utils::{create_payload, hash_data};
 use vrrb_core::{
     claim::Claim,
-    keypair::{KeyPair, MinerPk, MinerSk},
-    nonceable::Nonceable,
+    keypair::{MinerPk, MinerSk},
     txn::Txn,
 };
 
@@ -148,7 +141,7 @@ impl Miner {
 
     /// Facade method to mine the various available block types
     pub fn mine(&mut self, args: MineArgs) -> Result<Block, MinerError> {
-        let now = timestamp!();
+        let now = chrono::Utc::now().timestamp();
         todo!()
     }
 
@@ -383,8 +376,7 @@ impl Miner {
 
     /// Gets a local current timestamp
     pub fn get_timestamp(&self) -> u128 {
-        todo!()
-        // utils::timestamp!()
+        chrono::Utc::now().timestamp() as u128
     }
 
     // Check that conflicts with previous convergence block are removed

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -86,6 +86,7 @@ impl Node {
         let controller_events_rx = event_router.subscribe(&Topic::Network)?;
         let validator_events_rx = event_router.subscribe(&Topic::Consensus)?;
         let miner_events_rx = event_router.subscribe(&Topic::Consensus)?;
+        let jsonrpc_events_rx = event_router.subscribe(&Topic::Control)?;
 
         let (
             updated_config,
@@ -105,6 +106,7 @@ impl Node {
             controller_events_rx,
             validator_events_rx,
             miner_events_rx,
+            jsonrpc_events_rx,
         )
         .await?;
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,3 +10,5 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 hbbft = { workspace = true }
 secp256k1 = { workspace = true }
+serde_json = { workspace = true }
+jsonrpsee = { workspace = true }

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -77,7 +77,7 @@ impl StateStore {
                 "cannot insert account with nonce bigger than 0".to_string(),
             ));
         }
-        
+
         self.trie.insert_uncommitted(key, account);
 
         Ok(())

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -18,6 +18,7 @@ use crate::RocksDbAdapter;
 mod state_store_rh;
 pub use state_store_rh::*;
 
+pub type Accounts = Vec<Account>;
 pub type FailedAccountUpdates = Vec<(Address, Vec<UpdateArgs>, Result<()>)>;
 
 #[derive(Debug, Clone)]
@@ -76,7 +77,7 @@ impl StateStore {
                 "cannot insert account with nonce bigger than 0".to_string(),
             ));
         }
-
+        
         self.trie.insert_uncommitted(key, account);
 
         Ok(())

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -127,7 +127,7 @@ impl VrrbDb {
                     debits: Some(account.debits),
                     storage: Some(account.storage),
                     code: Some(account.code),
-                    digests: Some(account.digests)
+                    digests: Some(account.digests),
                 },
             )
             .map_err(|err| StorageError::Other(err.to_string()))

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -65,6 +65,10 @@ impl VrrbDb {
         }
     }
 
+    pub fn add_account(&mut self, address: Address, account: Account) -> Result<()> {
+        self.state_store.insert(address, account)
+    }
+
     pub fn state_store(&self) -> &StateStore {
         &self.state_store
     }
@@ -123,6 +127,7 @@ impl VrrbDb {
                     debits: Some(account.debits),
                     storage: Some(account.storage),
                     code: Some(account.code),
+                    digests: Some(account.digests)
                 },
             )
             .map_err(|err| StorageError::Other(err.to_string()))

--- a/crates/storage/vrrbdb/tests/node_state.rs
+++ b/crates/storage/vrrbdb/tests/node_state.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, collections::HashMap};
+use std::{collections::HashMap, env, fs};
 
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use state::NodeState;
@@ -59,7 +59,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
-                digests: HashMap::new() 
+                digests: HashMap::new(),
             },
         )
         .unwrap();
@@ -75,7 +75,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
-                digests: HashMap::new()
+                digests: HashMap::new(),
             },
         )
         .unwrap();
@@ -96,7 +96,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
-                digests: HashMap::new()
+                digests: HashMap::new(),
             },
         ),
         (
@@ -109,7 +109,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
-                digests: HashMap::new()
+                digests: HashMap::new(),
             },
         ),
         (
@@ -122,7 +122,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
-                digests: HashMap::new()
+                digests: HashMap::new(),
             },
         ),
     ]);

--- a/crates/storage/vrrbdb/tests/node_state.rs
+++ b/crates/storage/vrrbdb/tests/node_state.rs
@@ -1,4 +1,4 @@
-use std::{env, fs};
+use std::{env, fs, collections::HashMap};
 
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use state::NodeState;
@@ -59,6 +59,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
+                digests: HashMap::new() 
             },
         )
         .unwrap();
@@ -74,6 +75,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
+                digests: HashMap::new()
             },
         )
         .unwrap();
@@ -94,6 +96,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
+                digests: HashMap::new()
             },
         ),
         (
@@ -106,6 +109,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
+                digests: HashMap::new()
             },
         ),
         (
@@ -118,6 +122,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
+                digests: HashMap::new()
             },
         ),
     ]);

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,13 +1,6 @@
 pub mod payload;
 
 pub mod time {
-    #[macro_export]
-    /// Returns a Unix timestamp in UTC
-    macro_rules! timestamp {
-        () => {{
-            chrono::offset::Utc::now().timestamp()
-        }};
-    }
 }
 
 #[cfg(test)]

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod payload;
 
-pub mod time {
-}
+pub mod time {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/vrrb_core/src/account.rs
+++ b/crates/vrrb_core/src/account.rs
@@ -14,7 +14,7 @@ pub enum AccountField {
     Debits(u128),
     Storage(Option<String>),
     Code(Option<String>),
-    Digests(HashMap<AccountNonce, TransactionDigest>)
+    Digests(HashMap<AccountNonce, TransactionDigest>),
 }
 
 /// Struct representing the desired updates to be applied to account.
@@ -25,7 +25,7 @@ pub struct UpdateArgs {
     pub debits: Option<u128>,
     pub storage: Option<Option<String>>,
     pub code: Option<Option<String>>,
-    pub digests: Option<HashMap<AccountNonce, TransactionDigest>> 
+    pub digests: Option<HashMap<AccountNonce, TransactionDigest>>,
 }
 
 // The AccountFieldsUpdate will be compared by `nonce`. This way the updates can
@@ -53,7 +53,7 @@ pub struct Account {
     pub storage: Option<String>,
     pub code: Option<String>,
     pub pubkey: SerializedPublicKey,
-    pub digests: HashMap<AccountNonce, TransactionDigest>
+    pub digests: HashMap<AccountNonce, TransactionDigest>,
 }
 
 impl Account {
@@ -83,7 +83,7 @@ impl Account {
             storage,
             code,
             pubkey,
-            digests
+            digests,
         }
     }
 
@@ -118,8 +118,8 @@ impl Account {
     //
     // THOUGHT:
     //
-    // WRT the above, maybe what we want to do is use bytes/hex strings instead of values 
-    // and then just do byte/hex math for display...
+    // WRT the above, maybe what we want to do is use bytes/hex strings instead of
+    // values and then just do byte/hex math for display...
 
     /// Updates single field in account struct without updating it's hash.
     /// Unsafe to use alone (hash should be recalculated).
@@ -158,7 +158,7 @@ impl Account {
             // better to batch them and update or at least have option to.
             AccountField::Digests(digests) => {
                 self.digests.extend(digests);
-            }
+            },
         }
         Ok(())
     }

--- a/crates/vrrb_core/src/event_router.rs
+++ b/crates/vrrb_core/src/event_router.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use primitives::{
+    Address,
     FarmerQuorumThreshold,
     NodeIdx,
     NodeType,
@@ -12,7 +13,7 @@ use primitives::{
     QuorumType,
     RawSignature,
     TxHash,
-    TxHashString, Address,
+    TxHashString,
 };
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
@@ -21,7 +22,7 @@ use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
 };
 
-use crate::{txn::Txn, Error, Result, account::Account};
+use crate::{account::Account, txn::Txn, Error, Result};
 
 pub type Subscriber = UnboundedSender<Event>;
 pub type Publisher = UnboundedSender<(Topic, Event)>;

--- a/crates/vrrb_core/src/event_router.rs
+++ b/crates/vrrb_core/src/event_router.rs
@@ -12,7 +12,7 @@ use primitives::{
     QuorumType,
     RawSignature,
     TxHash,
-    TxHashString,
+    TxHashString, Address,
 };
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
@@ -21,10 +21,11 @@ use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
 };
 
-use crate::{txn::Txn, Error, Result};
+use crate::{txn::Txn, Error, Result, account::Account};
 
 pub type Subscriber = UnboundedSender<Event>;
 pub type Publisher = UnboundedSender<(Topic, Event)>;
+pub type AccountBytes = Vec<u8>;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerData {
@@ -126,6 +127,8 @@ pub enum Event {
     QuorumCertifiedTxns(QuorumCertifiedTxn),
 
     ConfirmedTxns(Vec<(String, QuorumPublicKey)>),
+    AccountCreated((Address, AccountBytes)),
+    UpdateAccount(AccountBytes),
     // SendTxn(u32, String, u128), // address number, receiver address, amount
     // ProcessTxnValidator(Vec<u8>),
     // PendingBlock(Vec<u8>, String),

--- a/crates/vrrb_core/src/txn.rs
+++ b/crates/vrrb_core/src/txn.rs
@@ -374,8 +374,6 @@ impl FromStr for NewTxnArgs {
     type Err = ParseTxnArgsError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s).map_err(|err| {
-            ParseTxnArgsError(err.to_string())
-        })
+        serde_json::from_str(s).map_err(|err| ParseTxnArgsError(err.to_string()))
     }
 }

--- a/crates/vrrb_rpc/src/rpc/api.rs
+++ b/crates/vrrb_rpc/src/rpc/api.rs
@@ -2,12 +2,7 @@ use std::{collections::HashMap, net::SocketAddr};
 
 use async_trait::async_trait;
 use jsonrpsee::{core::Error, proc_macros::rpc, types::SubscriptionResult};
-use primitives::{
-    Address,
-    NodeType,
-    SerializedPublicKey,
-    TransactionDigest,
-};
+use primitives::{Address, NodeType, SerializedPublicKey, TransactionDigest};
 use serde::{Deserialize, Serialize};
 use vrrb_core::{
     account::Account,
@@ -56,14 +51,17 @@ pub trait Rpc {
 
     /// List a group of transactions
     #[method(name = "listTransactions")]
-    async fn list_transactions(&self, digests: Vec<TransactionDigest>) -> Result<HashMap<TransactionDigest, Txn>, Error>;
+    async fn list_transactions(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> Result<HashMap<TransactionDigest, Txn>, Error>;
 
     #[method(name = "createAccount")]
-    async fn create_account(&self, address:Address, account: Account) -> Result<(), Error>;
+    async fn create_account(&self, address: Address, account: Account) -> Result<(), Error>;
 
     #[method(name = "updateAccount")]
     async fn update_account(&self, account: Account) -> Result<(), Error>;
-    
+
     #[method(name = "getAccount")]
     async fn get_account(&self, address: Address) -> Result<Account, Error>;
 

--- a/crates/vrrb_rpc/src/rpc/api.rs
+++ b/crates/vrrb_rpc/src/rpc/api.rs
@@ -5,16 +5,13 @@ use jsonrpsee::{core::Error, proc_macros::rpc, types::SubscriptionResult};
 use primitives::{
     Address,
     NodeType,
-    PublicKey,
     SerializedPublicKey,
-    SerializedPublicKeyString,
     TransactionDigest,
 };
 use serde::{Deserialize, Serialize};
-use storage::vrrbdb::VrrbDbReadHandle;
 use vrrb_core::{
     account::Account,
-    txn::{TxAmount, TxNonce, TxPayload, TxSignature, TxToken, Txn},
+    txn::{TxAmount, TxNonce, TxPayload, TxSignature, Txn},
 };
 
 pub type ExampleHash = [u8; 32];
@@ -35,6 +32,7 @@ pub struct CreateTxnArgs {
 }
 
 #[rpc(server, client, namespace = "state")]
+#[async_trait]
 pub trait Rpc {
     /// Returns a full list of all accounts within state
     #[method(name = "getFullState")]
@@ -48,18 +46,27 @@ pub trait Rpc {
     #[method(name = "getNodeType")]
     async fn get_node_type(&self) -> Result<NodeType, Error>;
 
+    /// Create a new transaction
     #[method(name = "createTxn")]
-    async fn create_txn(&self, args: CreateTxnArgs) -> Result<(), Error>;
+    async fn create_txn(&self, args: Txn) -> Result<(), Error>;
 
+    /// Get a transaction from state
     #[method(name = "getTransaction")]
-    async fn get_transaction(&self, transaction_digest: TransactionDigest) -> Result<(), Error>;
+    async fn get_transaction(&self, transaction_digest: TransactionDigest) -> Result<Txn, Error>;
 
+    /// List a group of transactions
     #[method(name = "listTransactions")]
-    async fn list_transactions(&self) -> Result<(), Error>;
+    async fn list_transactions(&self, digests: Vec<TransactionDigest>) -> Result<HashMap<TransactionDigest, Txn>, Error>;
 
     #[method(name = "createAccount")]
-    async fn create_account(&self, account: Account) -> Result<(), Error>;
+    async fn create_account(&self, address:Address, account: Account) -> Result<(), Error>;
 
     #[method(name = "updateAccount")]
     async fn update_account(&self, account: Account) -> Result<(), Error>;
+    
+    #[method(name = "getAccount")]
+    async fn get_account(&self, address: Address) -> Result<Account, Error>;
+
+    //#[method(name = "faucetDrip")]
+    //async fn faucet_drip(&self, address: Address) -> Result<(), Error>;
 }

--- a/crates/vrrb_rpc/src/rpc/server.rs
+++ b/crates/vrrb_rpc/src/rpc/server.rs
@@ -1,14 +1,14 @@
-use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use async_trait::async_trait;
 use jsonrpsee::{
     core::Error,
-    server::{ServerBuilder, SubscriptionSink, ServerHandle},
+    server::{ServerBuilder, ServerHandle, SubscriptionSink},
     types::SubscriptionResult,
 };
-use mempool::{MempoolReadHandleFactory, Mempool, LeftRightMempool};
+use mempool::{LeftRightMempool, Mempool, MempoolReadHandleFactory};
 use primitives::NodeType;
-use storage::vrrbdb::{VrrbDbReadHandle, VrrbDb, VrrbDbConfig};
+use storage::vrrbdb::{VrrbDb, VrrbDbConfig, VrrbDbReadHandle};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use vrrb_core::{
     account::Account,
@@ -57,24 +57,20 @@ impl JsonRpcServer {
 
 impl Default for JsonRpcServerConfig {
     fn default() -> JsonRpcServerConfig {
-        let address = SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127,0,0,1)), 
-            9293
-        );
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9293);
         let vrrbdb_config = VrrbDbConfig::default();
         let vrrbdb = VrrbDb::new(vrrbdb_config);
         let vrrbdb_read_handle = vrrbdb.read_handle();
         let mempool = LeftRightMempool::default();
         let mempool_read_handle_factory = mempool.factory();
         let node_type = NodeType::RPCNode;
-        let (events_tx, _) = unbounded_channel();  
-        JsonRpcServerConfig { 
-            address, 
-            vrrbdb_read_handle, 
-            mempool_read_handle_factory, 
-            node_type, 
-            events_tx 
+        let (events_tx, _) = unbounded_channel();
+        JsonRpcServerConfig {
+            address,
+            vrrbdb_read_handle,
+            mempool_read_handle_factory,
+            node_type,
+            events_tx,
         }
-        
     }
 }

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -1,5 +1,5 @@
-use std::net::SocketAddr;
-use std::collections::HashMap;
+use std::{collections::HashMap, net::SocketAddr};
+
 use async_trait::async_trait;
 use jsonrpsee::{
     core::Error,
@@ -7,7 +7,7 @@ use jsonrpsee::{
     types::SubscriptionResult,
 };
 use mempool::MempoolReadHandleFactory;
-use primitives::{NodeType, TransactionDigest, Address};
+use primitives::{Address, NodeType, TransactionDigest};
 use storage::vrrbdb::VrrbDbReadHandle;
 use tokio::sync::mpsc::UnboundedSender;
 use vrrb_core::{
@@ -60,18 +60,17 @@ impl RpcServer for RpcServerImpl {
     }
 
     async fn create_account(&self, address: Address, account: Account) -> Result<(), Error> {
-        let account_bytes = serde_json::to_vec(&account).map_err(|err| Error::Custom(err.to_string()))?;
+        let account_bytes =
+            serde_json::to_vec(&account).map_err(|err| Error::Custom(err.to_string()))?;
         let event = Event::AccountCreated((address, account_bytes));
 
         #[cfg(debug_assertions)]
         println!("{:?}", event.clone());
 
-        self.events_tx
-            .send((Topic::State, event))
-            .map_err(|err| {
-                telemetry::error!("could not create account: {err}");
-                Error::Custom(err.to_string())
-            })?;
+        self.events_tx.send((Topic::State, event)).map_err(|err| {
+            telemetry::error!("could not create account: {err}");
+            Error::Custom(err.to_string())
+        })?;
 
         Ok(())
     }
@@ -80,62 +79,62 @@ impl RpcServer for RpcServerImpl {
         #[cfg(debug_assertions)]
         println!("Received an updateAccount RPC request");
 
-        let account_bytes = serde_json::to_vec(&account).map_err(|err| {
-            Error::Custom(err.to_string())
-        })?;
+        let account_bytes =
+            serde_json::to_vec(&account).map_err(|err| Error::Custom(err.to_string()))?;
 
         let event = Event::UpdateAccount(account_bytes);
 
-        self.events_tx
-            .send((Topic::State, event))
-            .map_err(|err| {
-                telemetry::error!("could not update account: {err}");
-                Error::Custom(err.to_string())
-            })?;
+        self.events_tx.send((Topic::State, event)).map_err(|err| {
+            telemetry::error!("could not update account: {err}");
+            Error::Custom(err.to_string())
+        })?;
 
         Ok(())
     }
 
-    async fn get_transaction(
-        &self, 
-        transaction_digest: TransactionDigest
-    ) -> Result<Txn, Error> {
+    async fn get_transaction(&self, transaction_digest: TransactionDigest) -> Result<Txn, Error> {
         // Do we need to check both state AND mempool?
         #[cfg(debug_assertions)]
         println!("Received a getTransaction RPC request");
         let values = self.vrrbdb_read_handle.transaction_store_values();
         let value = values.get(&transaction_digest);
-        
+
         match value {
             Some(txn) => return Ok(txn.to_owned()),
-            None => return Err(Error::Custom("unable to find transaction".to_string()))
+            None => return Err(Error::Custom("unable to find transaction".to_string())),
         }
     }
 
-    async fn list_transactions(&self, digests: Vec<TransactionDigest>) -> Result<HashMap<TransactionDigest, Txn>, Error> {
+    async fn list_transactions(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> Result<HashMap<TransactionDigest, Txn>, Error> {
         #[cfg(debug_assertions)]
         println!("Received a listTransactions RPC request");
-        let mut values: HashMap<TransactionDigest, Txn> = HashMap::new(); 
+        let mut values: HashMap<TransactionDigest, Txn> = HashMap::new();
         digests.iter().for_each(|digest| {
-            if let Some(txn) = self.vrrbdb_read_handle.transaction_store_values().get(digest) {
+            if let Some(txn) = self
+                .vrrbdb_read_handle
+                .transaction_store_values()
+                .get(digest)
+            {
                 values.insert(digest.clone(), txn.clone());
             }
         });
-        
+
         Ok(values)
     }
 
     async fn get_account(&self, address: Address) -> Result<Account, Error> {
         let values = self.vrrbdb_read_handle.state_store_values();
         let value = values.get(&address);
-        
+
         #[cfg(debug_assertions)]
         println!("Received getAccount RPC Request");
 
         match value {
             Some(account) => return Ok(account.to_owned()),
-            None => return Err(Error::Custom("unable to find account".to_string()))
+            None => return Err(Error::Custom("unable to find account".to_string())),
         }
     }
-
 }

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -1,5 +1,5 @@
 use std::net::SocketAddr;
-
+use std::collections::HashMap;
 use async_trait::async_trait;
 use jsonrpsee::{
     core::Error,
@@ -7,13 +7,13 @@ use jsonrpsee::{
     types::SubscriptionResult,
 };
 use mempool::MempoolReadHandleFactory;
-use primitives::{NodeType, TransactionDigest};
+use primitives::{NodeType, TransactionDigest, Address};
 use storage::vrrbdb::VrrbDbReadHandle;
 use tokio::sync::mpsc::UnboundedSender;
 use vrrb_core::{
     account::Account,
     event_router::{DirectedEvent, Event, Topic},
-    txn::NewTxnArgs,
+    txn::{NewTxnArgs, Txn},
 };
 
 use super::api::{CreateTxnArgs, FullMempoolSnapshot};
@@ -44,21 +44,11 @@ impl RpcServer for RpcServerImpl {
         Ok(self.node_type)
     }
 
-    async fn create_txn(&self, args: CreateTxnArgs) -> Result<(), Error> {
-        let txn = vrrb_core::txn::Txn::new(NewTxnArgs {
-            sender_address: args.sender_address,
-            sender_public_key: args.sender_public_key,
-            receiver_address: args.receiver_address,
-            token: args.token,
-            amount: args.amount,
-            payload: args.payload,
-            signature: args.signature,
-            validators: None,
-            nonce: args.nonce,
-        });
+    async fn create_txn(&self, args: Txn) -> Result<(), Error> {
+        let event = Event::NewTxnCreated(args);
 
-        let event = Event::NewTxnCreated(txn);
-
+        #[cfg(debug_assertions)]
+        println!("{:?}", event);
         self.events_tx
             .send((Topic::Transactions, event))
             .map_err(|err| {
@@ -69,19 +59,83 @@ impl RpcServer for RpcServerImpl {
         Ok(())
     }
 
-    async fn create_account(&self, account: Account) -> Result<(), Error> {
-        todo!()
+    async fn create_account(&self, address: Address, account: Account) -> Result<(), Error> {
+        let account_bytes = serde_json::to_vec(&account).map_err(|err| Error::Custom(err.to_string()))?;
+        let event = Event::AccountCreated((address, account_bytes));
+
+        #[cfg(debug_assertions)]
+        println!("{:?}", event.clone());
+
+        self.events_tx
+            .send((Topic::State, event))
+            .map_err(|err| {
+                telemetry::error!("could not create account: {err}");
+                Error::Custom(err.to_string())
+            })?;
+
+        Ok(())
     }
 
     async fn update_account(&self, account: Account) -> Result<(), Error> {
-        todo!()
+        #[cfg(debug_assertions)]
+        println!("Received an updateAccount RPC request");
+
+        let account_bytes = serde_json::to_vec(&account).map_err(|err| {
+            Error::Custom(err.to_string())
+        })?;
+
+        let event = Event::UpdateAccount(account_bytes);
+
+        self.events_tx
+            .send((Topic::State, event))
+            .map_err(|err| {
+                telemetry::error!("could not update account: {err}");
+                Error::Custom(err.to_string())
+            })?;
+
+        Ok(())
     }
 
-    async fn get_transaction(&self, transaction_digest: TransactionDigest) -> Result<(), Error> {
-        todo!()
+    async fn get_transaction(
+        &self, 
+        transaction_digest: TransactionDigest
+    ) -> Result<Txn, Error> {
+        // Do we need to check both state AND mempool?
+        #[cfg(debug_assertions)]
+        println!("Received a getTransaction RPC request");
+        let values = self.vrrbdb_read_handle.transaction_store_values();
+        let value = values.get(&transaction_digest);
+        
+        match value {
+            Some(txn) => return Ok(txn.to_owned()),
+            None => return Err(Error::Custom("unable to find transaction".to_string()))
+        }
     }
 
-    async fn list_transactions(&self) -> Result<(), Error> {
-        todo!()
+    async fn list_transactions(&self, digests: Vec<TransactionDigest>) -> Result<HashMap<TransactionDigest, Txn>, Error> {
+        #[cfg(debug_assertions)]
+        println!("Received a listTransactions RPC request");
+        let mut values: HashMap<TransactionDigest, Txn> = HashMap::new(); 
+        digests.iter().for_each(|digest| {
+            if let Some(txn) = self.vrrbdb_read_handle.transaction_store_values().get(digest) {
+                values.insert(digest.clone(), txn.clone());
+            }
+        });
+        
+        Ok(values)
     }
+
+    async fn get_account(&self, address: Address) -> Result<Account, Error> {
+        let values = self.vrrbdb_read_handle.state_store_values();
+        let value = values.get(&address);
+        
+        #[cfg(debug_assertions)]
+        println!("Received getAccount RPC Request");
+
+        match value {
+            Some(account) => return Ok(account.to_owned()),
+            None => return Err(Error::Custom("unable to find account".to_string()))
+        }
+    }
+
 }

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "wallet"
+path = "src/lib.rs"
+
+[[test]]
+name = "wallet-rpc-tests"
+path = "tests/wallet_rpc_tests.rs"
 
 [dependencies]
 sha256 = { workspace = true }
@@ -22,3 +29,11 @@ strum_macros = { workspace = true }
 storage = { workspace = true }
 vrrb_core = { workspace = true }
 tabled = { workspace = true }
+jsonrpsee = { workspace = true } 
+primitives = { workspace = true }
+secp256k1 = { workspace = true }
+vrrb_rpc = { workspace = true }
+utils = { workspace = true }
+chrono = { workspace = true }
+tokio = { workspace = true }
+sha2 = { workspace = true }

--- a/crates/wallet/src/v2/mod.rs
+++ b/crates/wallet/src/v2/mod.rs
@@ -1,238 +1,310 @@
-#[derive(Debug, Clone, Default)]
+
+use primitives::Address;
+use vrrb_core::keypair::KeyPairError;
+use vrrb_core::txn::TxToken;
+use vrrb_core::{
+    account::Account,
+    keypair::KeyPair,
+    txn::Txn
+};
+use primitives::digest::TransactionDigest;
+use vrrb_rpc::rpc::api::RpcClient;
+use vrrb_rpc::rpc::client::create_client;
+use jsonrpsee::core::client::Client;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use secp256k1::{PublicKey, SecretKey, ecdsa::Signature};
+use std::str::FromStr;
+use thiserror::Error;
+use sha2::{Sha256, Digest};
+
+type WalletResult<Wallet> = Result<Wallet, WalletError>;
+
+#[derive(Error, Debug)]
+pub enum WalletError {
+    #[error("unable to create rpc client")]
+    InvalidRpcClient(#[from] vrrb_rpc::ApiError),
+    #[error("custom error")]
+    Custom(String)
+}
+
+#[derive(Debug)]
 pub struct Wallet {
-    //
+    secret_key: SecretKey,
+    welcome_message: String,
+    client: Client,
+    pub public_key: PublicKey,
+    pub addresses: HashMap<u32, Address>,
+    pub accounts: HashMap<Address, Account>, 
+    pub nonce: u128
 }
 
 impl Wallet {
     /// Initiate a new wallet.
-    pub fn new() -> Self {
-        Self::default()
+    pub async fn new(rpc_server: SocketAddr) -> WalletResult<Self> {
+
+        //TODO: Don't use random keypair, generate it from a 
+        //mnemonic phrase seed
+        let kp = KeyPair::random();
+
+        //TODO: Change name of kp methods, not only miner secret key 
+        let sk = kp.get_miner_secret_key();
+        let pk = kp.get_miner_public_key();
+    
+        let addresses = HashMap::new();
+        let accounts = HashMap::new();
+        //TODO: get rpc server address from config file
+        let client = create_client(rpc_server).await?; 
+
+        let welcome_message = format!(
+            "{}\nSECRET KEY: {:?}\nPUBLIC KEY: {:?}\n",
+            "DO NOT SHARE OR LOSE YOUR SECRET KEY:",
+            &sk,
+            &pk,
+        );
+         
+        let mut wallet = Wallet {
+            secret_key: sk.clone(),
+            welcome_message,
+            client,
+            public_key: pk.clone(),
+            addresses,
+            accounts,
+            nonce: 0
+        };
+       
+        let res = wallet.create_account().await;
+        #[cfg(debug_assertions)]
+        println!("{:?}", res);
+
+        if let Ok((address, account)) = res {
+            #[cfg(debug_assertions)]
+            println!("{:?}", address);
+            #[cfg(debug_assertions)]
+            println!("{:?}", account);
+            wallet.addresses.insert(0, address.clone());
+            wallet.accounts.insert(address.clone(), account);
+            #[cfg(debug_assertions)]
+            println!("{:?}", wallet.addresses);
+            #[cfg(debug_assertions)]
+            println!("{:?}", wallet.accounts);
+            let welcome_message = format!(
+                "{}\nSECRET KEY: {:?}\nPUBLIC KEY: {:?}\nADDRESS: {}\n",
+                "DO NOT SHARE OR LOSE YOUR SECRET KEY:",
+                &sk,
+                &pk,
+                &address,
+            );
+            wallet.welcome_message = welcome_message;
+        }
+
+        Ok(wallet)
+    } 
+
+    pub async fn send_txn(
+        &mut self,
+        address_number: u32,
+        receiver: String,
+        amount: u128,
+        token: Option<TxToken>
+    ) -> Result<TransactionDigest, WalletError> {
+        let time = chrono::Utc::now().timestamp(); 
+
+        let addresses = self.addresses.clone();
+        let sender_address = {
+            if let Some(addr) = addresses.get(&address_number) {
+                addr
+            } else {
+                if let Some(addr) = addresses.get(&0) {
+                    addr
+                } else {
+                    return Err(WalletError::Custom("wallet has no addresses".to_string()))
+                }
+            }
+        };
+    
+        let payload = format!(
+            "{},{},{},{},{},{:?},{}",
+            &time,
+            &sender_address,
+            &hex::encode(self.public_key.to_string().as_bytes().to_vec().clone()),
+            &receiver,
+            &amount,
+            &token,
+            &self.nonce.clone()
+        );
+
+        let mut hasher = Sha256::new();
+        hasher.update(payload.as_bytes());
+        let payload_hash = hasher.finalize();
+    
+        let signature = self.sign_txn(&payload_hash[..]).map_err(|err| WalletError::Custom(err.to_string()))?; 
+    
+        let txn = Txn::new(vrrb_core::txn::NewTxnArgs {
+            sender_address: sender_address.to_string(),
+            sender_public_key: self.public_key.to_string().as_bytes().to_vec(),
+            receiver_address: receiver,
+            token,
+            amount,
+            payload: Some(payload),
+            signature: signature.to_string().as_bytes().to_vec(),
+            validators: Some(HashMap::new()),
+            nonce: self.nonce,
+        });
+
+        let _ = self.client.create_txn(txn.clone()).await;
+        
+        let txn_string = serde_json::to_string(&txn).map_err(|_| {
+            WalletError::Custom("unable to convert txn to string".to_string())
+        });
+
+        let return_res = {
+            if let Ok(txn_string) = txn_string {
+
+                let mut hasher = Sha256::new();
+                hasher.update(txn_string.as_bytes());
+                let txn_hash = hasher.finalize();
+         
+                let digest = TransactionDigest::from(&txn_hash[..]);
+
+                Ok(digest)
+            } else {
+                Err(WalletError::Custom("unable to create txn digest".to_string()))
+            }
+        };
+
+        return_res
     }
 
-    // pub fn get_welcome_message(&self) -> String {
-    //     self.welcome_message.clone()
-    // }
-    //
-    // pub fn restore_from_private_key(private_key: String) -> Self {
-    //     let secretkey = SecretKey::from_str(&private_key).unwrap();
-    //     let pubkey =
-    // vrrb_core::keypair::KeyPair::get_miner_public_key_from_secret_key(secretkey);
-    //     let mut wallet = WalletAccount {
-    //         secret_key: secretkey.secret_bytes().to_vec(),
-    //         welcome_message: String::new(),
-    //         public_key: pubkey.serialize().to_vec(),
-    //         addresses: LinkedHashMap::new(),
-    //         total_balances: LinkedHashMap::new(),
-    //         available_balances: LinkedHashMap::new(),
-    //         claims: LinkedHashMap::new(),
-    //         nonce: 0,
-    //     };
-    //
-    //     wallet.get_new_addresses(1);
-    //
-    //     let welcome_message = format!(
-    //         "{}\nSECRET KEY: {:?}\nPUBLIC KEY: {:?}\nADDRESS: {}\n",
-    //         "DO NOT SHARE OR LOSE YOUR SECRET KEY:",
-    //         &wallet.secret_key,
-    //         &wallet.public_key,
-    //         &wallet.addresses.get(&1).unwrap(),
-    //     );
-    //
-    //     wallet.welcome_message = welcome_message;
-    //
-    //     wallet
-    // }
-    //
-    // pub fn get_txn_nonce(&mut self, _network_state: &NetworkState) {
-    //     // TODO: add a get_account_txn_nonce() function to network state to
-    //     // update txn nonce in walet when restored.
-    // }
-    //
-    // pub fn get_new_addresses(&mut self, number_of_addresses: u8) {
-    //     let mut counter = 1u8;
-    //     (counter..=number_of_addresses).for_each(|n| {
-    //         let mut address_bytes = self.public_key.clone();
-    //         address_bytes.push(n);
-    //         // TODO: Is double hashing neccesary?
-    //         let address = digest(digest(&*address_bytes).as_bytes());
-    //         let mut address_prefix: String = "0x192".to_string();
-    //         address_prefix.push_str(&address);
-    //         self.addresses.insert(n as u32, address_prefix);
-    //         counter += 1
-    //     })
-    // }
-    //
-    // pub fn get_wallet_addresses(&self) -> LinkedHashMap<u32, String> {
-    //     self.addresses.clone()
-    // }
-    //
-    // pub fn render_balances(&self) -> LinkedHashMap<String, LinkedHashMap<String,
-    // u128>> {     self.total_balances.clone()
-    // }
-    //
-    // pub fn update_balances(&mut self, network_state: NetworkState) {
-    //     let mut balance_map = LinkedHashMap::new();
-    //     self.get_balances(network_state)
-    //         .iter()
-    //         .for_each(|(address, balance)| {
-    //             let mut vrrb_map = LinkedHashMap::new();
-    //             vrrb_map.insert("VRRB".to_string(), *balance);
-    //             balance_map.insert(address.clone(), vrrb_map);
-    //         });
-    //
-    //     self.total_balances = balance_map;
-    // }
-    //
-    // pub fn get_balances(&self, network_state: NetworkState) ->
-    // LinkedHashMap<String, u128> {     let mut balance_map =
-    // LinkedHashMap::new();
-    //
-    //     self.addresses.iter().for_each(|(_, address)| {
-    //         let balance = network_state.get_balance(address);
-    //         balance_map.insert(address.clone(), balance);
-    //     });
-    //
-    //     balance_map
-    // }
-    //
-    // pub fn get_address_balance(
-    //     &mut self,
-    //     network_state: NetworkState,
-    //     address_number: u32,
-    // ) -> Option<u128> {
-    //     self.update_balances(network_state);
-    //     if let Some(address) = self.addresses.get(&address_number) {
-    //         if let Some(entry) = self.total_balances.get(&address.clone()) {
-    //             entry.get("VRRB").copied()
-    //         } else {
-    //             None
-    //         }
-    //     } else {
-    //         None
-    //     }
-    // }
-    //
-    // pub fn n_claims_owned(&self) -> u128 {
-    //     self.claims.len() as u128
-    // }
-    //
-    // pub fn get_claims(&self) -> LinkedHashMap<u128, Claim> {
-    //     self.claims.clone()
-    // }
-    //
-    // /// Checks if the local wallet has any transactions in the most recent block
-    // pub fn txns_in_block(&mut self, txns: &LinkedHashMap<String, Txn>) {
-    //     let _my_txns = {
-    //         let mut some_txn = false;
-    //         self.addresses.iter().for_each(|(_, address)| {
-    //             let mut cloned_data = txns.clone();
-    //             cloned_data.retain(|_, txn| {
-    //                 true
-    //
-    //                 // TODO: re-enable this
-    //                 // txn.receivable() == address.clone() || txn.payable() ==
-    //                 // Some(address.clone())
-    //             });
-    //
-    //             if !cloned_data.is_empty() {
-    //                 some_txn = true;
-    //             }
-    //         });
-    //         some_txn
-    //     };
-    // }
-    //
-    // /// Structures a `Txn` and returns a Result enum with either Ok(Txn) or an
-    // /// Error if the local wallet cannot create a Txn for whatever reason
-    // pub fn send_txn(
-    //     &mut self,
-    //     address_number: u32,
-    //     receiver: String,
-    //     amount: u128,
-    // ) -> Result<Txn, Box<dyn std::error::Error>> {
-    //     let time = SystemTime::now()
-    //         .duration_since(UNIX_EPOCH)
-    //         .unwrap()
-    //         .as_nanos();
-    //     let sender_address = {
-    //         if let Some(addr) = self.addresses.get(&address_number) {
-    //             addr
-    //         } else {
-    //             let n_new_addresses = address_number as usize -
-    // self.addresses.len();             self.get_new_addresses(n_new_addresses
-    // as u8);             self.addresses.get(&address_number).unwrap()
-    //         }
-    //     };
-    //
-    //     let payload = format!(
-    //         "{},{},{},{},{},{}",
-    //         &time,
-    //         &sender_address,
-    //         &hex::encode(self.public_key.clone()),
-    //         &receiver,
-    //         &amount,
-    //         &self.nonce
-    //     );
-    //
-    //     let signature = KeyPair::ecdsa_signature(payload.as_bytes(),
-    // &self.secret_key)?         .to_string()
-    //         .as_bytes()
-    //         .to_vec();
-    //
-    //     let txn = Txn::new(vrrb_core::txn::NewTxnArgs {
-    //         sender_address: sender_address.to_string(),
-    //         sender_public_key: self.public_key.clone(),
-    //         receiver_address: receiver,
-    //         token: None,
-    //         amount,
-    //         payload: Some(payload),
-    //         signature,
-    //         validators: Some(HashMap::new()),
-    //         nonce: self.nonce,
-    //     });
-    //
-    //     Ok(txn)
-    // }
-    //
-    // /// Gets the local address of a wallet given an address number (naive HD
-    // /// wallet)
-    // pub fn get_address(&mut self, address_number: u32) -> String {
-    //     if let Some(address) = self.addresses.get(&address_number) {
-    //         address.to_string()
-    //     } else {
-    //         while self.addresses.len() < address_number as usize {
-    //             self.generate_new_address()
-    //         }
-    //         self.get_address(address_number)
-    //     }
-    // }
-    //
-    // /// Generates a new address for the wallet based on the public key and a
-    // /// unique ID
-    // pub fn generate_new_address(&mut self) {
-    //     let uid = Uuid::new_v4().to_string();
-    //     let address_number: u32 = self.addresses.len() as u32 + 1u32;
-    //     let payload = format!(
-    //         "{},{},{}",
-    //         &address_number,
-    //         &uid,
-    //         &hex::encode(self.public_key.clone())
-    //     );
-    //     let address = digest(payload.as_bytes());
-    //     self.addresses.insert(address_number, address);
-    // }
-    //
-    // /// Serializes the wallet into a vector of bytes.
-    // pub fn as_bytes(&self) -> Vec<u8> {
-    //     let as_string = serde_json::to_string(self).unwrap();
-    //     as_string.as_bytes().to_vec()
-    // }
-    //
-    // /// Deserializes a wallet from a byte array
-    // pub fn from_bytes(data: &[u8]) -> WalletAccount {
-    //     let mut buffer: Vec<u8> = vec![];
-    //     data.iter().for_each(|x| buffer.push(*x));
-    //     let to_string = String::from_utf8(buffer).unwrap();
-    //     serde_json::from_str::<WalletAccount>(&to_string).unwrap()
-    // }
+    pub async fn get_transaction(
+        &mut self,
+        transaction_digest: TransactionDigest
+    ) -> Option<Txn> {
+        
+        let res = self.client.get_transaction(transaction_digest).await;
+        
+        if let Ok(value) = res {
+            return Some(value);
+        } else {
+            return None;
+        }
+    }
+
+    pub async fn get_account(
+        &mut self,
+        address: Address 
+    ) -> Option<Account> {
+
+        let res = self.client.get_account(address).await;
+
+        if let Ok(value) = res {
+            return Some(value);
+        } else {
+            return None;
+        }
+    }
+
+    pub async fn list_transactions(
+        &mut self, 
+        digests: Vec<TransactionDigest>
+    ) -> HashMap<TransactionDigest, Txn> {
+
+        let res = self.client.list_transactions(digests).await;
+        
+        if let Ok(values) = res {
+            return values
+        } else {
+            return HashMap::new()
+        }
+    }
+
+    fn sign_txn(
+        &mut self, 
+        payload: &[u8]
+    ) -> Result<Signature, KeyPairError> {
+        
+        KeyPair::ecdsa_signature(
+            payload, 
+            &self.secret_key.secret_bytes().to_vec()
+        )
+    }
+
+    pub fn get_welcome_message(&self) -> String {
+        self.welcome_message.clone()
+    }
+   
+    pub async fn restore_from_private_key(
+        secret_key: String, 
+        rpc_server: SocketAddr,
+    ) -> WalletResult<Self> {
+        if let Ok(secretkey) = SecretKey::from_str(&secret_key) {
+
+            let pubkey = vrrb_core::keypair::KeyPair::get_miner_public_key_from_secret_key(
+                secretkey
+            );
+
+            let client = create_client(rpc_server).await?;
+
+            let mut wallet = Wallet {
+                secret_key: secretkey,
+                welcome_message: String::new(),
+                client, 
+                public_key: pubkey,
+                addresses: HashMap::new(),
+                accounts: HashMap::new(),
+                nonce: 0,
+            };
+
+            wallet.get_new_address();
+
+            let mut accounts = HashMap::new();
+            let addresses = wallet.addresses.clone();
+            for (_, addr) in addresses.iter() {
+                let ret = wallet.get_account(addr.clone()).await;
+                if let Some(account) = ret {
+                    accounts.insert(addr.to_owned(), account);
+                }
+            }
+
+            wallet.accounts = accounts;
+
+            let welcome_message = format!(
+                "{}\nSECRET KEY: {:?}\nPUBLIC KEY: {:?}\nADDRESS: {}\n",
+                "DO NOT SHARE OR LOSE YOUR SECRET KEY:",
+                &wallet.secret_key,
+                &wallet.public_key,
+                &wallet.addresses.get(&1).unwrap(),
+            );
+
+            wallet.welcome_message = welcome_message;
+    
+            Ok(wallet)
+        } else {
+            return Err(WalletError::Custom("unable to restore wallet from secret key".to_string()));
+        }
+        
+    }
+
+    // Create an account for each address created
+    pub fn get_new_address(&mut self) {
+        let largest_address_index = self.addresses.len();
+        let pk = self.public_key.clone();
+        let new_address = Address::new(pk);
+        self.addresses.insert(largest_address_index as u32, new_address);
+    }
+    
+    pub fn get_wallet_addresses(&self) -> HashMap<u32, Address> {
+        self.addresses.clone()
+    }
+
+    pub async fn create_account(&mut self) -> Result<(Address, Account), WalletError> {
+        let pk = self.public_key.clone(); 
+        let account = Account::new(pk.clone());
+        let address = Address::new(pk.clone());
+        let _ = self.client.create_account(address.clone(), account.clone()).await.map_err(|err| {
+            WalletError::Custom(err.to_string())
+        });
+            
+        Ok((address, account))
+    }
 }

--- a/crates/wallet/tests/wallet_rpc_tests.rs
+++ b/crates/wallet/tests/wallet_rpc_tests.rs
@@ -1,12 +1,13 @@
 #![allow(unused_imports)]
+use std::net::SocketAddr;
+
 use vrrb_rpc::rpc::{JsonRpcServer, JsonRpcServerConfig};
 use wallet::v2::Wallet;
-use std::net::SocketAddr;
 
 #[tokio::test]
 pub async fn create_wallet_with_rpc_client() {
-   
-    let socket_addr: SocketAddr = "127.0.0.1:9293".parse()
+    let socket_addr: SocketAddr = "127.0.0.1:9293"
+        .parse()
         .expect("Unable to create Socket Address");
 
     // Set up RPC Server to accept connection from client
@@ -22,21 +23,28 @@ pub async fn create_wallet_with_rpc_client() {
 
 #[tokio::test]
 pub async fn wallet_sends_txn_to_rpc_server() {
-
-    let socket_addr: SocketAddr = "127.0.0.1:9293".parse()
+    let socket_addr: SocketAddr = "127.0.0.1:9293"
+        .parse()
         .expect("Unable to create Socket Address");
 
     // Set up RPC Server to accept connection from client
     let json_rpc_server_config = JsonRpcServerConfig::default();
     let result = JsonRpcServer::run(&json_rpc_server_config).await;
-    
+
     if let Ok((handle, _)) = result {
         tokio::spawn(handle.stopped());
 
         let res = Wallet::new(socket_addr.clone()).await;
-    
+
         if let Ok(mut wallet) = res {
-            let tx_res = wallet.send_txn(0, "0x192abcdef01234567890fedcba09876543210".to_string(), 10, None).await;
+            let tx_res = wallet
+                .send_txn(
+                    0,
+                    "0x192abcdef01234567890fedcba09876543210".to_string(),
+                    10,
+                    None,
+                )
+                .await;
             println!("{:?}", tx_res);
         }
     }
@@ -44,8 +52,8 @@ pub async fn wallet_sends_txn_to_rpc_server() {
 
 #[tokio::test]
 pub async fn wallet_requests_account_from_rpc_server() {
-
-    let socket_addr: SocketAddr = "127.0.0.1:9293".parse()
+    let socket_addr: SocketAddr = "127.0.0.1:9293"
+        .parse()
         .expect("Unable to create Socket Address");
 
     // Set up RPC Server to accept connection from client
@@ -53,20 +61,20 @@ pub async fn wallet_requests_account_from_rpc_server() {
     let _ = JsonRpcServer::run(&json_rpc_server_config).await;
 
     let res = Wallet::new(socket_addr.clone()).await;
-    
+
     if let Ok(mut wallet) = res {
         let addresses = wallet.addresses.clone();
-        if let Some(addr) = addresses.get(&0u32) { 
+        if let Some(addr) = addresses.get(&0u32) {
             let rpc_res = wallet.get_account(addr.clone()).await;
             println!("{:?}", rpc_res);
-        } 
+        }
     }
 }
 
 #[tokio::test]
 pub async fn wallet_sends_create_account_request_to_rpc_server() {
-
-    let socket_addr: SocketAddr = "127.0.0.1:9293".parse()
+    let socket_addr: SocketAddr = "127.0.0.1:9293"
+        .parse()
         .expect("Unable to create Socket Address");
 
     // Set up RPC Server to accept connection from client
@@ -79,6 +87,4 @@ pub async fn wallet_sends_create_account_request_to_rpc_server() {
         let res = wallet.create_account().await;
         println!("{:?}", res);
     }
-    
 }
-

--- a/crates/wallet/tests/wallet_rpc_tests.rs
+++ b/crates/wallet/tests/wallet_rpc_tests.rs
@@ -1,0 +1,84 @@
+#![allow(unused_imports)]
+use vrrb_rpc::rpc::{JsonRpcServer, JsonRpcServerConfig};
+use wallet::v2::Wallet;
+use std::net::SocketAddr;
+
+#[tokio::test]
+pub async fn create_wallet_with_rpc_client() {
+   
+    let socket_addr: SocketAddr = "127.0.0.1:9293".parse()
+        .expect("Unable to create Socket Address");
+
+    // Set up RPC Server to accept connection from client
+    let json_rpc_server_config = JsonRpcServerConfig::default();
+    let result = JsonRpcServer::run(&json_rpc_server_config).await;
+    if let Ok((handle, _)) = result {
+        tokio::spawn(handle.stopped());
+
+        let wallet = Wallet::new(socket_addr.clone()).await;
+        println!("{:?}", wallet);
+    }
+}
+
+#[tokio::test]
+pub async fn wallet_sends_txn_to_rpc_server() {
+
+    let socket_addr: SocketAddr = "127.0.0.1:9293".parse()
+        .expect("Unable to create Socket Address");
+
+    // Set up RPC Server to accept connection from client
+    let json_rpc_server_config = JsonRpcServerConfig::default();
+    let result = JsonRpcServer::run(&json_rpc_server_config).await;
+    
+    if let Ok((handle, _)) = result {
+        tokio::spawn(handle.stopped());
+
+        let res = Wallet::new(socket_addr.clone()).await;
+    
+        if let Ok(mut wallet) = res {
+            let tx_res = wallet.send_txn(0, "0x192abcdef01234567890fedcba09876543210".to_string(), 10, None).await;
+            println!("{:?}", tx_res);
+        }
+    }
+}
+
+#[tokio::test]
+pub async fn wallet_requests_account_from_rpc_server() {
+
+    let socket_addr: SocketAddr = "127.0.0.1:9293".parse()
+        .expect("Unable to create Socket Address");
+
+    // Set up RPC Server to accept connection from client
+    let json_rpc_server_config = JsonRpcServerConfig::default();
+    let _ = JsonRpcServer::run(&json_rpc_server_config).await;
+
+    let res = Wallet::new(socket_addr.clone()).await;
+    
+    if let Ok(mut wallet) = res {
+        let addresses = wallet.addresses.clone();
+        if let Some(addr) = addresses.get(&0u32) { 
+            let rpc_res = wallet.get_account(addr.clone()).await;
+            println!("{:?}", rpc_res);
+        } 
+    }
+}
+
+#[tokio::test]
+pub async fn wallet_sends_create_account_request_to_rpc_server() {
+
+    let socket_addr: SocketAddr = "127.0.0.1:9293".parse()
+        .expect("Unable to create Socket Address");
+
+    // Set up RPC Server to accept connection from client
+    let json_rpc_server_config = JsonRpcServerConfig::default();
+    let _ = JsonRpcServer::run(&json_rpc_server_config).await;
+
+    let res = Wallet::new(socket_addr.clone()).await;
+
+    if let Ok(mut wallet) = res {
+        let res = wallet.create_account().await;
+        println!("{:?}", res);
+    }
+    
+}
+


### PR DESCRIPTION
Added RPC endpoints, still some work to do. Made some small changes to Account struct to track Tx digests so we can list account related txs. Added Wallet CLI subcommands and execution functions.

TODO;

Clean up wallet.send_txn() method
Add tests for RPC Client/Server and Wallet CLI
Fix tests affected by changes herein
Further adapt accounts so they can track multiple tokens, or, alternatively change wallet so that a single address can track multiple accounts.
Convert wallet from "mock HD" to actual HD.
more