### PR TITLE
Remove event router topics for internal use

### DIFF
--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -229,7 +229,8 @@ pub struct EventRouter {
 
 pub const DEFAULT_BUFFER: usize = 1000;
 
-pub type DirectedEvent = (Topic, Event);
+#[deprecated]
+pub type DirectedEvent = Event;
 
 impl Default for EventRouter {
     fn default() -> Self {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -20,10 +20,7 @@ use tokio::sync::{
     broadcast::{self, Receiver, Sender},
     mpsc::{UnboundedReceiver, UnboundedSender},
 };
-use vrrb_core::{
-    account::Account,
-    txn::{TransactionDigest, Txn},
-};
+use vrrb_core::txn::{TransactionDigest, Txn};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -252,11 +249,7 @@ impl EventRouter {
     }
 
     #[deprecated]
-    pub fn add_topic(&mut self, topic: Topic, size: Option<usize>) {
-        // let buffer = size.unwrap_or(1);
-        // let (tx, _) = broadcast::channel(buffer);
-        // self._topics.insert(topic, tx);
-    }
+    pub fn add_topic(&mut self, topic: Topic, size: Option<usize>) {}
 
     pub fn subscribe(&self) -> Receiver<Event> {
         self.sender.subscribe()
@@ -311,8 +304,6 @@ mod tests {
     async fn should_stop_when_issued_stop_event() {
         let (event_tx, mut event_rx) = unbounded_channel::<Event>();
         let mut router = EventRouter::default();
-
-        // router.add_topic(Topic::Control, Some(10));
 
         let mut subscriber_rx = router.subscribe();
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -17,7 +17,7 @@ use primitives::{
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
 use tokio::sync::{
-    broadcast::{self, Sender},
+    broadcast::{self, Receiver, Sender},
     mpsc::{UnboundedReceiver, UnboundedSender},
 };
 use vrrb_core::{
@@ -224,62 +224,62 @@ pub enum Topic {
 /// between runtime modules.
 pub struct EventRouter {
     /// Map of async transmitters to various runtime modules
-    topics: HashMap<Topic, Sender<Event>>,
+    _topics: HashMap<Topic, Sender<Event>>,
+
+    /// Event broadcast sender
+    sender: Sender<Event>,
 }
+
+pub const DEFAULT_BUFFER: usize = 1000;
 
 pub type DirectedEvent = (Topic, Event);
 
 impl Default for EventRouter {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
 impl EventRouter {
-    pub fn new() -> Self {
+    pub fn new(buffer: Option<usize>) -> Self {
+        let buffer = buffer.unwrap_or(DEFAULT_BUFFER);
+        let (sender, _) = broadcast::channel(buffer);
+
         Self {
-            topics: HashMap::new(),
+            _topics: HashMap::new(),
+            sender,
         }
     }
 
+    #[deprecated]
     pub fn add_topic(&mut self, topic: Topic, size: Option<usize>) {
-        let buffer = size.unwrap_or(1);
-        let (tx, _) = broadcast::channel(buffer);
-
-        self.topics.insert(topic, tx);
+        // let buffer = size.unwrap_or(1);
+        // let (tx, _) = broadcast::channel(buffer);
+        // self._topics.insert(topic, tx);
     }
 
-    pub fn subscribe(
-        &self,
-        topic: &Topic,
-    ) -> std::result::Result<broadcast::Receiver<Event>, Error> {
-        if let Some(sender) = self.topics.get(topic) {
-            Ok(sender.subscribe())
-        } else {
-            Err(Error::Other(format!("unable to subscribe to {topic:?}")))
-        }
+    pub fn subscribe(&self) -> Receiver<Event> {
+        self.sender.subscribe()
     }
 
     /// Starts the event router, distributing all incomming events to all
     /// subscribers
-    pub async fn start(&mut self, event_rx: &mut UnboundedReceiver<DirectedEvent>) {
-        while let Some((topic, event)) = event_rx.recv().await {
+    pub async fn start(&mut self, event_rx: &mut UnboundedReceiver<Event>) {
+        while let Some(event) = event_rx.recv().await {
             if event == Event::Stop {
                 info!("event router received stop signal");
-                self.fan_out_event(Event::Stop, &topic);
+                self.fan_out_event(Event::Stop);
 
                 return;
             }
 
-            self.fan_out_event(event, &topic);
+            self.fan_out_event(event);
         }
     }
 
-    fn fan_out_event(&mut self, event: Event, topic: &Topic) {
-        if let Some(topic_sender) = self.topics.get_mut(topic) {
-            if let Err(err) = topic_sender.send(event.clone()) {
-                error!("failed to send event {event:?} to topic {topic:?}: {err:?}");
-            }
+    fn fan_out_event(&mut self, event: Event) {
+        if let Err(err) = self.sender.send(event.clone()) {
+            error!("failed to broadcast event {event:?}: {err:?}");
         }
     }
 }
@@ -299,6 +299,7 @@ impl QuorumCertifiedTxn {
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
 
@@ -307,28 +308,19 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn should_susbcribe_to_topics() {
-        let mut router = EventRouter::new();
-
-        router.add_topic(Topic::Control, None);
-
-        router.subscribe(&Topic::Control).unwrap();
-    }
-
-    #[tokio::test]
     async fn should_stop_when_issued_stop_event() {
-        let (event_tx, mut event_rx) = unbounded_channel::<DirectedEvent>();
-        let mut router = EventRouter::new();
+        let (event_tx, mut event_rx) = unbounded_channel::<Event>();
+        let mut router = EventRouter::default();
 
-        router.add_topic(Topic::Control, Some(10));
+        // router.add_topic(Topic::Control, Some(10));
 
-        let mut subscriber_rx = router.subscribe(&Topic::Control).unwrap();
+        let mut subscriber_rx = router.subscribe();
 
         let handle = tokio::spawn(async move {
             router.start(&mut event_rx).await;
         });
 
-        event_tx.send((Topic::Control, Event::Stop)).unwrap();
+        event_tx.send(Event::Stop).unwrap();
 
         handle.await.unwrap();
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -17,7 +17,7 @@ pub use services::*;
 
 pub use crate::node::*;
 
-pub(crate) type EventBroadcastSender = tokio::sync::mpsc::UnboundedSender<DirectedEvent>;
+pub(crate) type EventBroadcastSender = tokio::sync::mpsc::UnboundedSender<Event>;
 pub(crate) type EventBroadcastReceiver = tokio::sync::broadcast::Receiver<Event>;
 
 /// The maximum size in kilobytes of transactions that can be in the mempool at

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -28,7 +28,7 @@ pub struct Node {
     event_router_handle: JoinHandle<()>,
     running_status: RuntimeModuleState,
     control_rx: UnboundedReceiver<Event>,
-    events_tx: UnboundedSender<DirectedEvent>,
+    events_tx: UnboundedSender<Event>,
 
     // TODO: make this private
     pub keypair: KeyPair,
@@ -52,22 +52,22 @@ impl Node {
         let vm = None;
         let keypair = config.keypair.clone();
 
-        let (events_tx, mut events_rx) = unbounded_channel::<DirectedEvent>();
+        let (events_tx, mut events_rx) = unbounded_channel::<Event>();
         let mut event_router = Self::setup_event_routing_system();
 
-        let mempool_events_rx = event_router.subscribe(&Topic::Storage)?;
-        let vrrbdb_events_rx = event_router.subscribe(&Topic::Storage)?;
-        let network_events_rx = event_router.subscribe(&Topic::Network)?;
-        let controller_events_rx = event_router.subscribe(&Topic::Network)?;
-        let miner_events_rx = event_router.subscribe(&Topic::Consensus)?;
+        let mempool_events_rx = event_router.subscribe();
+        let vrrbdb_events_rx = event_router.subscribe();
+        let network_events_rx = event_router.subscribe();
+        let controller_events_rx = event_router.subscribe();
+        let miner_events_rx = event_router.subscribe();
 
-        let farmer_events_rx = event_router.subscribe(&Topic::Consensus)?;
-        let harvester_events_rx = event_router.subscribe(&Topic::Consensus)?;
-        let mrc_events_rx = event_router.subscribe(&Topic::Throttle)?;
-        let cm_events_rx = event_router.subscribe(&Topic::Throttle)?;
-        let reputation_events_rx = event_router.subscribe(&Topic::Consensus)?;
-        let jsonrpc_events_rx = event_router.subscribe(&Topic::Control)?;
-        let dkg_events_rx = event_router.subscribe(&Topic::Network)?;
+        let farmer_events_rx = event_router.subscribe();
+        let harvester_events_rx = event_router.subscribe();
+        let mrc_events_rx = event_router.subscribe();
+        let cm_events_rx = event_router.subscribe();
+        let reputation_events_rx = event_router.subscribe();
+        let jsonrpc_events_rx = event_router.subscribe();
+        let dkg_events_rx = event_router.subscribe();
 
         let (
             updated_config,
@@ -127,7 +127,7 @@ impl Node {
 
         info!("node received stop signal");
 
-        self.events_tx.send((Topic::Control, Event::Stop))?;
+        self.events_tx.send(Event::Stop)?;
 
         if let Some(handle) = self.state_handle {
             handle.await??;
@@ -216,15 +216,7 @@ impl Node {
     }
 
     fn setup_event_routing_system() -> EventRouter {
-        let mut event_router = EventRouter::new();
-        event_router.add_topic(Topic::Control, Some(1));
-        event_router.add_topic(Topic::State, Some(1));
-        event_router.add_topic(Topic::Internal, Some(100));
-        event_router.add_topic(Topic::External, Some(100));
-        event_router.add_topic(Topic::Network, Some(100));
-        event_router.add_topic(Topic::Consensus, Some(100));
-        event_router.add_topic(Topic::Storage, Some(100));
-        event_router.add_topic(Topic::Throttle, Some(100));
+        let mut event_router = EventRouter::default();
 
         event_router
     }

--- a/crates/node/src/runtime/broadcast_module.rs
+++ b/crates/node/src/runtime/broadcast_module.rs
@@ -203,7 +203,7 @@ mod tests {
         events_tx.send(Event::SyncPeers(vec![peer_data])).unwrap();
         events_tx.send(Event::Stop).unwrap();
 
-        let (_, evt) = internal_events_rx.recv().await.unwrap();
+        let evt = internal_events_rx.recv().await.unwrap();
 
         handle.await.unwrap();
     }

--- a/crates/node/src/runtime/farmer_harvester_module.rs
+++ b/crates/node/src/runtime/farmer_harvester_module.rs
@@ -103,7 +103,6 @@ pub struct FarmerHarvesterModule {
     async_jobs_status_receiver: Receiver<JobResult>,
 }
 
-
 impl FarmerHarvesterModule {
     pub fn new(
         certified_txns_filter: Bloom,
@@ -163,13 +162,10 @@ impl FarmerHarvesterModule {
                 JobResult::Votes((votes, farmer_quorum_threshold)) => {
                     for vote_opt in votes.iter() {
                         if let Some(vote) = vote_opt {
-                            let _ = broadcast_events_tx.send((
-                                Topic::Network,
-                                Event::Vote(
-                                    vote.clone(),
-                                    QuorumType::Harvester,
-                                    farmer_quorum_threshold,
-                                ),
+                            let _ = broadcast_events_tx.send(Event::Vote(
+                                vote.clone(),
+                                QuorumType::Harvester,
+                                farmer_quorum_threshold,
                             ));
                         }
                     }
@@ -323,7 +319,7 @@ impl Handler<Event> for FarmerHarvesterModule {
                     .take(num_of_txns)
                     .for_each(|txn| {
                         self.broadcast_events_tx
-                            .send((Topic::Storage, Event::QuorumCertifiedTxns(txn.clone())));
+                            .send(Event::QuorumCertifiedTxns(txn.clone()));
                     });
             },
             Event::NoOp => {},

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -95,9 +95,10 @@ impl FarmerModule {
                 JobResult::Votes((votes, farmer)) => {
                     for vote_opt in votes.iter() {
                         if let Some(vote) = vote_opt {
-                            let _ = broadcast_events_tx.send((
-                                Topic::Network,
-                                Event::Vote(vote.clone(), QuorumType::Harvester, farmer),
+                            let _ = broadcast_events_tx.send(Event::Vote(
+                                vote.clone(),
+                                QuorumType::Harvester,
+                                farmer,
                             ));
                         }
                     }

--- a/crates/node/src/runtime/mempool_module.rs
+++ b/crates/node/src/runtime/mempool_module.rs
@@ -92,7 +92,7 @@ impl Handler<Event> for MempoolModule {
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 self.events_tx
-                    .send((Topic::Consensus, Event::TxnAddedToMempool(txn_hash.clone())))
+                    .send(Event::TxnAddedToMempool(txn_hash.clone()))
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 info!("Transaction {} sent to mempool", txn_hash);
@@ -104,12 +104,9 @@ impl Handler<Event> for MempoolModule {
                     self.cutoff_transaction = Some(txn_hash.clone());
 
                     self.events_tx
-                        .send((
-                            Topic::Consensus,
-                            Event::MempoolSizeThesholdReached {
-                                cutoff_transaction: txn_hash,
-                            },
-                        ))
+                        .send(Event::MempoolSizeThesholdReached {
+                            cutoff_transaction: txn_hash,
+                        })
                         .map_err(|err| TheaterError::Other(err.to_string()))?;
                 }
             },

--- a/crates/node/src/runtime/state_module.rs
+++ b/crates/node/src/runtime/state_module.rs
@@ -70,7 +70,7 @@ impl StateModule {
             .map_err(|err| NodeError::Other(err.to_string()))?;
 
         self.events_tx
-            .send((Topic::Storage, Event::TxnAddedToMempool(txn_hash)))
+            .send(Event::TxnAddedToMempool(txn_hash))
             .map_err(|err| NodeError::Other(err.to_string()))?;
 
         Ok(())

--- a/crates/node/src/services/broadcast_controller.rs
+++ b/crates/node/src/services/broadcast_controller.rs
@@ -114,8 +114,7 @@ impl BroadcastEngineController {
                 if peers.is_empty() {
                     warn!("No peers to sync with");
 
-                    self.events_tx
-                        .send((Topic::Consensus, Event::EmptyPeerSync))?;
+                    self.events_tx.send(Event::EmptyPeerSync)?;
 
                     // TODO: revisit this return
                     return Ok(());
@@ -144,8 +143,7 @@ impl BroadcastEngineController {
                 if let Err(err) = peer_connection_result {
                     error!("unable to add peer connection: {err}");
 
-                    self.events_tx
-                        .send((Topic::Consensus, Event::PeerSyncFailed(quic_addresses)))?;
+                    self.events_tx.send(Event::PeerSyncFailed(quic_addresses))?;
 
                     return Err(err.into());
                 }

--- a/crates/vrrb_rpc/src/rpc/server.rs
+++ b/crates/vrrb_rpc/src/rpc/server.rs
@@ -21,7 +21,7 @@ pub struct JsonRpcServerConfig {
     pub vrrbdb_read_handle: VrrbDbReadHandle,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
     pub node_type: NodeType,
-    pub events_tx: UnboundedSender<DirectedEvent>,
+    pub events_tx: UnboundedSender<Event>,
 }
 
 #[derive(Debug)]

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -67,12 +67,10 @@ impl RpcApiServer for RpcServerImpl {
             return Err(err);
         }
 
-        self.events_tx
-            .send((Topic::Storage, event))
-            .map_err(|err| {
-                error!("could not queue transaction to mempool: {err}");
-                Error::Custom(err.to_string())
-            })?;
+        self.events_tx.send(event).map_err(|err| {
+            error!("could not queue transaction to mempool: {err}");
+            Error::Custom(err.to_string())
+        })?;
 
         Ok(RpcTransactionRecord::from(txn))
     }
@@ -85,12 +83,10 @@ impl RpcApiServer for RpcServerImpl {
 
         debug!("{:?}", event);
 
-        self.events_tx
-            .send((Topic::Storage, event.clone()))
-            .map_err(|err| {
-                error!("could not create account: {err}");
-                Error::Custom(err.to_string())
-            })?;
+        self.events_tx.send(event.clone()).map_err(|err| {
+            error!("could not create account: {err}");
+            Error::Custom(err.to_string())
+        })?;
 
         telemetry::info!("requested account creation for address: {}", address);
 
@@ -108,7 +104,7 @@ impl RpcApiServer for RpcServerImpl {
 
         let event = Event::AccountUpdateRequested((addr, account_bytes));
 
-        self.events_tx.send((Topic::State, event)).map_err(|err| {
+        self.events_tx.send(event).map_err(|err| {
             error!("could not update account: {err}");
             Error::Custom(err.to_string())
         })?;


### PR DESCRIPTION
Simplifies usage of the event router defined at vrrb_core by removing the notion of topics and the need to specify them when publishing an event.

Now all runtime components receive all events and can decide to ignore them if they're not relevant for their function.