### PR TITLE
Rename DkgEngine.clear_state to DkgEngine.clear_dkg_state for clarity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ theater = { git = "https://github.com/vrrb-io/theater" }
 hbbft = { git = "https://github.com/vrrb-io/hbbft", branch = "master" }
 bulldag = { git = "https://github.com/vrrb-io/bulldag", branch = "main" }
 kademlia-dht = { git = "https://github.com/vrrb-io/kademlia-dht-rs" }
-rendezvous_dht = { git = "https://github.com/vrrb-io/rendezvous_dht" }
+rendezvous_dht={git="https://github.com/vrrb-io/rendezvous_dht"}
 
 secp256k1 = { version = "0.25.0", features = [
     "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ laminar = "0.5.0"
 futures = { version = "0.3.24", features = ["thread-pool"] }
 qp2p = "0.30.0"
 
+
 [dev-dependencies]
 cuckoofilter.workspace = true
 reqwest.workspace = true

--- a/crates/consensus/dkg_engine/src/types/mod.rs
+++ b/crates/consensus/dkg_engine/src/types/mod.rs
@@ -163,7 +163,7 @@ impl DkgEngine {
     }
 
     /// It clears the state of the DKG. it happens during change of Epoch
-    pub fn clear_state(&mut self) {
+    pub fn clear_dkg_state(&mut self) {
         self.dkg_state.part_message_store.clear();
         self.dkg_state.ack_message_store.clear();
         self.dkg_state.sync_key_gen = None;

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -13,7 +13,6 @@ use dkg_engine::{
     dkg::DkgGenerator,
     types::{config::ThresholdConfig, DkgEngine, DkgError, DkgResult},
 };
-use events::{DirectedEvent, Event, SyncPeerData, Topic};
 use hbbft::{crypto::PublicKey, sync_key_gen::Part};
 use kademlia_dht::{Key, Node, NodeData};
 use laminar::{Config, ErrorKind, Packet, Socket, SocketEvent};
@@ -37,6 +36,7 @@ use serde::{Deserialize, Serialize};
 use telemetry::info;
 use theater::{Actor, ActorId, ActorLabel, ActorState, Handler};
 use tracing::error;
+use events::{DirectedEvent, Event, SyncPeerData, Topic};
 
 use crate::{result::Result, NodeError};
 
@@ -115,7 +115,6 @@ impl DkgModule {
                 "Error occurred while binding socket to port. Details :{0}",
                 e.to_string()
             ))),
-
         }
     }
 

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -18,7 +18,6 @@ use kademlia_dht::{Key, Node, NodeData};
 use laminar::{Config, ErrorKind, Packet, Socket, SocketEvent};
 use lr_trie::ReadHandleFactory;
 use patriecia::{db::MemoryDB, inner::InnerTrie};
-
 use primitives::{
     NodeIdx,
     NodeType,

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -19,6 +19,7 @@ use kademlia_dht::{Key, Node, NodeData};
 use laminar::{Config, ErrorKind, Packet, Socket, SocketEvent};
 use lr_trie::ReadHandleFactory;
 use patriecia::{db::MemoryDB, inner::InnerTrie};
+
 use primitives::{
     NodeIdx,
     NodeType,
@@ -114,6 +115,7 @@ impl DkgModule {
                 "Error occurred while binding socket to port. Details :{0}",
                 e.to_string()
             ))),
+
         }
     }
 

--- a/crates/node/src/runtime/farmer_harvester_module.rs
+++ b/crates/node/src/runtime/farmer_harvester_module.rs
@@ -362,7 +362,6 @@ mod tests {
 
     use vrrb_core::{
         cache,
-        event_router::{DirectedEvent, Event},
         is_enum_variant,
         keypair::KeyPair,
         txn::NewTxnArgs,

--- a/crates/node/src/runtime/farmer_harvester_module.rs
+++ b/crates/node/src/runtime/farmer_harvester_module.rs
@@ -38,12 +38,7 @@ use crate::{
     NodeError,
 };
 
-/// `FarmerHarvesterModule` is a struct that contains a bunch of `Option`s, a
-/// `Bloom` filter, a `GroupPublicKey`, a `SignatureProvider`, a `PeerId`, a
-/// `NodeIdx`, an `ActorState`, an `ActorLabel`, an `ActorId`, a
-/// `tokio::sync::mpsc::UnboundedSender`, a
-/// `tokio::sync::mpsc::UnboundedReceiver`, a `FarmerQuorumThreshold`, a
-/// `HarvesterQuorumThreshold`, a
+/// `FarmerHarvesterModule` is reponsible for voting of transactions,certifying it
 ///
 /// Properties:
 ///
@@ -364,7 +359,14 @@ mod tests {
         txn_validator::{StateSnapshot, TxnValidator},
         validator_core_manager::ValidatorCoreManager,
     };
-    use vrrb_core::{cache, is_enum_variant, keypair::KeyPair, txn::NewTxnArgs};
+
+    use vrrb_core::{
+        cache,
+        event_router::{DirectedEvent, Event},
+        is_enum_variant,
+        keypair::KeyPair,
+        txn::NewTxnArgs,
+    };
 
     use super::*;
     use crate::scheduler::JobSchedulerController;


### PR DESCRIPTION
Rename the `clear_state` method to `clear_dkg_state` to avoid confusion with node state