### PR TITLE
Creates, implements, and integrates a claim_store to serve as a "table" in the vrrbdb....

### DIFF
--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -162,6 +162,13 @@ impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
             //TODO: Implement
+            Event::Election(block) => {
+                let accounts = self.db_read_handle.state_store_values();
+                accounts.iter().map(|addr, acct| {
+                    account.claim.
+                })  
+                
+            }
             _ => {},
         }
 

--- a/crates/storage/vrrbdb/src/lib.rs
+++ b/crates/storage/vrrbdb/src/lib.rs
@@ -1,3 +1,5 @@
+
+mod claim_store;
 mod event_store;
 pub mod result;
 mod rocksdb_adapter;
@@ -7,6 +9,7 @@ mod vrrbdb;
 mod vrrbdb_read_handle;
 mod vrrbdb_serialized_values;
 
+pub use claim_store::*;
 pub use event_store::*;
 pub use rocksdb_adapter::*;
 pub use state_store::*;

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -122,7 +122,7 @@ impl StateStore {
         failed_inserts
     }
 
-    /// Retain returns new StateDb with witch all Accounts that fulfill `filter`
+    /// Retain returns new StateDb with which all Accounts that fulfill `filter`
     /// cloned to it.
     pub fn retain<F>(&self, _filter: F) -> StateStore
     where

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -1,15 +1,17 @@
 use std::{collections::HashMap, fmt::Display, path::PathBuf};
 
 use lr_trie::H256;
-use primitives::Address;
+use primitives::{Address, NodeId};
 use serde_json::json;
 use storage_utils::{Result, StorageError};
 use vrrb_core::{
     account::{Account, UpdateArgs},
-    txn::Txn,
+    txn::Txn, claim::Claim,
 };
 
 use crate::{
+    ClaimStore,
+    ClaimStoreReadHandleFactory,
     StateStore,
     StateStoreReadHandleFactory,
     TransactionStore,
@@ -23,6 +25,7 @@ pub struct VrrbDbConfig {
     pub state_store_path: Option<String>,
     pub transaction_store_path: Option<String>,
     pub event_store_path: Option<String>,
+    pub claim_store_path: Option<String>, 
 }
 
 impl Default for VrrbDbConfig {
@@ -36,6 +39,7 @@ impl Default for VrrbDbConfig {
             state_store_path: None,
             transaction_store_path: None,
             event_store_path: None,
+            claim_store_path: None,
         }
     }
 }
@@ -44,16 +48,19 @@ impl Default for VrrbDbConfig {
 pub struct VrrbDb {
     state_store: StateStore,
     transaction_store: TransactionStore,
+    claim_store: ClaimStore,
 }
 
 impl VrrbDb {
     pub fn new(config: VrrbDbConfig) -> Self {
         let state_store = StateStore::new(&config.path);
         let transaction_store = TransactionStore::new(&config.path);
+        let claim_store = ClaimStore::new(&config.path);
 
         Self {
             state_store,
             transaction_store,
+            claim_store,
         }
     }
 
@@ -61,10 +68,16 @@ impl VrrbDb {
         VrrbDbReadHandle::new(self.state_store.factory(), self.transaction_store_factory())
     }
 
-    pub fn new_with_stores(state_store: StateStore, transaction_store: TransactionStore) -> Self {
+    pub fn new_with_stores(
+        state_store: StateStore, 
+        transaction_store: TransactionStore,
+        claim_store: ClaimStore
+    ) -> Self {
+
         Self {
             state_store,
             transaction_store,
+            claim_store,
         }
     }
 
@@ -74,6 +87,10 @@ impl VrrbDb {
 
     pub fn transaction_store(&self) -> &TransactionStore {
         &self.transaction_store
+    }
+
+    pub fn claim_store(&self) -> &ClaimStore {
+        &self.claim_store 
     }
 
     /// Returns the current state store trie's root hash.
@@ -86,6 +103,12 @@ impl VrrbDb {
         self.transaction_store.root_hash()
     }
 
+    /// Returns the claim store trie's root hash.
+    pub fn claims_root_hash(&self) -> Option<H256> {
+        self.claim_store.root_hash() 
+    }
+
+
     /// Produces a reader factory that can be used to generate read handles into
     /// the state trie.
     pub fn state_store_factory(&self) -> StateStoreReadHandleFactory {
@@ -96,6 +119,12 @@ impl VrrbDb {
     /// the the transaction trie.
     pub fn transaction_store_factory(&self) -> TransactionStoreReadHandleFactory {
         self.transaction_store.factory()
+    }
+
+    /// Produces a reader factory that can be used to generate read_handles into 
+    /// the claim trie
+    pub fn claim_store_factory(&self) -> ClaimStoreReadHandleFactory {
+        self.claim_store.factory() 
     }
 
     /// Inserts an account to current state tree.
@@ -131,7 +160,7 @@ impl VrrbDb {
         self.transaction_store.insert(txn)
     }
 
-    /// Adds multiplpe accounts to current state tree. Does not check if
+    /// Adds multiplpe transactions to current state tree. Does not check if
     /// accounts involved in the transaction actually exist.
     pub fn extend_transactions_unchecked(&mut self, transactions: Vec<Txn>) {
         self.transaction_store.extend(transactions);
@@ -143,11 +172,32 @@ impl VrrbDb {
         self.transaction_store.insert(txn)
     }
 
-    /// Adds multiplpe accounts to current state tree. Does not check if
+    /// Adds multiplpe transactions to current transaction tree. Does not check if
     /// accounts involved in the transaction actually exist.
     pub fn extend_transactions(&mut self, transactions: Vec<Txn>) {
         self.transaction_store.extend(transactions);
     }
+
+    /// Inserts a confirmed claim to the current claim tree. 
+    pub fn insert_claim_unchecked(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
+        self.claim_store.insert(node_id, claim)
+    }
+
+    /// Adds multiple claims to the current claim tree.  
+    pub fn extend_claims_unchecked(&mut self, claims: Vec<(NodeId, Claim)>) {
+        self.claim_store.extend(claims)
+    }
+
+    /// Inserts a confirmed claim into the claim tree. 
+    pub fn insert_claim(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
+        self.claim_store.insert(node_id, claim) 
+    }
+    
+    /// Inserts multiple claims into the current claim trie
+    pub fn extend_claims(&mut self, claims: Vec<(NodeId, Claim)>) {
+        self.claim_store.extend(claims)
+    }
+
 }
 
 impl Clone for VrrbDb {
@@ -155,6 +205,7 @@ impl Clone for VrrbDb {
         Self {
             state_store: self.state_store.clone(),
             transaction_store: self.transaction_store.clone(),
+            claim_store: self.claim_store.clone(),
         }
     }
 }
@@ -169,6 +220,7 @@ impl Display for VrrbDb {
             .into_iter()
             .map(|(digest, txn)| (digest.to_string(), txn))
             .collect::<HashMap<String, Txn>>();
+        let claim_entries = self.claim_store_factory().handle().entries();
 
         let out = json!({
             "state": {
@@ -178,6 +230,10 @@ impl Display for VrrbDb {
             "transactions": {
                 "count": transaction_entries.len(),
                 "entries": transaction_entries,
+            },
+            "claims": {
+                "count": claim_entries.len(),
+                "entries": claim_entries,
             },
         });
 

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -65,7 +65,11 @@ impl VrrbDb {
     }
 
     pub fn read_handle(&self) -> VrrbDbReadHandle {
-        VrrbDbReadHandle::new(self.state_store.factory(), self.transaction_store_factory())
+        VrrbDbReadHandle::new(
+            self.state_store.factory(), 
+            self.transaction_store_factory(),
+            self.claim_store_factory(),
+            )
     }
 
     pub fn new_with_stores(

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -1,27 +1,37 @@
 use std::collections::HashMap;
 
-use primitives::Address;
+use primitives::{Address, NodeId};
 use vrrb_core::{
     account::Account,
     txn::{TransactionDigest, Txn},
+    claim::Claim,
 };
 
-use crate::{StateStoreReadHandleFactory, TransactionStoreReadHandleFactory};
+use crate::{
+    StateStoreReadHandleFactory, 
+    TransactionStoreReadHandleFactory, 
+    ClaimStoreReadHandleFactory
+};
 
 #[derive(Debug, Clone)]
 pub struct VrrbDbReadHandle {
     state_store_handle_factory: StateStoreReadHandleFactory,
     transaction_store_handle_factory: TransactionStoreReadHandleFactory,
+    claim_store_handle_factory: ClaimStoreReadHandleFactory,
 }
 
 impl VrrbDbReadHandle {
+
     pub fn new(
         state_store_handle_factory: StateStoreReadHandleFactory,
         transaction_store_handle_factory: TransactionStoreReadHandleFactory,
+        claim_store_handle_factory: ClaimStoreReadHandleFactory,
     ) -> Self {
+
         Self {
             state_store_handle_factory,
             transaction_store_handle_factory,
+            claim_store_handle_factory,
         }
     }
 
@@ -34,4 +44,9 @@ impl VrrbDbReadHandle {
     pub fn transaction_store_values(&self) -> HashMap<TransactionDigest, Txn> {
         self.transaction_store_handle_factory.handle().entries()
     }
+
+    pub fn claim_store_values(&self) -> HashMap<NodeId, Claim> {
+        self.claim_store_handle_factory.handle().entries()
+    }
 }
+

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -1,7 +1,8 @@
-use primitives::{Address, SecretKey};
+use primitives::{Address, SecretKey, NodeId};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secp256k1::{Message, Secp256k1};
 use vrrb_core::{
+    claim::Claim,
     keypair::Keypair,
     txn::{NewTxnArgs, Txn},
 };
@@ -66,4 +67,14 @@ pub fn generate_random_valid_transaction() -> Txn {
         validators: None,
         nonce: 10,
     })
+}
+
+pub fn generate_random_claim() -> Claim {
+    let keypair = Keypair::random(); 
+
+    Claim::new(
+        keypair.miner_kp.1.clone().to_string(), 
+        Address::new(keypair.miner_kp.1).to_string(), 
+        0
+    ) 
 }

--- a/crates/storage/vrrbdb/tests/test_transaction_store.rs
+++ b/crates/storage/vrrbdb/tests/test_transaction_store.rs
@@ -29,6 +29,7 @@ fn transactions_can_be_added() {
         state_store_path: None,
         transaction_store_path: None,
         event_store_path: None,
+        claim_store_path: None,
     });
 
     let txn1 = generate_random_valid_transaction();


### PR DESCRIPTION
This is done so that we can efficiently get and use claims for the purposes of miner elections, quorum elections, and conflict resolution. 

Prior to this PR Claims did not live anywhere in state, this provides them a place to persist. This is not a full implementation and another PR to provide update methods for:

- Adding stake to claims
- Determining Eligibility based on Stake and Liveness
- Other reasons to update the claim

This is Q&D implementation of the functionality necessary to finish implementing the Election Module, and to ensure that we can efficiently get and use claims for elections.