### PR TITLE
[wip] implement http client to post txnRecord to indexer upon creation

### DIFF
--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -21,6 +21,10 @@ chrono = "0.4.23"
 rand = "0.8.5"
 thiserror = "1.0.38"
 secp256k1 = { workspace = true }
+reqwest = { workspace = true }
+tokio = { workspace = true }
+anyhow = "1.0"
+telemetry = { workspace = true }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/mempool/src/lib.rs
+++ b/crates/mempool/src/lib.rs
@@ -3,7 +3,36 @@ pub mod mempool;
 
 // TODO: merge pool w Mempool later on
 pub mod pool;
+use anyhow::{Context, Result};
+use reqwest::StatusCode;
+
 pub use crate::mempool::*;
+// use serde_json::{Error as JsonError, json};
+// use serde::{Deserialize, Serialize};
+
+pub async fn create_tx_indexer(txn_record: &TxnRecord) -> Result<StatusCode> {
+    let url = "http://localhost:3444/transactions"; // TODO: Move to config
+    let req_json =
+        serde_json::to_string(txn_record).context("Failed to serialize txn_record to json")?;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(req_json)
+        .send()
+        .await
+        .context("Request error")?;
+
+    if response.status().is_success() {
+        Ok(response.status())
+    } else {
+        Err(anyhow::anyhow!(
+            "Unexpected status code: {}",
+            response.status()
+        ))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -9,9 +9,12 @@ use indexmap::IndexMap;
 use left_right::{Absorb, ReadHandle, ReadHandleFactory, WriteHandle};
 use primitives::TxHashString;
 use serde::{Deserialize, Serialize};
+use telemetry::{error, info, warn};
+use tokio;
 use vrrb_core::txn::{TransactionDigest, TxTimestamp, Txn};
 
 use super::error::MempoolError;
+use crate::create_tx_indexer;
 
 pub type Result<T> = StdResult<T, MempoolError>;
 
@@ -189,7 +192,22 @@ impl LeftRightMempool {
 
     pub fn insert(&mut self, txn: Txn) -> Result<()> {
         let txn_record = TxnRecord::new(txn);
-        self.write.append(MempoolOp::Add(txn_record)).publish();
+
+        self.write
+            .append(MempoolOp::Add(txn_record.to_owned()))
+            .publish();
+
+        tokio::spawn(async move {
+            match create_tx_indexer(&txn_record).await {
+                Ok(_) => {
+                    info!("Successfully sent TxnRecord to block exploror indexer");
+                },
+                Err(e) => {
+                    warn!("Error sending TxnRecord to block explorer indexer {}", e);
+                },
+            }
+        });
+
         Ok(())
     }
 

--- a/crates/vrrb_rpc/Cargo.toml
+++ b/crates/vrrb_rpc/Cargo.toml
@@ -25,6 +25,8 @@ jsonrpsee = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 secp256k1 = { workspace = true }
+sha256 = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 hyper = { workspace = true }

--- a/crates/vrrb_rpc/src/rpc/api.rs
+++ b/crates/vrrb_rpc/src/rpc/api.rs
@@ -9,6 +9,8 @@ use vrrb_core::{
     txn::{NewTxnArgs, Token, TxAmount, TxNonce, TxTimestamp, Txn},
 };
 
+use super::SignOpts;
+
 pub type ExampleHash = [u8; 32];
 pub type ExampleStorageKey = Vec<u8>;
 pub type FullStateSnapshot = HashMap<Address, Account>;
@@ -101,4 +103,7 @@ pub trait RpcApi {
 
     //#[method(name = "faucetDrip")]
     //async fn faucet_drip(&self, address: Address) -> Result<(), Error>;
+
+    #[method(name = "signTransaction")]
+    async fn sign_transaction(&self, sign_opts: SignOpts) -> Result<String, Error>;
 }

--- a/crates/vrrb_rpc/src/rpc/mod.rs
+++ b/crates/vrrb_rpc/src/rpc/mod.rs
@@ -2,5 +2,19 @@ pub mod api;
 pub mod client;
 mod server;
 mod server_impl;
+use serde::{Deserialize, Serialize};
 pub use server::*;
 pub use server_impl::*;
+use vrrb_core::txn::Token;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SignOpts {
+    pub timestamp: i64,
+    pub sender_address: String,
+    pub sender_public_key: String,
+    pub receiver_address: String,
+    pub amount: u128,
+    pub token: Token,
+    pub nonce: u128,
+    pub private_key: String,
+}


### PR DESCRIPTION
## Info

- Implement HTTP client to consume `POST/transactions` on the indexer when a `txnRecord` is create in _a_ mempool. The idea here is to get the txn when its being farmed.
- Implement `signTranscation`RPC endpoint to help testing a bit.