### PR TITLE
Fix db directory config during VrrbDb setup

### DIFF
--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -211,7 +211,12 @@ async fn setup_state_store(
     mut state_events_rx: Receiver<Event>,
     mempool_read_handle_factory: MempoolReadHandleFactory,
 ) -> Result<(VrrbDbReadHandle, Option<JoinHandle<Result<()>>>)> {
-    let vrrbdb_config = VrrbDbConfig::default();
+    let mut vrrbdb_config = VrrbDbConfig::default();
+
+    if config.db_path() != &vrrbdb_config.path {
+        vrrbdb_config.with_path(config.db_path().to_path_buf());
+    }
+
     let db = storage::vrrbdb::VrrbDb::new(vrrbdb_config);
     let vrrbdb_read_handle = db.read_handle();
 

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -25,6 +25,14 @@ pub struct VrrbDbConfig {
     pub event_store_path: Option<String>,
 }
 
+impl VrrbDbConfig {
+    pub fn with_path(&mut self, path: PathBuf) -> Self {
+        self.path = path;
+
+        self.clone()
+    }
+}
+
 impl Default for VrrbDbConfig {
     fn default() -> Self {
         let path = storage_utils::get_node_data_dir()


### PR DESCRIPTION
Forwards db directory config from NodeConfig to VrrbDbConfig so nodes dont try to open an instance of the database on the same directory during tests.