### PR TITLE
Remove mutices from  BroadcastEngine

### DIFF
--- a/crates/network/src/network.rs
+++ b/crates/network/src/network.rs
@@ -133,10 +133,8 @@ impl BroadcastEngine {
         Ok(BroadcastStatus::ConnectionEstablished)
     }
 
-    pub async fn add_raptor_peers(&mut self, address: Vec<SocketAddr>) -> Result<BroadcastStatus> {
-        self.raptor_list.extend(address);
-
-        Ok(BroadcastStatus::ConnectionEstablished)
+    pub async fn add_raptor_peers(&mut self, address: Vec<SocketAddr>) {
+        self.raptor_list.extend(address)
     }
 
     /// This function removes a peer connection from the peer connection list

--- a/crates/network/src/types/config.rs
+++ b/crates/network/src/types/config.rs
@@ -33,22 +33,32 @@ impl Topology {
 }
 
 #[derive(Debug)]
-pub enum BroadCastResult {
+pub enum BroadcastStatus {
     ConnectionEstablished,
     Success,
 }
 
 /// List of all possible errors related to BroadCasting .
 #[derive(Error, Debug)]
-pub enum BroadCastError {
-    #[error("There was a problem while creating endpoint")]
-    EndpointError(#[from] EndpointError),
-    #[error("There was a problem while connecting to endpoint")]
-    ConnectionError(#[from] ConnectionError),
-    #[error("There was a problem while broadcasting data to peers")]
-    BroadcastingDataError(#[from] SendError),
+pub enum BroadcastError {
+    #[error("Connection error: {0}")]
+    Connection(#[from] ConnectionError),
+
+    #[error("Send error: {0}")]
+    Send(#[from] SendError),
+
+    #[error("Endpoint error: {0}")]
+    Endpoint(#[from] EndpointError),
+
     #[error("Udp Port already in use")]
     EaddrInUse,
+
     #[error("Current Node doesn't have any peers")]
     NoPeers,
+
+    #[error("error: {0}")]
+    Other(String),
 }
+
+#[deprecated(note = "here for backwards compatibility")]
+pub type BroadCastError = BroadcastError;


### PR DESCRIPTION
Refactors the need for mutices within the BroadcastEngine struct and updates the BroadcastError type to propagate source error messages.

Refactors unwrap within `unreliable_broadcast` function