### PR TITLE
integrate ElectionModule into node runtime; pending tests which will …

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -15,7 +15,7 @@ use crate::{
     result::{NodeError, Result},
     runtime::setup_runtime_components,
     NodeType,
-    RuntimeModuleState,
+    RuntimeModuleState, farmer_module::QuorumMember,
 };
 
 /// Node represents a member of the VRRB network and it is responsible for
@@ -41,6 +41,9 @@ pub struct Node {
     miner_handle: Option<JoinHandle<Result<()>>>,
     jsonrpc_server_handle: Option<JoinHandle<Result<()>>>,
     dkg_handle: Option<JoinHandle<Result<()>>>,
+    miner_election_handle: Option<JoinHandle<Result<()>>>,
+    quorum_election_handle: Option<JoinHandle<Result<()>>>,
+    conflict_resolution_handle: Option<Join<Result<()>>>,
 }
 
 impl Node {
@@ -68,6 +71,9 @@ impl Node {
         let reputation_events_rx = event_router.subscribe(&Topic::Consensus)?;
         let jsonrpc_events_rx = event_router.subscribe(&Topic::Control)?;
         let dkg_events_rx = event_router.subscribe(&Topic::Network)?;
+        let miner_election_events_rx = event_router.subscribe(&Topic::Consensus)?;
+        let quorum_election_events_rx = event_router.subscribe(&Topic::Consensus)?;
+        let conflict_resolution_events_rx = event_router.subscribe(&Topic::Consensus)?;
 
         let (
             updated_config,
@@ -77,6 +83,9 @@ impl Node {
             jsonrpc_server_handle,
             miner_handle,
             dkg_handle,
+            miner_election_handle,
+            quorum_election_handle,
+            conflict_resolution_handle
         ) = setup_runtime_components(
             &config,
             events_tx.clone(),
@@ -87,6 +96,9 @@ impl Node {
             miner_events_rx,
             jsonrpc_events_rx,
             dkg_events_rx,
+            miner_election_events_rx,
+            quorum_election_events_rx
+            conflict_resolution_events_rx,
         )
         .await?;
 
@@ -110,6 +122,9 @@ impl Node {
             events_tx,
             miner_handle,
             keypair,
+            miner_election_handle,
+            quorum_election_handle,
+            conflict_resolution_handle,
         })
     }
 

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -17,10 +17,6 @@ use serde::{Serialize, Deserialize};
 use std::fmt::Debug;
 use tokio::task::JoinHandle;
 
-// TODO: Create Seed Struct that 
-// checks upon creation that the 
-// value of the seed is between 
-// u32::MAX and u64::MAX 
 pub type Seed = u64;
 
 pub trait ElectionType: Clone + Debug {}

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -12,17 +12,18 @@ use storage::{
 use telemetry::info;
 use theater::{Actor, ActorImpl, Handler};
 use tokio::{
-    sync::{broadcast::Receiver, mpsc::UnboundedSender},
+    sync::{broadcast::Receiver, mpsc::{UnboundedSender, UnboundedReceiver}},
     task::JoinHandle,
 };
 use vrrb_config::NodeConfig;
+use vrrb_core::claim::Claim;
 use vrrb_rpc::rpc::{JsonRpcServer, JsonRpcServerConfig};
 
 use self::{
     broadcast_module::{BroadcastModule, BroadcastModuleConfig},
     mempool_module::{MempoolModule, MempoolModuleConfig},
     mining_module::{MiningModule, MiningModuleConfig},
-    state_module::StateModule,
+    state_module::StateModule, election_module::{ElectionModuleConfig, ElectionModule, QuorumElection, QuorumElectionResult, ConflictResolutionResult, ConflictResolution},
 };
 use crate::{
     broadcast_controller::{BroadcastEngineController, BROADCAST_CONTROLLER_BUFFER_SIZE},
@@ -53,8 +54,14 @@ pub async fn setup_runtime_components(
     miner_events_rx: Receiver<Event>,
     jsonrpc_events_rx: Receiver<Event>,
     dkg_events_rx: Receiver<Event>,
+    miner_election_events_rx: Receiver<Event>,
+    quorum_election_events_rx: Receiver<Event>,
+    conflict_resolution_events_rx: Receiver<Event>,
 ) -> Result<(
     NodeConfig,
+    Option<JoinHandle<Result<()>>>,
+    Option<JoinHandle<Result<()>>>,
+    Option<JoinHandle<Result<()>>>,
     Option<JoinHandle<Result<()>>>,
     Option<JoinHandle<Result<()>>>,
     Option<JoinHandle<Result<()>>>,
@@ -131,6 +138,31 @@ pub async fn setup_runtime_components(
 
     let dkg_handle = setup_dkg_module(&config, events_tx.clone(), dkg_events_rx)?;
 
+    let claim: Claim = config.keypair.clone().into();
+    let miner_election_handle = setup_miner_election_module(
+        &config, 
+        events_tx.clone(), 
+        miner_election_events_rx, 
+        state_read_handle.clone(),
+        claim.clone()
+    )?;
+    
+    let quorum_election_handle = setup_quorum_election_module(
+        &config, 
+        events_tx.clone(), 
+        quorum_election_events_rx,
+        state_read_handle.clone(),
+        claim.clone()
+    )?;
+
+    let conflict_resolution_handle = setup_conflict_resolution_module(
+        &config, 
+        events_tx.clone(), 
+        conflict_resolution_events_rx,
+        state_read_handle.clone(),
+        cliam.clone()
+    )?;
+
     Ok((
         config,
         mempool_handle,
@@ -138,7 +170,10 @@ pub async fn setup_runtime_components(
         gossip_handle,
         jsonrpc_server_handle,
         miner_handle,
-        None,
+        dkg_handle,
+        miner_election_handle,
+        quorum_election_handle,
+        conflict_resolution_handle
     ))
 }
 
@@ -244,8 +279,7 @@ async fn setup_rpc_api_server(
     vrrbdb_read_handle: VrrbDbReadHandle,
     mempool_read_handle_factory: MempoolReadHandleFactory,
     mut jsonrpc_events_rx: Receiver<Event>,
-) -> Result<(Option<JoinHandle<Result<()>>>, SocketAddr)> {
-    let jsonrpc_server_config = JsonRpcServerConfig {
+) -> Result<(Option<JoinHandle<Result<()>>>, SocketAddr)> { let jsonrpc_server_config = JsonRpcServerConfig {
         address: config.jsonrpc_server_address,
         node_type: config.node_type,
         events_tx,
@@ -351,6 +385,91 @@ fn setup_dkg_module(
     }
 }
 
+fn setup_miner_election_module(
+    config: &NodeConfig,
+    events_tx: UnboundedSender<DirectedEvent>,
+    mut miner_election_events_rx: Receiver<Event>,
+    db_read_handle: VrrbDbReadHandle,
+    local_claim: Claim,
+) -> Result<Option<JoinHandle<Result<()>>>> {
+
+    let module_config = ElectionModuleConfig {
+        db_read_handle,
+        events_tx,
+        local_claim,
+    };
+    
+    let module: ElectionModule<MinerElection, MinerElectionResult> = {
+        ElectionModule::new(ElectionModuleConfig)
+    };
+
+    let miner_election_module_actor = ActorImpl::new(module);
+    let miner_election_module_handle = tokio::spawn(async move {
+        miner_election_module_actor
+            .start(&miner_election_events_rx)
+            .await 
+            .map_err(|err| NodeError::Other(err.to_string()))
+    });
+
+    return Ok(Some(miner_election_module_handle));
+}
+
+fn setup_quorum_election_module(
+    config: &NodeConfig,
+    events_tx: UnboundedSender<DirectedEvent>,
+    mut quourum_election_events_rx: Receiver<Event>,
+    db_read_handle: VrrbDbReadHandle,
+    local_claim: Claim,
+) -> Result<Option<JoinHandle<Result<()>>>> {
+    let module_config = ElectionModuleConfig {
+        db_read_handle,
+        events_tx,
+        local_claim,
+    };
+    
+    let module: ElectionModule<QuorumElection, QuorumElectionResult> = {
+        ElectionModule::new(ElectionModuleConfig)
+    };
+
+    let quorum_election_module_actor = ActorImpl::new(module);
+    let quorum_election_module_handle = tokio::spawn(async move {
+        quorum_election_module_actor
+            .start(&quorum_election_events_rx)
+            .await 
+            .map_err(|err| NodeError::Other(err.to_string()))
+    });
+
+    return Ok(Some(quorum_election_module_handle));
+}
+
+fn setup_conflict_resolution_module(
+    config: &NodeConfig,
+    events_tx: UnboundedSender<DirectedEvent>,
+    mut conflict_resolution_events_rx: Receiver<Event>,
+    db_read_handle: VrrbDbReadHandle,
+    local_claim: Claim,
+) -> Result<Option<JoinHandle<Result<()>>>> {
+    let module_config = ElectionModuleConfig {
+        db_read_handle,
+        events_tx,
+        local_claim,
+    };
+    
+    let module: ElectionModule<ConflictResolution, ConflictResolutionResult> = {
+        ElectionModule::new(ElectionModuleConfig)
+    };
+
+    let conflict_resolution_module_actor = ActorImpl::new(module);
+    let conflict_resolution_module_handle = tokio::spawn(async move {
+        conflict_resolution_module_actor
+            .start(&conflict_resolution_events_rx)
+            .await 
+            .map_err(|err| NodeError::Other(err.to_string()))
+    });
+
+    return Ok(Some(quorum_election_module_handle));
+}
+
 fn setup_farmer_module() -> Result<Option<JoinHandle<Result<()>>>> {
     Ok(None)
 }
@@ -366,3 +485,4 @@ fn setup_reputation_module() -> Result<Option<JoinHandle<Result<()>>>> {
 fn setup_credit_model_module() -> Result<Option<JoinHandle<Result<()>>>> {
     Ok(None)
 }
+

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -1,3 +1,4 @@
+use primitives::Address;
 use serde::{Deserialize, Serialize};
 /// a Module for creating, maintaining, and using a claim in the fair,
 /// computationally inexpensive, collission proof, fully decentralized, fully
@@ -5,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use sha256::digest;
 
-use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable};
+use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable, keypair::Keypair};
 
 /// A custom error type for invalid claims that are used/attempted to be used
 /// in the mining of a block.
@@ -182,5 +183,16 @@ impl Nonceable for Claim {
         });
 
         self.hash = hash;
+    }
+}
+
+
+impl From<Keypair> for Claim {
+    fn from(item: Keypair) -> Claim {
+        Claim::new(
+           item.miner_kp.1.to_string(),
+           Address::new(item.miner_kp.1).to_string(),
+           0
+        )
     }
 }


### PR DESCRIPTION
…be built in parent branch, currently still awaiting the implementation of ElectionModule<QuorumElection, QuorumElectionResult>, but the MinerElection and ConflictResolution versions have been implemented and integrated. Also implemented From<Keypair> for Claim struct for easier conversion given the claim object can be build directly from the miner public key and the miner public key is in the Keypair which is in the NodeConfig, this way we can create the Claim upon startup, and we need the local claim in the ElectionModule right now, though we are not currently doing anything with it and will likely remove it, as the MinerModule, FarmerModule and HarvesterModule will have this information and can check from the return election result whether or not they have been elected.