### PR TITLE
Refactor miner to focus on only building convergence blocks. 

### DIFF
--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -27,3 +27,4 @@ bulldag = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
+ethereum-types = { workspace = true }

--- a/crates/block/src/block.rs
+++ b/crates/block/src/block.rs
@@ -1,5 +1,6 @@
 // This file contains code for creating blocks to be proposed, including the
 // genesis block and blocks being mined.
+#![allow(unused_imports)]
 
 use std::fmt;
 
@@ -72,21 +73,21 @@ impl Block {
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|(txn)| std::mem::size_of_val(&txn))
+                .map(|txn| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
 
             Block::Proposal { block } => block
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|(txn)| std::mem::size_of_val(&txn))
+                .map(|txn| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
 
             Block::Genesis { block } => block
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|(txn)| std::mem::size_of_val(&txn))
+                .map(|txn| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
         }
     }

--- a/crates/block/src/block.rs
+++ b/crates/block/src/block.rs
@@ -45,6 +45,7 @@ pub trait InnerBlock: std::fmt::Debug {
     fn get_next_block_reward(&self) -> Self::RewardType;
     fn is_genesis(&self) -> bool;
     fn get_hash(&self) -> String;
+    fn get_ref_hashes(&self) -> Vec<String>;
     fn into_static_convergence(&self) -> Option<ConvergenceBlock>;
     fn into_static_genesis(&self) -> Option<GenesisBlock>;
 }
@@ -157,6 +158,10 @@ impl InnerBlock for ConvergenceBlock {
     fn into_static_genesis(&self) -> Option<GenesisBlock> {
         None
     }
+
+    fn get_ref_hashes(&self) -> Vec<String> {
+        self.header.ref_hashes.clone()
+    }
 }
 
 impl InnerBlock for GenesisBlock {
@@ -189,6 +194,10 @@ impl InnerBlock for GenesisBlock {
     
     fn into_static_genesis(&self) -> Option<GenesisBlock> {
         Some(self.clone())
+    }
+
+    fn get_ref_hashes(&self) -> Vec<String> {
+        self.header.ref_hashes.clone()
     }
 }
 

--- a/crates/block/src/block.rs
+++ b/crates/block/src/block.rs
@@ -1,9 +1,10 @@
 // This file contains code for creating blocks to be proposed, including the
 // genesis block and blocks being mined.
-#![allow(unused_imports)]
+
 
 use std::fmt;
 
+use bulldag::vertex::Vertex;
 use primitives::{Epoch, SecretKey as SecretKeyBytes};
 use reward::reward::Reward;
 #[cfg(mainnet)]
@@ -35,7 +36,7 @@ use crate::{
     ProposalBlock,
 };
 
-pub trait InnerBlock {
+pub trait InnerBlock: std::fmt::Debug {
     type Header;
     type RewardType;
 
@@ -44,6 +45,8 @@ pub trait InnerBlock {
     fn get_next_block_reward(&self) -> Self::RewardType;
     fn is_genesis(&self) -> bool;
     fn get_hash(&self) -> String;
+    fn into_static_convergence(&self) -> Option<ConvergenceBlock>;
+    fn into_static_genesis(&self) -> Option<GenesisBlock>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -73,21 +76,21 @@ impl Block {
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|txn| std::mem::size_of_val(&txn))
+                .map(|(txn)| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
 
             Block::Proposal { block } => block
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|txn| std::mem::size_of_val(&txn))
+                .map(|(txn)| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
 
             Block::Genesis { block } => block
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|txn| std::mem::size_of_val(&txn))
+                .map(|(txn)| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
         }
     }
@@ -146,6 +149,14 @@ impl InnerBlock for ConvergenceBlock {
     fn get_hash(&self) -> String {
         self.hash.clone()
     }
+
+    fn into_static_convergence(&self) -> Option<ConvergenceBlock> {
+        Some(self.clone())
+    }
+    
+    fn into_static_genesis(&self) -> Option<GenesisBlock> {
+        None
+    }
 }
 
 impl InnerBlock for GenesisBlock {
@@ -170,5 +181,29 @@ impl InnerBlock for GenesisBlock {
 
     fn get_hash(&self) -> String {
         self.hash.clone()
+    }
+
+    fn into_static_convergence(&self) -> Option<ConvergenceBlock> {
+        None
+    }
+    
+    fn into_static_genesis(&self) -> Option<GenesisBlock> {
+        Some(self.clone())
+    }
+}
+
+impl From<Block> for Vertex<Block, String> {
+    fn from(item: Block) -> Vertex<Block, String> {
+        match item {
+            Block::Convergence { ref block } => {
+                return Vertex::new(item.clone(), block.hash.clone());
+            },
+            Block::Proposal { ref block } => {
+                return Vertex::new(item.clone(), block.hash.clone());
+            },
+            Block::Genesis { ref block } => {
+                return Vertex::new(item.clone(), block.hash.clone());
+            }
+        }
     }
 }

--- a/crates/block/src/convergence_block.rs
+++ b/crates/block/src/convergence_block.rs
@@ -1,59 +1,23 @@
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, HashSet},
-    fmt,
-};
-
-use bulldag::{
-    graph::BullDag,
-    index::Index,
-    vertex::{Direction, Vertex},
-};
 use primitives::{
     Epoch,
-    RawSignature,
     SecretKey as SecretKeyBytes,
-    GENESIS_EPOCH,
-    SECOND,
-    VALIDATOR_THRESHOLD,
 };
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;
-use reward::reward::{Reward, NUMBER_OF_BLOCKS_PER_EPOCH};
+use reward::reward::Reward;
 use ritelinked::{LinkedHashMap, LinkedHashSet};
-use secp256k1::{
-    hashes::{sha256 as s256, Hash},
-    Message,
-};
 use serde::{Deserialize, Serialize};
-use sha256::digest;
-use utils::{create_payload, hash_data};
-use vrrb_core::{
-    accountable::Accountable,
-    claim::Claim,
-    keypair::KeyPair,
-    txn::Txn,
-    verifiable::Verifiable,
-};
+use vrrb_core::{claim::Claim, txn::{Txn, TransactionDigest}};
 
 #[cfg(mainnet)]
 use crate::genesis;
 use crate::{
-    genesis,
     header::BlockHeader,
-    invalid::{BlockError, InvalidBlockErrorReason},
     Block,
     BlockHash,
     Certificate,
-    ClaimHash,
-    Conflict,
-    ConflictList,
     ConsolidatedClaims,
     ConsolidatedTxns,
-    GenesisBlock,
-    ProposalBlock,
-    RefHash,
-    TxnId,
 };
 
 pub struct MineArgs<'a> {
@@ -88,7 +52,7 @@ impl ConvergenceBlock {
         self.certificate = Some(cert);
     }
 
-    pub fn txn_id_set(&self) -> LinkedHashSet<&TxnId> {
+    pub fn txn_id_set(&self) -> LinkedHashSet<&TransactionDigest> {
         self.txns.iter().flat_map(|(_, set)| set).collect()
     }
 }

--- a/crates/block/src/genesis.rs
+++ b/crates/block/src/genesis.rs
@@ -1,13 +1,6 @@
-#![allow(unused_imports)]
-use primitives::SecretKey as SecretKeyBytes;
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;
-use ritelinked::LinkedHashMap;
-use secp256k1::{hashes::Hash, SecretKey};
 use serde::{Deserialize, Serialize};
-use sha256::digest;
-use utils::{create_payload, hash_data};
-use vrrb_core::claim::Claim;
 
 #[cfg(mainnet)]
 use crate::genesis;

--- a/crates/block/src/genesis.rs
+++ b/crates/block/src/genesis.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use primitives::SecretKey as SecretKeyBytes;
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;

--- a/crates/block/src/header.rs
+++ b/crates/block/src/header.rs
@@ -153,7 +153,7 @@ impl BlockHeader {
 
         // Get current epoch which is the same as last epoch unless it's an
         // epoch change block.
-        let epoch = last_block.get_header().epoch;
+        let epoch = block_reward.epoch;
         // Get the reward for current block which is last_block.round + 1
         let round = last_block.get_header().round + 1;
 

--- a/crates/block/src/header.rs
+++ b/crates/block/src/header.rs
@@ -1,24 +1,20 @@
 // FEATURE TAG(S): Block Structure, Rewards
 use chrono;
-use primitives::{Epoch, SecretKey, SerializedSecretKey};
+use primitives::{Epoch, SecretKey};
 use reward::reward::Reward;
 use secp256k1::{
     hashes::{sha256 as s256, Hash},
     Message,
 };
 use serde::{Deserialize, Serialize};
-use sha256::digest;
 use utils::{create_payload, hash_data};
-use vrrb_core::{claim::Claim, keypair::KeyPair};
+use vrrb_core::claim::Claim;
 use vrrb_vrf::{vrng::VRNG, vvrf::VVRF};
 
 use crate::{
     block::Block,
-    ConvergenceBlock,
-    GenesisBlock,
     InnerBlock,
     NextEpochAdjustment,
-    ProposalBlock,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -54,19 +50,19 @@ impl BlockHeader {
         //TODO: Determine data fields to be used as message in VPRNG, must be
         // known/revealed within block but cannot be predictable or gameable.
         // Leading candidates are some combination of last_hash and last_block_seed
-        let ref_hashes = vec![hash_data!("Genesis_Ref_Hash")];
+        let ref_hashes = vec![format!("{:x}", hash_data!("Genesis_Ref_Hash".to_string()))];
         let message = {
-            hash_data!(ref_hashes, hash_data!("Genesis_Last_Hash"))
-                .as_bytes()
-                .to_vec()
+            let genesis_message = format!("{:x}", hash_data!("Genesis_Last_Hash".to_string()));
+            let hash = hash_data!(ref_hashes, genesis_message);
+            let hash_string = format!("{:x}", hash); 
+            hash_string.as_bytes().to_vec()
         };
 
         let mut vrf = VVRF::new(&message, &secret_key.secret_bytes().to_vec());
-
         let next_block_seed = vrf.generate_u64_in_range(u32::MAX as u64, u64::MAX);
 
         let timestamp = chrono::Utc::now().timestamp();
-        let txn_hash = hash_data!("Genesis_Txn_Hash");
+        let txn_hash = format!("{:x}", hash_data!("Genesis_Txn_Hash".to_string()));
         let block_reward = Reward::genesis(Some(miner_claim.address.clone()));
         let block_height = 0;
         let next_block_reward = Reward::default();
@@ -115,6 +111,8 @@ impl BlockHeader {
         adjustment_next_epoch: NextEpochAdjustment,
     ) -> Option<BlockHeader> {
         // Get the last block
+        let timestamp = chrono::Utc::now().timestamp();
+
         let last_block: &dyn InnerBlock<Header = BlockHeader, RewardType = Reward> = {
             match last_block {
                 Block::Convergence { ref block } => block,
@@ -133,7 +131,7 @@ impl BlockHeader {
         // last_block.certificate
         let message = {
             let hash = hash_data!(last_block.get_hash(), ref_hashes);
-            hash.as_bytes().to_vec()
+            hash
         };
 
         let sk_bytes = &secret_key.secret_bytes();
@@ -141,9 +139,6 @@ impl BlockHeader {
         // Generate next_block_seed
         let mut vrf = VVRF::new(&message, sk_bytes);
         let next_block_seed = vrf.generate_u64_in_range(u32::MAX as u64, u64::MAX);
-
-        // generate timestamp
-        let timestamp = chrono::Utc::now().timestamp();
 
         // Get current block reward, which is last_block.next_block_reward
         let mut block_reward = last_block.get_next_block_reward();

--- a/crates/block/src/proposal_block.rs
+++ b/crates/block/src/proposal_block.rs
@@ -10,6 +10,28 @@ use vrrb_core::{claim::Claim, txn::TransactionDigest};
 
 use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnList};
 
+/// A Block type that goes between two ConvergenceBlocks in the 
+/// VRRB Dag.
+///
+/// ```
+/// use serde::{Serialize, Deserialize};
+/// use block::{BlockHash, RefHash, TxnList};
+/// use primitives::Epoch;
+///
+/// #[derive(Clone, Debug, Serialize, Deserialize)]
+/// #[repr(C)]
+/// pub struct ProposalBlock {
+///     pub ref_block: RefHash;
+///     pub round: u128,
+///     pub epoch: Epoch,
+///     pub txns: TxnList,
+///     pub claims: ClaimList,
+///     pub from: Claim,
+///     pub hash: BlockHash,
+///     pub signature: String,
+/// }
+/// ```
+///
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[repr(C)]
 pub struct ProposalBlock {

--- a/crates/block/src/proposal_block.rs
+++ b/crates/block/src/proposal_block.rs
@@ -6,7 +6,7 @@ use secp256k1::{
 };
 use serde::{Deserialize, Serialize};
 use utils::{create_payload, hash_data};
-use vrrb_core::{claim::Claim, txn::TransactionDigest};
+use vrrb_core::{claim::Claim, txn::{Txn, TransactionDigest}};
 
 use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnList};
 
@@ -59,7 +59,12 @@ impl ProposalBlock {
 
         let payload = create_payload!(round, epoch, txns, claims, from);
         let signature = secret_key.sign_ecdsa(payload).to_string();
-        let hash = hash_data!(round, epoch, txns, claims, from, signature);
+        let hashable_txns: Vec<(String, Txn)> = {
+            txns.clone().iter().map(|(k, v)| {
+                (k.digest_string(), v.clone())
+            }).collect()
+        };
+        let hash = hash_data!(round, epoch, hashable_txns, claims, from, signature);
         let hash_string = format!("{:x}", hash);
 
         ProposalBlock {

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -1,53 +1,21 @@
 // This file contains code for creating blocks to be proposed, including the
 // genesis block and blocks being mined.
 
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, HashSet},
-    fmt,
-};
+use std::collections::{HashMap, HashSet};
 
-use bulldag::{
-    graph::BullDag,
-    index::Index,
-    vertex::{Direction, Vertex},
-};
-use primitives::{
-    Epoch,
-    RawSignature,
-    SecretKey as SecretKeyBytes,
-    GENESIS_EPOCH,
-    SECOND,
-    VALIDATOR_THRESHOLD,
-};
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;
-use reward::reward::{Reward, NUMBER_OF_BLOCKS_PER_EPOCH};
 use ritelinked::{LinkedHashMap, LinkedHashSet};
-use secp256k1::{
-    hashes::{sha256 as s256, Hash},
-    Message,
-};
 use serde::{Deserialize, Serialize};
-use sha256::digest;
-use utils::{create_payload, hash_data};
 use vrrb_core::{
-    accountable::Accountable,
     claim::Claim,
-    keypair::KeyPair,
     txn::{Txn, TransactionDigest},
-    verifiable::Verifiable,
 };
 use tokio::task::JoinHandle;
 use std::error::Error;
 
 #[cfg(mainnet)]
 use crate::genesis;
-use crate::{
-    genesis,
-    header::BlockHeader,
-    invalid::{BlockError, InvalidBlockErrorReason},
-};
 
 pub const GROSS_UTILITY_PERCENTAGE: f64 = 0.01;
 pub const PERCENTAGE_CHANGE_SUPPLY_CAP: f64 = 0.25;
@@ -58,7 +26,7 @@ pub type NextEpochAdjustment = i128;
 pub type ClaimHash = String;
 pub type RefHash = String;
 pub type TxnList = LinkedHashMap<TransactionDigest, Txn>;
-pub type ClaimList = LinkedHashMap<ClaimHash, Claim>;
+pub type ClaimList = LinkedHashMap<String, Claim>;
 pub type ConsolidatedTxns = LinkedHashMap<RefHash, LinkedHashSet<TransactionDigest>>;
 pub type ConsolidatedClaims = LinkedHashMap<RefHash, LinkedHashSet<ClaimHash>>;
 pub type BlockHash = String;

--- a/crates/consensus/reward/src/reward.rs
+++ b/crates/consensus/reward/src/reward.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, deprecated_in_future)]
 //FEATURE TAG(S): Rewards, Block Structure
 
 use serde::{Deserialize, Serialize};
@@ -54,7 +53,7 @@ impl Reward {
     pub fn genesis(miner: Option<String>) -> Reward {
         Reward {
             current_block: 0,
-            epoch: 1,
+            epoch: 0,
             next_epoch_block: NUMBER_OF_BLOCKS_PER_EPOCH,
             miner,
             amount: BASELINE_REWARD,

--- a/crates/consensus/reward/src/reward.rs
+++ b/crates/consensus/reward/src/reward.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated, deprecated_in_future)]
 //FEATURE TAG(S): Rewards, Block Structure
 
 use serde::{Deserialize, Serialize};

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports, deprecated_in_future, deprecated)]
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports, deprecated_in_future, deprecated)]
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
@@ -9,12 +8,9 @@ use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
 use left_right::{Absorb, ReadHandle, ReadHandleFactory, WriteHandle};
 use serde::{Deserialize, Serialize};
-use telemetry::{error, info, warn};
-use tokio;
 use vrrb_core::txn::{TransactionDigest, TxTimestamp, Txn};
 
 use super::error::MempoolError;
-use crate::create_tx_indexer;
 
 pub type Result<T> = StdResult<T, MempoolError>;
 

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated, deprecated_in_future)]
 //FEATURE TAG(S): Left-Right Mempool, Validator Cores, Tx Validation, Tx Writes
 // to Confirmed, Block Validation & Confirmation, Block Structure
 use std::{cmp::Eq, hash::Hash};

--- a/crates/miner/Cargo.toml
+++ b/crates/miner/Cargo.toml
@@ -21,3 +21,5 @@ block = { workspace = true }
 mempool = { workspace = true }
 thiserror = { workspace = true }
 utils = { workspace = true }
+sha2 = { workspace = true }
+ethereum-types = { workspace = true }

--- a/crates/miner/Cargo.toml
+++ b/crates/miner/Cargo.toml
@@ -23,3 +23,4 @@ thiserror = { workspace = true }
 utils = { workspace = true }
 sha2 = { workspace = true }
 ethereum-types = { workspace = true }
+tokio = { workspace = true }

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,3 +1,8 @@
+use std::collections::HashSet;
+
+use block::{RefHash, Block};
+use bulldag::vertex::Vertex;
+
 use crate::conflict_resolver::Resolver;
 /// A trait that can be implemented on any type that can build blocks.
 /// For current purposes, this is to be implemented on both Miner struct 
@@ -24,4 +29,28 @@ pub trait BlockBuilder: Resolver {
     fn update(&mut self, adjustment: &i128); 
     fn build(&self) -> Option<Self::BlockType>;
     fn get_references(&self) -> Option<Vec<Self::RefType>>;
+
+    fn get_orphaned_references(
+        &self, 
+        idx: RefHash, 
+        current_round: usize, 
+        n_rounds: usize
+    ) -> Vec<Self::RefType> {
+        let _ = n_rounds;
+        let _ = current_round;
+        let _ = idx;
+        vec![]
+    }
+
+    fn get_last_block_vertex(&self, idx: Option<RefHash>) -> Option<Vertex<Block, String>> {
+        let _ = idx;
+        None
+    }
+
+    fn get_n_rounds_convergence(&self, idx: RefHash, current_round: usize, n_rounds: usize) -> HashSet<RefHash> {
+        let _ = idx;
+        let _ = current_round;
+        let _ = n_rounds;
+        vec![]
+    }
 }

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,0 +1,29 @@
+use std::error::Error;
+use events::Event;
+use block::{Block, ConvergenceBlock, ProposalBlock};
+use bulldag::graph::BullDag;
+use crate::conflict_resolver::Resolver;
+
+/// A trait that can be implemented on any type that can build blocks.
+/// For current purposes, this is to be implemented on both Miner struct 
+/// and Harvester. 
+///     
+/// ```
+/// pub trait BlockBuilder: Resolver {
+///     type BlockType;
+///     type RefType;
+///     
+///     fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128);
+///     fn build(&self) -> Option<Self::BlockType>;
+///     fn get_references(&self) -> Vec<Self::RefType>; 
+/// }
+///
+// TODO: This should be moved to a separate crate
+pub trait BlockBuilder: Resolver {
+    type BlockType;
+    type RefType;
+
+    fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128); 
+    fn build(&self) -> Option<Self::BlockType>;
+    fn get_references(&self) -> Option<Vec<Self::RefType>>;
+}

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
-use block::{RefHash, Block};
+use block::{RefHash, Block, header::BlockHeader, InnerBlock};
 use bulldag::vertex::Vertex;
+use reward::reward::Reward;
+use std::sync::Arc;
 
 use crate::conflict_resolver::Resolver;
 /// A trait that can be implemented on any type that can build blocks.
@@ -26,7 +28,11 @@ pub trait BlockBuilder: Resolver {
     type BlockType;
     type RefType;
 
-    fn update(&mut self, adjustment: &i128); 
+    fn update(
+        &mut self, 
+        last_block: Option<Arc<dyn InnerBlock<Header = BlockHeader, RewardType = Reward>>>,
+        adjustment: &i128
+    ); 
     fn build(&self) -> Option<Self::BlockType>;
     fn get_references(&self) -> Option<Vec<Self::RefType>>;
 
@@ -51,6 +57,6 @@ pub trait BlockBuilder: Resolver {
         let _ = idx;
         let _ = current_round;
         let _ = n_rounds;
-        vec![]
+        HashSet::new()
     }
 }

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,4 +1,3 @@
-use block::ConvergenceBlock;
 use crate::conflict_resolver::Resolver;
 /// A trait that can be implemented on any type that can build blocks.
 /// For current purposes, this is to be implemented on both Miner struct 
@@ -12,7 +11,7 @@ use crate::conflict_resolver::Resolver;
 ///     type BlockType;
 ///     type RefType;
 ///     
-///     fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128);
+///     fn update(&mut self, adjustment: &i128);
 ///     fn build(&self) -> Option<Self::BlockType>;
 ///     fn get_references(&self) -> Vec<Self::RefType>; 
 /// }
@@ -22,7 +21,7 @@ pub trait BlockBuilder: Resolver {
     type BlockType;
     type RefType;
 
-    fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128); 
+    fn update(&mut self, adjustment: &i128); 
     fn build(&self) -> Option<Self::BlockType>;
     fn get_references(&self) -> Option<Vec<Self::RefType>>;
 }

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,14 +1,13 @@
-use std::error::Error;
-use events::Event;
-use block::{Block, ConvergenceBlock, ProposalBlock};
-use bulldag::graph::BullDag;
+use block::ConvergenceBlock;
 use crate::conflict_resolver::Resolver;
-
 /// A trait that can be implemented on any type that can build blocks.
 /// For current purposes, this is to be implemented on both Miner struct 
 /// and Harvester. 
 ///     
 /// ```
+/// use miner::conflict_resolver::Resolver;
+/// use block::ConvergenceBlock;
+///
 /// pub trait BlockBuilder: Resolver {
 ///     type BlockType;
 ///     type RefType;

--- a/crates/miner/src/conflict_resolver.rs
+++ b/crates/miner/src/conflict_resolver.rs
@@ -55,10 +55,10 @@ pub trait Resolver {
     fn get_proposers(&self, proposals: &Vec<Self::Proposal>) -> Vec<Self::BallotInfo>; 
     fn append_winner(&self, conflicts: &mut Self::Identified, election_results: &mut BTreeMap<U256, Self::BallotInfo>); 
     fn resolve_current(&self, current: &mut Vec<Self::Proposal>, conflicts: &Self::Identified);
-    #[allow(unused)]
     fn split_proposals_by_round(
         &self, proposals: &Vec<Self::Proposal>
     ) -> (Vec<Self::Proposal>, Vec<Self::Proposal>) {
+        let _ = proposals;
         (vec![], vec![])
     }
 }

--- a/crates/miner/src/conflict_resolver.rs
+++ b/crates/miner/src/conflict_resolver.rs
@@ -1,0 +1,61 @@
+use std::collections::BTreeMap;
+
+use ethereum_types::U256;
+use vrrb_core::claim::Claim;
+
+/// A trait that can be implemented on any type that may need to resolve 
+/// any kind of conflict in the process of working. In particular, the 
+/// Miner and Harvester should implement this trait. 
+///
+/// Miners will use the methods to resolve conflicts between 
+/// proposal blocks 
+///
+/// Harvesters will use this trait as an MEV engine to reduce the subset 
+/// of transactions that it may want to include in a block to only those 
+/// that it has a high probability of winning. 
+/// ```
+/// pub trait Resolver {
+///   type ProposalInner;
+///   type Identified: IntoIterator;
+///   type SourceInner;
+///   type BallotInfo; 
+///
+///    fn identify<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &Self::Identified;
+///    fn resolve<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &I;
+///    fn resolve_earlier<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &I;
+///    fn get_sources<I: IntoIterator<Item = Self::SourceInner>>(&self, proposals: &I) -> &I;
+///    fn get_election_results<I: IntoIterator<Item = Self::BallotInfo>>(&self, proposers: &I) -> BTreeMap<U256, Self::BallotInfo>; 
+///    fn get_proposers<I: IntoIterator<Item = Self::ProposalInner>, E: IntoIterator<Item = Self::BallotInfo>>(&self, proposals: &I) -> &E; 
+///    fn append_winner(&self, conflicts: &mut Self::Identified, election_results: &mut BTreeMap<U256, Self::BallotInfo>); 
+///    fn resolve_current<I: IntoIterator<Item = Self::ProposalInner>>(&self, current: &mut I, conflicts: &Self::Identified);
+///    fn split_proposals_by_round<I: IntoIterator<Item = Self::ProposalInner>>(
+///        &self, proposals: &I
+///    ) -> (I, I) {
+///        (vec![], vec![])
+///    }
+/// }
+/// ``` 
+///
+///
+// TODO: This should be moved to a separate crate
+// TODO: We should add a basic doctest example of implementing this
+pub trait Resolver {
+    type ProposalInner;
+    type Identified: IntoIterator + Default;
+    type SourceInner;
+    type BallotInfo;
+    
+    fn identify<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &Self::Identified;
+    fn resolve<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &I;
+    fn resolve_earlier<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &I;
+    fn get_sources<I: IntoIterator<Item = Self::SourceInner>>(&self, proposals: &I) -> &I;
+    fn get_election_results<I: IntoIterator<Item = Self::BallotInfo>>(&self, proposers: &I) -> BTreeMap<U256, Self::BallotInfo>; 
+    fn get_proposers<I: IntoIterator<Item = Self::ProposalInner>, E: IntoIterator<Item = Self::BallotInfo>>(&self, proposals: &I) -> &E; 
+    fn append_winner(&self, conflicts: &mut Self::Identified, election_results: &mut BTreeMap<U256, Self::BallotInfo>); 
+    fn resolve_current<I: IntoIterator<Item = Self::ProposalInner>>(&self, current: &mut I, conflicts: &Self::Identified);
+    fn split_proposals_by_round<I: IntoIterator<Item = Self::ProposalInner>>(
+        &self, proposals: &I
+    ) -> (I, I) {
+        (vec![], vec![])
+    }
+}

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -35,7 +35,7 @@ mod tests {
             create_miner, 
             create_miner_from_keypair, 
             create_keypair, 
-            create_and_sign_message, MinerDag, create_miner_return_dag, build_proposal_block, add_edges_to_dag
+            create_and_sign_message, MinerDag, create_miner_return_dag, build_proposal_block, create_txns
         }, MinerConfig
     };
 
@@ -131,7 +131,44 @@ mod tests {
 
     #[test]
     fn test_mine_valid_convergence_block_from_proposals_w_no_conflicts() {
+        let (mut miner, mut dag) = create_miner_return_dag();
+        let keypair = Keypair::random();
+        let other_miner = create_miner_from_keypair(&keypair); 
+        
         let genesis = mine_genesis();
+        if let Some(genesis) = genesis {
+            miner.last_block = Some(&genesis);
+            let gblock = Block::Genesis { block: genesis.clone() };
+            let gvtx: Vertex<Block, String> = gblock.into();
+            let prop1 = ProposalBlock::build(
+                genesis.hash.clone(),
+                0,
+                0,
+                LinkedHashMap::new(),
+                LinkedHashMap::new(),
+                other_miner.claim.clone(),
+                keypair.miner_kp.0.clone()
+            );
+            let pblock1 = Block::Proposal { block: prop1.clone() };
+            let pvtx1: Vertex<Block, String> = pblock1.into(); 
+            if let Ok(mut guard) = dag.write() {
+                let edge = (&gvtx, &pvtx1);
+                guard.add_edge(edge);
+            }
+
+            let convergence = miner.try_mine(); 
+            if let Ok(cblock) = convergence {
+                let cvtx: Vertex<Block, String> = cblock.into();
+                if let Ok(mut guard) = dag.write() {
+                    let edge = (&pvtx1, &cvtx);
+                    guard.add_edge(edge);
+                }
+            }
+
+            if let Ok(guard) = dag.read() {
+                assert_eq!(guard.len(), 3);
+            }
+        }
     }
 
     #[test]
@@ -160,10 +197,11 @@ pub(crate) mod test_helpers {
         Block,
         GenesisBlock,
         ProposalBlock,
-        TxnList, ConvergenceBlock,
+        TxnList, ConvergenceBlock, InnerBlock,
     };
     use bulldag::{graph::BullDag, vertex::Vertex};
     use primitives::{Address, PublicKey, SecretKey, Signature};
+    use ritelinked::LinkedHashMap;
     use secp256k1::Message;
     use sha2::{Digest, Sha256};
     use vrrb_core::{
@@ -360,85 +398,195 @@ pub(crate) mod test_helpers {
         (miner, dag)
     }
 
-    pub(crate) fn add_edges_to_dag(
-        dag: &mut MinerDag, 
-        genesis: bool, 
-        n_proposals: u32, 
-        n_rounds: u32, 
-    ) {
-        let mut batch = BatchEdges {
-            genesis: None,
-            proposals: vec![],
-            convergence: vec![],
-        };
+    pub(crate) fn create_miner_from_dag(dag: MinerDag) -> (Miner<'static>, MinerDag) {
+        let mut miner = create_miner();
+        miner.dag = dag.clone(); 
+
+        (miner, dag)
+    }
+
+    pub(crate) fn build_single_proposal_block(
+        last_block_hash: String,
+        n_txns: usize, 
+        n_claims: usize,
+        round: u128,
+        epoch: u128,
+        from: Claim,
+        sk: SecretKey,
+    ) -> ProposalBlock {
+        let txns = create_txns(n_txns).collect();
+        let claims = create_claims(n_claims).collect();
+        ProposalBlock::build(
+            last_block_hash,
+            round,
+            epoch,
+            txns,
+            claims,
+            from,
+            sk 
+        )
+    }
+
+    pub(crate) fn build_multiple_proposal_blocks_single_round(
+        n_blocks: usize,
+        last_block_hash: String,
+        n_txns: usize,
+        n_claims: usize,
+        round: u128,
+        epoch: u128,
+    ) -> Vec<ProposalBlock> {
         
-        let genesis: Option<Vertex<Block, String>> = {
-            if genesis {
-                if let Some(genesis) = mine_genesis() {
-                    let gblock = Block::Genesis { block: genesis.clone() };
-                    Some(gblock.clone().into())
-                } else {
-                    None
-                }
+        (0..n_blocks).into_iter().map(|n| {
+
+            let keypair = Keypair::random();
+            let address = Address::new(keypair.miner_kp.1.clone());
+            let claim = Claim::new(keypair.miner_kp.1.clone().to_string(), address.to_string());
+            let prop = build_single_proposal_block(
+                last_block_hash.clone(), 
+                n_txns, 
+                n_claims, 
+                round, 
+                epoch, 
+                claim, 
+                keypair.miner_kp.0.clone()
+            );
+            prop
+        }).collect()
+    }
+
+    pub(crate) fn build_multiple_rounds(
+        dag: &mut MinerDag,
+        last_block_hash: String, 
+        n_blocks: usize, 
+        n_txns: usize,
+        n_claims: usize,
+        n_rounds: usize,
+        round: &mut usize,
+        epoch: usize,
+    ) {
+        // Recursively add rounds of blocks to the DAG
+        // Need to ensure that there is a genesis block in the dag already.
+        if n_rounds > round.clone() {
+            if dag_has_genesis(&mut dag.clone()) {
+                if let Some(hash) = mine_next_convergence_block(&mut dag.clone()) {
+                    *round += 1usize;
+                    let proposals = build_multiple_proposal_blocks_single_round(
+                        n_blocks, hash.clone(), n_txns, n_claims, round.clone() as u128, epoch as u128
+                    );
+                    append_proposal_blocks_to_dag(&mut dag.clone(), proposals);
+                    build_multiple_rounds(
+                        &mut dag.clone(),
+                        hash,
+                        n_blocks,
+                        n_txns,
+                        n_claims,
+                        n_rounds,
+                        round,
+                        epoch,
+                    );
+                };
+                
             } else {
-                None 
+                if let Some(hash) = add_genesis_to_dag(&mut dag.clone()) {
+                    *round += 1usize;
+                    build_multiple_rounds(
+                        &mut dag.clone(),
+                        hash,
+                        n_blocks,
+                        n_txns,
+                        n_claims,
+                        n_rounds,
+                        round,
+                        epoch
+                    );
+                }
             }
-        };
+        }
+    }
 
-        batch.genesis = genesis;
+    pub(crate) fn dag_has_genesis(dag: &mut MinerDag) -> bool {
+        dag.read().unwrap().len() > 0
+    }
 
-        if batch.genesis.is_none() {
-            return 
+    pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
+        let mut prop_vertices = Vec::new();
+        let genesis = mine_genesis();
+        let keypair = Keypair::random();
+        let miner = create_miner_from_keypair(&keypair);
+
+        if let Some(genesis) = genesis {
+            let gblock = Block::Genesis { block: genesis.clone() };
+            let gvtx: Vertex<Block, String> = gblock.into();
+            let prop1 = ProposalBlock::build(
+                genesis.hash.clone(),
+                0,
+                0,
+                LinkedHashMap::new(),
+                LinkedHashMap::new(),
+                miner.claim.clone(),
+                keypair.miner_kp.0.clone()
+            );
+            let pblock = Block::Proposal { block: prop1.clone() };
+            let pvtx: Vertex<Block, String> = pblock.into(); 
+            prop_vertices.push(pvtx.clone());
+            if let Ok(mut guard) = dag.write() {
+                let edge = (&gvtx, &pvtx);
+                guard.add_edge(edge);
+                return Some(genesis.get_hash().clone())
+            }
+        }
+        None
+    }
+
+    pub(crate) fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> {
+        let keypair = Keypair::random();
+        let mut miner = create_miner_from_keypair(&keypair);
+        miner.dag = dag.clone();
+        if let Ok(cblock) = miner.try_mine() {
+            if let Block::Convergence { ref block } = cblock.clone() {
+                let cvtx: Vertex<Block, String> = cblock.into();
+                let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![]; 
+                if let Ok(guard) = dag.read() {
+                    block.clone().get_ref_hashes().iter().for_each(|t| {
+                        if let Some(pvtx) = guard.get_vertex(t.clone()) {
+                            edges.push((pvtx.clone(), cvtx.clone()));
+                        }
+                    });
+                }
+    
+                if let Ok(mut guard) = dag.write() {
+                    let edges = edges.iter().map(|(source, reference)| {
+                        (source, reference)
+                    }).collect();
+                    guard.extend_from_edges(edges);
+                    return Some(block.get_hash())
+                }
+            }
+        }
+    
+        None
+    }
+
+    pub(crate) fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
+        let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
+        for block in proposals.iter() {
+            let ref_hash = block.ref_block.clone();
+            if let Ok(guard) = dag.read() {
+                if let Some(cvtx) = guard.get_vertex(ref_hash) {
+                    let pblock = Block::Proposal { block: block.clone() };
+                    let pvtx: Vertex<Block, String> = pblock.into();
+                    let edge = (cvtx.clone(), pvtx.clone());
+                    edges.push(edge);
+                }
+            }
         }
 
-        for round in (0..n_rounds).into_iter() {  
-            if round == 0 {
-                match batch.genesis.clone().unwrap().get_data() {
-                    Block::Genesis { ref block } => {
-                        let proposals: Vec<Vertex<Block, String>> = (0..n_proposals)
-                            .into_iter()
-                            .map(|_| {
-                                let proposal = build_proposal_block(
-                                    &block.hash, 5, 4, round as u128, 0
-                                    ).unwrap();  
-                                let block = Block::from(proposal);
-                                block.into()
-                            }).collect();
-    
-                        batch.proposals.push(proposals);
-                        
-                        let mut miner = create_miner();
-                        miner.dag = dag.clone();
-                        if let Ok(block) = miner.try_mine() {
-                            batch.convergence.push(block.into());
-                        }
-                    },
-                    _ => {}
-                }
-            } else {
-                match batch.convergence.clone()[round as usize].get_data() {
-                    Block::Convergence { ref block } => {
-                        let proposals: Vec<Vertex<Block, String>> = (0..n_proposals)
-                            .into_iter()
-                            .map(|_| {
-                                let proposal = build_proposal_block(
-                                    &block.hash, 5, 4, round as u128, 0
-                                    ).unwrap();  
-                                let block = Block::from(proposal);
-                                block.into()
-                            }).collect();
-    
-                        batch.proposals.push(proposals);
+        let edges: Vec<(&Vertex<Block, String>, &Vertex<Block, String>)> = edges.iter().map(|(source, reference)| {
+            (source, reference)
+        }).collect();
 
-                        let mut miner = create_miner();
-                        miner.dag = dag.clone();
-                        if let Ok(block) = miner.try_mine() {
-                            batch.convergence.push(block.into());
-                        }
-                    },
-                    _ => {}
-                }
-            }
+        if let Ok(mut guard) = dag.write() {
+            guard.extend_from_edges(edges);
         }
     }
 }

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -3,6 +3,7 @@ pub mod result;
 pub use crate::miner::*;
 pub mod block_builder;
 pub mod conflict_resolver;
+pub mod miner_impl;
 // mod miner_v1;
 
 /// Legacy miner implementation

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -4,6 +4,7 @@ pub use crate::miner::*;
 pub mod block_builder;
 pub mod conflict_resolver;
 pub mod miner_impl;
+pub(crate) mod test_helpers;
 // mod miner_v1;
 
 /// Legacy miner implementation
@@ -18,25 +19,18 @@ pub mod v2 {
 
 #[cfg(test)]
 mod tests {
-    #![allow(unused, deprecated, deprecated_in_future)]
     use bulldag::vertex::Vertex;
-    use patriecia::common::Key;
     use primitives::Address;
     use ritelinked::LinkedHashMap;
-    use secp256k1::Message;
-    use vrrb_core::{keypair::Keypair, claim::Claim};
-    use sha2::{Digest, Sha256};
+    use vrrb_core::{keypair::Keypair, claim::Claim, txn::{TransactionDigest, Txn}};
     use block::{Block, ProposalBlock};
-    use tokio;
 
-    use crate::{
-        test_helpers::{
-            mine_genesis, 
-            create_miner, 
-            create_miner_from_keypair, 
-            create_keypair, 
-            create_and_sign_message, MinerDag, create_miner_return_dag, build_proposal_block, create_txns
-        }, MinerConfig
+    use crate::test_helpers::{
+        mine_genesis, 
+        create_miner, 
+        create_miner_from_keypair, 
+        create_and_sign_message, 
+        create_miner_return_dag, build_single_proposal_block, create_miner_from_keypair_and_dag, create_miner_from_keypair_return_dag, build_single_proposal_block_from_txns, create_txns
     };
 
     #[test]
@@ -61,7 +55,6 @@ mod tests {
     #[test]
     fn test_get_miner_publickey() {
         let kp = Keypair::random();
-        let address = Address::new(kp.miner_kp.1.clone());
         let miner = create_miner_from_keypair(&kp);
 
         assert_eq!(miner.public_key(), kp.miner_kp.1);
@@ -78,7 +71,7 @@ mod tests {
     #[test]
     fn test_sign_valid_message() {
         let (msg, kp, sig) = create_and_sign_message();
-        let mut miner = create_miner_from_keypair(&kp);
+        let miner = create_miner_from_keypair(&kp);
         let from_miner = miner.sign_message(msg.clone());
 
         assert_eq!(from_miner, sig);
@@ -89,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_mine_valid_convergence_block_empty_proposals() {
-        let (mut miner, mut dag) = create_miner_return_dag();
+        let (mut miner, dag) = create_miner_return_dag();
         let keypair = Keypair::random();
         let other_miner = create_miner_from_keypair(&keypair); 
         
@@ -131,55 +124,123 @@ mod tests {
 
     #[test]
     fn test_mine_valid_convergence_block_from_proposals_w_no_conflicts() {
-        let (mut miner, mut dag) = create_miner_return_dag();
-        let keypair = Keypair::random();
-        let other_miner = create_miner_from_keypair(&keypair); 
+        let m1kp = Keypair::random();
+        let m2kp = Keypair::random();
+        let (mut miner, dag) = create_miner_from_keypair_return_dag(&m1kp); 
+        let mut other_miner = create_miner_from_keypair_and_dag(
+            &m2kp, 
+            dag.clone()
+        ); 
         
         let genesis = mine_genesis();
         if let Some(genesis) = genesis {
             miner.last_block = Some(&genesis);
+            other_miner.last_block = Some(&genesis);
             let gblock = Block::Genesis { block: genesis.clone() };
             let gvtx: Vertex<Block, String> = gblock.into();
-            let prop1 = ProposalBlock::build(
+            let prop1 = build_single_proposal_block(
                 genesis.hash.clone(),
+                5,
+                4,
                 0,
                 0,
-                LinkedHashMap::new(),
-                LinkedHashMap::new(),
-                other_miner.claim.clone(),
-                keypair.miner_kp.0.clone()
+                miner.claim.clone(),
+                m1kp.miner_kp.0.clone()
             );
+            let prop2 = build_single_proposal_block(
+                genesis.hash.clone(),
+                5,
+                4,
+                0,
+                0,
+                other_miner.claim.clone(),
+                m2kp.miner_kp.0.clone()
+            );
+
             let pblock1 = Block::Proposal { block: prop1.clone() };
             let pvtx1: Vertex<Block, String> = pblock1.into(); 
+            let pblock2 = Block::Proposal { block: prop2.clone() };
+            let pvtx2: Vertex<Block, String> = pblock2.into(); 
             if let Ok(mut guard) = dag.write() {
-                let edge = (&gvtx, &pvtx1);
-                guard.add_edge(edge);
+                let edge1 = (&gvtx, &pvtx1);
+                let edge2 = (&gvtx, &pvtx2);
+                guard.add_edge(edge1);
+                guard.add_edge(edge2);
             }
 
             let convergence = miner.try_mine(); 
             if let Ok(cblock) = convergence {
                 let cvtx: Vertex<Block, String> = cblock.into();
                 if let Ok(mut guard) = dag.write() {
-                    let edge = (&pvtx1, &cvtx);
-                    guard.add_edge(edge);
+                    let edge1 = (&pvtx1, &cvtx);
+                    let edge2 = (&pvtx2, &cvtx);
+                    guard.add_edge(edge1);
+                    guard.add_edge(edge2);
                 }
             }
 
             if let Ok(guard) = dag.read() {
-                assert_eq!(guard.len(), 3);
+                assert_eq!(guard.len(), 4);
             }
         }
     }
 
     #[test]
     fn test_mine_valid_convergence_block_from_proposals_conflicts_curr_round() {
+        let m1kp = Keypair::random();
+        let (mut miner, dag) = create_miner_from_keypair_return_dag(&m1kp); 
+        
         let genesis = mine_genesis();
+        if let Some(genesis) = genesis {
+            miner.last_block = Some(&genesis);
+            let gblock = Block::Genesis { block: genesis.clone() };
+            let gvtx: Vertex<Block, String> = gblock.into();
+            let txns: LinkedHashMap<TransactionDigest, Txn> = create_txns(5).collect();
+            let prop1 = build_single_proposal_block_from_txns(
+                genesis.hash.clone(), txns.clone(), 0, 0
+            );
+            let prop2 = build_single_proposal_block_from_txns(
+                genesis.hash.clone(), txns.clone(), 0, 0
+            );
+
+            let pblock1 = Block::Proposal { block: prop1.clone() };
+            let pvtx1: Vertex<Block, String> = pblock1.into(); 
+            let pblock2 = Block::Proposal { block: prop2.clone() };
+            let pvtx2: Vertex<Block, String> = pblock2.into(); 
+            if let Ok(mut guard) = dag.write() {
+                let edge1 = (&gvtx, &pvtx1);
+                let edge2 = (&gvtx, &pvtx2);
+                guard.add_edge(edge1);
+                guard.add_edge(edge2);
+            }
+
+            let convergence = miner.try_mine(); 
+            if let Ok(cblock) = convergence {
+                let cvtx: Vertex<Block, String> = cblock.clone().into();
+                if let Ok(mut guard) = dag.write() {
+                    let edge1 = (&pvtx1, &cvtx);
+                    let edge2 = (&pvtx2, &cvtx);
+                    guard.add_edge(edge1);
+                    guard.add_edge(edge2);
+                }
+
+                match cblock {
+                    Block::Convergence { ref block } => {
+                        let total_len: usize = block.txns.iter().map(|(_, v)| {v.len()}).sum();
+                        assert_eq!(total_len, 15usize);
+                    },
+                    _ => {}
+                }
+            }
+
+            if let Ok(guard) = dag.read() {
+                assert_eq!(guard.len(), 4);
+            }
+        }
     }
 
     #[test]
-    fn test_mine_valid_convergence_block_from_proposals_conflicts_prev_rounds() {
-        let genesis = mine_genesis();
-    }
+    fn test_mine_valid_convergence_block_from_proposals_conflicts_prev_rounds() {}
 
     #[test]
     fn test_miner_handles_epoch_change() {}
@@ -188,405 +249,3 @@ mod tests {
     fn test_miner_handles_utility_adjustment_upon_epoch_change() {}
 }
 
-pub(crate) mod test_helpers {
-    #![allow(unused, deprecated, deprecated_in_future)]
-    use std::sync::{Arc, RwLock};
-
-    use block::{
-        invalid::InvalidBlockErrorReason,
-        Block,
-        GenesisBlock,
-        ProposalBlock,
-        TxnList, ConvergenceBlock, InnerBlock,
-    };
-    use bulldag::{graph::BullDag, vertex::Vertex};
-    use primitives::{Address, PublicKey, SecretKey, Signature};
-    use ritelinked::LinkedHashMap;
-    use secp256k1::Message;
-    use sha2::{Digest, Sha256};
-    use vrrb_core::{
-        claim::Claim,
-        helpers::size_of_txn_list,
-        keypair::Keypair,
-        txn::{NewTxnArgs, Txn, TransactionDigest, generate_txn_digest_vec},
-    };
-
-    use crate::{Miner, MinerConfig, result::MinerError};
-
-    /// Move this into primitives and call it simply `BlockDag`
-    pub type MinerDag = Arc<RwLock<BullDag<Block, String>>>;
-
-    /// Helper struct to build out DAG for testing 
-    ///
-    /// fields:
-    ///     `genesis: Option<Vertex<Block, String>>`
-    ///     `proposals: Vec<Vec<Vertex<Block, String>>>`
-    ///     `convergence: Vec<Vec<Vertex<Block, String>>>`
-    #[derive(Debug, Clone)]
-    pub(crate) struct BatchEdges {
-        genesis: Option<Vertex<Block, String>>,
-        proposals: Vec<Vec<Vertex<Block, String>>>,
-        convergence: Vec<Vertex<Block, String>>
-    }
-
-    pub(crate) fn create_miner() -> Miner<'static> {
-        let (secret_key, public_key) = create_keypair();
-        let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
-
-        let config = MinerConfig {
-            secret_key,
-            public_key,
-            dag,
-        };
-
-        Miner::new(config)
-    }
-
-    pub(crate) fn create_miner_from_keypair(kp: &Keypair) -> Miner {
-        let (secret_key, public_key) = kp.miner_kp;
-        let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
-        
-        let config = MinerConfig {
-            secret_key,
-            public_key,
-            dag
-        };
-
-        Miner::new(config)
-    }
-
-    pub(crate) fn create_keypair() -> (SecretKey, PublicKey) {
-        let kp = Keypair::random();
-        kp.miner_kp
-    }
-
-    pub(crate) fn create_address(pubkey: &PublicKey) -> Address {
-        Address::new(pubkey.clone())
-    }
-
-    pub(crate) fn create_claim(pk: &PublicKey, addr: &str) -> Claim {
-        Claim::new(pk.to_string(), addr.to_string())
-    }
-
-    pub(crate) fn create_and_sign_message() -> (Message, Keypair, Signature) {
-        let kp = Keypair::random();
-        let message = b"Test Message";
-        let msg = {
-            let mut hasher = sha2::Sha256::new();
-            hasher.update(message);
-            let message = hasher.finalize();
-            Message::from_slice(&message[..]).unwrap()
-        };
-
-        let sig = kp.miner_kp.0.sign_ecdsa(msg);
-
-        return (msg, kp, sig)
-
-    }
-
-    pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
-        let miner = create_miner();
-
-        let claim = miner.generate_claim();
-
-        let claim_list = {
-            vec![(claim.public_key.clone(), claim.clone())]
-                .iter()
-                .cloned()
-                .collect()
-        };
-
-        miner.mine_genesis_block(claim_list)
-    }
-
-    pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
-        (0..n)
-            .map(|n| {
-                let (sk, pk) = create_keypair();
-                let raddr = "0x192abcdef01234567890".to_string();
-                let saddr = create_address(&pk);
-                let amount = (n.pow(2)) as u128;
-                let token = None;
-
-                let txn_args = NewTxnArgs {
-                    timestamp: 0,
-                    sender_address: saddr.to_string(),
-                    sender_public_key: pk.clone(),
-                    receiver_address: raddr,
-                    token,
-                    amount,
-                    signature: sk.sign_ecdsa(Message::from_hashed_data::<
-                        secp256k1::hashes::sha256::Hash,
-                    >(b"vrrb")),
-                    validators: None,
-                    nonce: n.clone() as u128,
-                };
-
-                let mut txn = Txn::new(txn_args);
-
-                txn.sign(&sk);
-
-                let txn_digest_vec = generate_txn_digest_vec(
-                    txn.timestamp, 
-                    txn.sender_address.clone(), 
-                    txn.sender_public_key.clone(), 
-                    txn.receiver_address.clone(), 
-                    txn.token.clone(), 
-                    txn.amount, 
-                    txn.nonce
-                ); 
-
-                let digest = TransactionDigest::from(txn_digest_vec);
-
-                (digest, txn)
-            })
-            .into_iter()
-    }
-
-    pub(crate) fn create_claims(n: usize) -> impl Iterator<Item = (String, Claim)> {
-        (0..n)
-            .map(|_| {
-                let (_, pk) = create_keypair();
-                let addr = create_address(&pk);
-                let claim = create_claim(&pk, &addr.to_string());
-                (claim.public_key.clone(), claim)
-            })
-            .into_iter()
-    }
-
-    pub(crate) fn build_proposal_block(
-        ref_hash: &String,
-        n_tx: usize,
-        n_claims: usize,
-        round: u128,
-        epoch: u128,
-    ) -> Result<ProposalBlock, InvalidBlockErrorReason> {
-        let txns: TxnList = create_txns(n_tx).collect();
-
-        let claims = create_claims(n_claims).collect();
-
-        let miner = create_miner();
-
-        let prop_block =
-            miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims);
-
-        let total_txns_size = size_of_txn_list(&txns);
-
-        if total_txns_size > 2000 {
-            return Err(InvalidBlockErrorReason::InvalidBlockSize);
-        }
-
-        return prop_block;
-    }
-
-    pub(crate) fn mine_convergence_block() -> Result<Block, MinerError> {
-        let mut miner = create_miner();
-        miner.try_mine()
-    }
-
-    pub(crate) fn mine_convergence_block_epoch_change(
-    ) -> Result<Block, MinerError> {
-        let mut miner = create_miner();
-        //TODO: Add Mock Convergence Block with round height of 29.999999mm
-        miner.try_mine()
-    }
-
-    pub(crate) fn create_miner_return_dag() -> (Miner<'static>, MinerDag) {
-        let mut miner = create_miner();
-        let dag = miner.dag.clone();
-
-        (miner, dag)
-    }
-
-    pub(crate) fn create_miner_from_dag(dag: MinerDag) -> (Miner<'static>, MinerDag) {
-        let mut miner = create_miner();
-        miner.dag = dag.clone(); 
-
-        (miner, dag)
-    }
-
-    pub(crate) fn build_single_proposal_block(
-        last_block_hash: String,
-        n_txns: usize, 
-        n_claims: usize,
-        round: u128,
-        epoch: u128,
-        from: Claim,
-        sk: SecretKey,
-    ) -> ProposalBlock {
-        let txns = create_txns(n_txns).collect();
-        let claims = create_claims(n_claims).collect();
-        ProposalBlock::build(
-            last_block_hash,
-            round,
-            epoch,
-            txns,
-            claims,
-            from,
-            sk 
-        )
-    }
-
-    pub(crate) fn build_multiple_proposal_blocks_single_round(
-        n_blocks: usize,
-        last_block_hash: String,
-        n_txns: usize,
-        n_claims: usize,
-        round: u128,
-        epoch: u128,
-    ) -> Vec<ProposalBlock> {
-        
-        (0..n_blocks).into_iter().map(|n| {
-
-            let keypair = Keypair::random();
-            let address = Address::new(keypair.miner_kp.1.clone());
-            let claim = Claim::new(keypair.miner_kp.1.clone().to_string(), address.to_string());
-            let prop = build_single_proposal_block(
-                last_block_hash.clone(), 
-                n_txns, 
-                n_claims, 
-                round, 
-                epoch, 
-                claim, 
-                keypair.miner_kp.0.clone()
-            );
-            prop
-        }).collect()
-    }
-
-    pub(crate) fn build_multiple_rounds(
-        dag: &mut MinerDag,
-        last_block_hash: String, 
-        n_blocks: usize, 
-        n_txns: usize,
-        n_claims: usize,
-        n_rounds: usize,
-        round: &mut usize,
-        epoch: usize,
-    ) {
-        // Recursively add rounds of blocks to the DAG
-        // Need to ensure that there is a genesis block in the dag already.
-        if n_rounds > round.clone() {
-            if dag_has_genesis(&mut dag.clone()) {
-                if let Some(hash) = mine_next_convergence_block(&mut dag.clone()) {
-                    *round += 1usize;
-                    let proposals = build_multiple_proposal_blocks_single_round(
-                        n_blocks, hash.clone(), n_txns, n_claims, round.clone() as u128, epoch as u128
-                    );
-                    append_proposal_blocks_to_dag(&mut dag.clone(), proposals);
-                    build_multiple_rounds(
-                        &mut dag.clone(),
-                        hash,
-                        n_blocks,
-                        n_txns,
-                        n_claims,
-                        n_rounds,
-                        round,
-                        epoch,
-                    );
-                };
-                
-            } else {
-                if let Some(hash) = add_genesis_to_dag(&mut dag.clone()) {
-                    *round += 1usize;
-                    build_multiple_rounds(
-                        &mut dag.clone(),
-                        hash,
-                        n_blocks,
-                        n_txns,
-                        n_claims,
-                        n_rounds,
-                        round,
-                        epoch
-                    );
-                }
-            }
-        }
-    }
-
-    pub(crate) fn dag_has_genesis(dag: &mut MinerDag) -> bool {
-        dag.read().unwrap().len() > 0
-    }
-
-    pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
-        let mut prop_vertices = Vec::new();
-        let genesis = mine_genesis();
-        let keypair = Keypair::random();
-        let miner = create_miner_from_keypair(&keypair);
-
-        if let Some(genesis) = genesis {
-            let gblock = Block::Genesis { block: genesis.clone() };
-            let gvtx: Vertex<Block, String> = gblock.into();
-            let prop1 = ProposalBlock::build(
-                genesis.hash.clone(),
-                0,
-                0,
-                LinkedHashMap::new(),
-                LinkedHashMap::new(),
-                miner.claim.clone(),
-                keypair.miner_kp.0.clone()
-            );
-            let pblock = Block::Proposal { block: prop1.clone() };
-            let pvtx: Vertex<Block, String> = pblock.into(); 
-            prop_vertices.push(pvtx.clone());
-            if let Ok(mut guard) = dag.write() {
-                let edge = (&gvtx, &pvtx);
-                guard.add_edge(edge);
-                return Some(genesis.get_hash().clone())
-            }
-        }
-        None
-    }
-
-    pub(crate) fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> {
-        let keypair = Keypair::random();
-        let mut miner = create_miner_from_keypair(&keypair);
-        miner.dag = dag.clone();
-        if let Ok(cblock) = miner.try_mine() {
-            if let Block::Convergence { ref block } = cblock.clone() {
-                let cvtx: Vertex<Block, String> = cblock.into();
-                let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![]; 
-                if let Ok(guard) = dag.read() {
-                    block.clone().get_ref_hashes().iter().for_each(|t| {
-                        if let Some(pvtx) = guard.get_vertex(t.clone()) {
-                            edges.push((pvtx.clone(), cvtx.clone()));
-                        }
-                    });
-                }
-    
-                if let Ok(mut guard) = dag.write() {
-                    let edges = edges.iter().map(|(source, reference)| {
-                        (source, reference)
-                    }).collect();
-                    guard.extend_from_edges(edges);
-                    return Some(block.get_hash())
-                }
-            }
-        }
-    
-        None
-    }
-
-    pub(crate) fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
-        let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
-        for block in proposals.iter() {
-            let ref_hash = block.ref_block.clone();
-            if let Ok(guard) = dag.read() {
-                if let Some(cvtx) = guard.get_vertex(ref_hash) {
-                    let pblock = Block::Proposal { block: block.clone() };
-                    let pvtx: Vertex<Block, String> = pblock.into();
-                    let edge = (cvtx.clone(), pvtx.clone());
-                    edges.push(edge);
-                }
-            }
-        }
-
-        let edges: Vec<(&Vertex<Block, String>, &Vertex<Block, String>)> = edges.iter().map(|(source, reference)| {
-            (source, reference)
-        }).collect();
-
-        if let Ok(mut guard) = dag.write() {
-            guard.extend_from_edges(edges);
-        }
-    }
-}

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod miner;
 pub mod result;
 pub use crate::miner::*;
+pub mod block_builder;
+pub mod conflict_resolver;
 // mod miner_v1;
 
 /// Legacy miner implementation

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -18,663 +18,150 @@ pub mod v2 {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr};
+    #![allow(unused, deprecated, deprecated_in_future)]
+    use primitives::Address;
+    use secp256k1::Message;
+    use vrrb_core::{keypair::Keypair, claim::Claim};
+    use sha2::{Digest, Sha256};
 
-    use block::{header::BlockHeader, Block, ConvergenceBlock};
-    use bulldag::{graph::BullDag, vertex::Vertex};
-    use primitives::{PublicKey, Signature};
-    use reward::reward::Reward;
-    use ritelinked::{LinkedHashMap, LinkedHashSet};
-    use secp256k1::{
-        hashes::{sha256 as s256, Hash},
-        Message,
-    };
-    use sha256::digest;
-    use utils::{create_payload, hash_data};
-    use vrrb_core::txn::Txn;
-
-    use super::test_helpers::create_txns;
-    use crate::test_helpers::{
-        build_proposal_block,
-        create_claim,
-        create_keypair,
-        create_miner,
-        mine_convergence_block,
-        mine_convergence_block_epoch_change,
-        mine_genesis,
-    };
+    use crate::{test_helpers::{mine_genesis, create_miner, create_miner_from_keypair, create_keypair, create_and_sign_message}, MinerConfig};
 
     #[test]
-    fn test_create_genesis_block() {
-        let genesis = mine_genesis();
-        assert!(genesis.is_some());
+    fn test_create_miner() {
+        let kp = Keypair::random();
+        let address = Address::new(kp.miner_kp.1.clone());
+        let claim = Claim::new(kp.miner_kp.1.to_string().clone(), address.to_string().clone());
+        let miner = create_miner_from_keypair(&kp);
+
+        assert_eq!(miner.claim, claim);
     }
 
     #[test]
-    fn test_create_proposal_block() {
-        let genesis = mine_genesis().unwrap();
-        let proposal = build_proposal_block(&genesis.hash, 30, 10, 0, 0).unwrap();
+    fn test_get_miner_address() {
+        let kp = Keypair::random();
+        let address = Address::new(kp.miner_kp.1.clone());
+        let miner = create_miner_from_keypair(&kp);
 
-        let payload = create_payload!(
-            proposal.round,
-            proposal.epoch,
-            proposal.txns,
-            proposal.claims,
-            proposal.from
-        );
+        assert_eq!(miner.address(), address);
+    } 
 
-        let h_pk = proposal.from.public_key;
-        let h_pk = PublicKey::from_str(&h_pk).unwrap();
-        let sig = proposal.signature;
-        let sig = Signature::from_str(&sig).unwrap();
-        let verify = sig.verify(&payload, &h_pk);
+    #[test]
+    fn test_get_miner_publickey() {
+        let kp = Keypair::random();
+        let address = Address::new(kp.miner_kp.1.clone());
+        let miner = create_miner_from_keypair(&kp);
 
-        assert!(verify.is_ok())
+        assert_eq!(miner.public_key(), kp.miner_kp.1);
     }
 
     #[test]
-    fn test_create_proposal_block_over_size_limit() {
-        let genesis = mine_genesis().unwrap();
-        let proposal = build_proposal_block(&genesis.hash, 2000, 10, 0, 0);
-
-        assert!(proposal.is_err());
-    }
-
-    #[test]
-    fn test_create_convergence_block_no_conflicts() {
-        let genesis = mine_genesis();
-        if let Some(gblock) = genesis {
-            let ref_hash = gblock.hash.clone();
-            let round = gblock.header.round.clone() + 1;
-            let epoch = gblock.header.epoch.clone();
-
-            let prop1 = build_proposal_block(&ref_hash, 30, 10, round, epoch)
-                .unwrap()
-                .clone();
-
-            let prop2 = build_proposal_block(&ref_hash, 40, 5, round, epoch)
-                .unwrap()
-                .clone();
-
-            let proposals = vec![prop1.clone(), prop2.clone()];
-
-            let mut chain: BullDag<Block, String> = BullDag::new();
-
-            let gvtx = Vertex::new(
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-                gblock.hash.clone(),
-            );
-
-            let p1vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop1.clone(),
-                },
-                prop1.hash.clone(),
-            );
-
-            let p2vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop2.clone(),
-                },
-                prop2.hash.clone(),
-            );
-
-            let edges = vec![(&gvtx, &p1vtx), (&gvtx, &p2vtx)];
-
-            chain.extend_from_edges(edges);
-
-            let c_block =
-                mine_convergence_block(&proposals, &chain, Block::Genesis { block: gblock });
-
-            if let Some(cb) = c_block {
-                let sig = cb.header.miner_signature;
-                let sig = Signature::from_str(&sig).unwrap();
-
-                let payload = create_payload!(
-                    cb.header.ref_hashes,
-                    cb.header.round,
-                    cb.header.epoch,
-                    cb.header.block_seed,
-                    cb.header.next_block_seed,
-                    cb.header.block_height,
-                    cb.header.timestamp,
-                    cb.header.txn_hash,
-                    cb.header.miner_claim,
-                    cb.header.claim_list_hash,
-                    cb.header.block_reward,
-                    cb.header.next_block_reward
-                );
-
-                let mpk = cb.header.miner_claim.public_key;
-                let mpk = PublicKey::from_str(&mpk).unwrap();
-
-                let verify = sig.verify(&payload, &mpk);
-
-                assert!(verify.is_ok())
-            }
-        } else {
-            panic!("A ConvergenceBlock should be produced")
-        }
-    }
-
-    #[test]
-    fn test_resolve_conflicts_curr_round() {
-        // Create a large transaction map
-        let genesis = mine_genesis();
-        if let Some(gblock) = genesis {
-            let ref_hash = gblock.hash.clone();
-            let round = gblock.header.round + 1;
-            let epoch = gblock.header.epoch;
-
-            let mut prop1 = build_proposal_block(&ref_hash, 30, 10, round, epoch)
-                .unwrap()
-                .clone();
-
-            let mut prop2 = build_proposal_block(&ref_hash, 40, 5, round, epoch)
-                .unwrap()
-                .clone();
-
-            let txns: HashMap<String, Txn> = create_txns(5).collect();
-            prop1.txns.extend(txns.clone());
-            prop2.txns.extend(txns.clone());
-
-            let proposals = vec![prop1.clone(), prop2.clone()];
-
-            let mut chain: BullDag<Block, String> = BullDag::new();
-
-            let gvtx = Vertex::new(
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-                gblock.hash.clone(),
-            );
-
-            let p1vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop1.clone(),
-                },
-                prop1.hash.clone(),
-            );
-
-            let p2vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop2.clone(),
-                },
-                prop2.hash.clone(),
-            );
-
-            let edges = vec![(&gvtx, &p1vtx), (&gvtx, &p2vtx)];
-
-            chain.extend_from_edges(edges);
-
-            let c_block =
-                mine_convergence_block(&proposals, &chain, Block::Genesis { block: gblock });
-
-            if let Some(cb) = c_block {
-                let sig = cb.header.miner_signature;
-                let sig = Signature::from_str(&sig).unwrap();
-
-                let payload = create_payload!(
-                    cb.header.ref_hashes,
-                    cb.header.round,
-                    cb.header.epoch,
-                    cb.header.block_seed,
-                    cb.header.next_block_seed,
-                    cb.header.block_height,
-                    cb.header.timestamp,
-                    cb.header.txn_hash,
-                    cb.header.miner_claim,
-                    cb.header.claim_list_hash,
-                    cb.header.block_reward,
-                    cb.header.next_block_reward
-                );
-
-                let mpk = cb.header.miner_claim.public_key;
-                let mpk = PublicKey::from_str(&mpk).unwrap();
-
-                let verify = sig.verify(&payload, &mpk);
-
-                assert!(verify.is_ok());
-
-                let total_w_duplicates = { prop1.txns.keys().len() + prop2.txns.keys().len() };
-
-                assert!(total_w_duplicates > cb.txns.len());
-
-                // Get the winner of the PoC election between proposer 1 and 2
-                let mut proposer_ps = vec![
-                    (
-                        prop1.hash,
-                        prop1.from.get_pointer(cb.header.block_seed as u128),
-                    ),
-                    (
-                        prop2.hash,
-                        prop2.from.get_pointer(cb.header.block_seed as u128),
-                    ),
-                ];
-
-                // The first will be the winner
-                proposer_ps.sort_unstable_by(|(_, a_pointer), (_, b_pointer)| {
-                    match (a_pointer, b_pointer) {
-                        (Some(x), Some(y)) => x.cmp(y),
-                        (None, Some(_)) => std::cmp::Ordering::Greater,
-                        (Some(_), None) => std::cmp::Ordering::Less,
-                        (None, None) => std::cmp::Ordering::Equal,
-                    }
-                });
-                let winner = proposer_ps[0].0.clone();
-                let mut resolved_conflicts = cb.txns.clone();
-                resolved_conflicts.retain(|_, set| {
-                    let conflicts = txns.keys().cloned().collect();
-                    let intersection: LinkedHashSet<&String> =
-                        set.intersection(&conflicts).collect();
-                    intersection.len() > 0
-                });
-
-                let key: Vec<String> = resolved_conflicts.keys().cloned().collect();
-                assert!(key.len() == 1);
-                assert_eq!(key[0], winner);
-            }
-        } else {
-            panic!("A ConvergenceBlock should be produced")
-        }
-    }
-
-    #[test]
-    fn test_resolve_conflicts_prev_rounds() {
-        let genesis = mine_genesis();
-        if let Some(gblock) = genesis {
-            let ref_hash = gblock.hash.clone();
-            let round = gblock.header.round.clone() + 1;
-            let epoch = gblock.header.epoch.clone();
-
-            let mut prop1 = build_proposal_block(&ref_hash, 30, 10, round, epoch)
-                .unwrap()
-                .clone();
-
-            let mut prop2 = build_proposal_block(&ref_hash, 40, 5, round, epoch)
-                .unwrap()
-                .clone();
-
-            let txns: HashMap<String, Txn> = create_txns(5).collect();
-            prop1.txns.extend(txns.clone());
-
-            let proposals = vec![prop1.clone(), prop2.clone()];
-
-            let mut chain: BullDag<Block, String> = BullDag::new();
-
-            let gvtx = Vertex::new(
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-                gblock.hash.clone(),
-            );
-
-            let p1vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop1.clone(),
-                },
-                prop1.hash.clone(),
-            );
-
-            let p2vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop2.clone(),
-                },
-                prop2.hash.clone(),
-            );
-
-            let edges = vec![(&gvtx, &p1vtx), (&gvtx, &p2vtx)];
-
-            chain.extend_from_edges(edges);
-
-            let c_block_1 = mine_convergence_block(
-                &proposals,
-                &chain,
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-            );
-
-            let cb1 = c_block_1.unwrap();
-
-            let cb1vtx = Vertex::new(Block::Convergence { block: cb1.clone() }, cb1.hash.clone());
-
-            let edges = vec![(&p1vtx, &cb1vtx), (&p2vtx, &cb1vtx)];
-
-            chain.extend_from_edges(edges);
-
-            let mut prop3 = build_proposal_block(&ref_hash, 20, 10, round, epoch)
-                .unwrap()
-                .clone();
-
-            prop3.txns.extend(txns.clone());
-
-            let c_block_2 = mine_convergence_block(
-                &vec![prop3.clone()],
-                &chain,
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-            );
-
-            let cb2 = {
-                let cb = c_block_2.unwrap();
-                let sig = cb.header.miner_signature.clone();
-                let sig = Signature::from_str(&sig).unwrap();
-
-                let payload = create_payload!(
-                    cb.header.ref_hashes,
-                    cb.header.round,
-                    cb.header.epoch,
-                    cb.header.block_seed,
-                    cb.header.next_block_seed,
-                    cb.header.block_height,
-                    cb.header.timestamp,
-                    cb.header.txn_hash,
-                    cb.header.miner_claim,
-                    cb.header.claim_list_hash,
-                    cb.header.block_reward,
-                    cb.header.next_block_reward
-                );
-
-                let mpk = cb.header.miner_claim.public_key.clone();
-                let mpk = PublicKey::from_str(&mpk).unwrap();
-
-                let verify = sig.verify(&payload, &mpk);
-
-                assert!(verify.is_ok());
-
-                let total_w_duplicates = { prop3.txns.keys().len() };
-
-                assert!(total_w_duplicates > cb.txns.len());
-
-                cb
-            };
-
-            let p3vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop3.clone(),
-                },
-                prop3.hash.clone(),
-            );
-
-            let cb2vtx = Vertex::new(Block::Convergence { block: cb2.clone() }, cb2.hash.clone());
-
-            let edges = vec![(&gvtx, &p3vtx), (&p3vtx, &cb2vtx)];
-
-            chain.extend_from_edges(edges);
-        }
-    }
-
-    #[test]
-    fn test_epoch_change() {
-        let (msk1, mpk1) = create_keypair();
-
+    fn test_read_miner_dag_copy() {
         let miner = create_miner();
-        let addr = miner.address();
-        let nonce = 1;
+        let read_guard = miner.dag.read();
 
-        let ref_hashes = vec!["abcdef".to_string()];
-        let epoch = 0;
-        let round = 29_999_998;
-        let block_seed = 34_989_333;
-        let next_block_seed = 839_999_843;
-        let block_height = 29_999_998;
-        let timestamp = chrono::Utc::now().timestamp();
-        let txn_hash = "abcdef01234567890".to_string();
-        let miner_claim = miner.generate_claim();
-        let claim_list_hash = "01234567890abcdef".to_string();
-        let mut block_reward = Reward::default();
-        block_reward.current_block = block_height;
-        let next_block_reward = block_reward.clone();
-
-        let payload = create_payload!(
-            ref_hashes,
-            round,
-            epoch,
-            block_seed,
-            next_block_seed,
-            block_height,
-            timestamp,
-            txn_hash,
-            miner_claim,
-            claim_list_hash,
-            block_reward,
-            next_block_reward
-        );
-
-        let miner_signature = miner.sign_message(payload).to_string();
-
-        let header = BlockHeader {
-            ref_hashes,
-            round,
-            epoch,
-            block_seed,
-            next_block_seed,
-            block_height,
-            timestamp,
-            txn_hash,
-            miner_claim,
-            claim_list_hash,
-            block_reward,
-            next_block_reward,
-            miner_signature,
-        };
-
-        let txns = LinkedHashMap::new();
-        let claims = LinkedHashMap::new();
-        let block_hash = hash_data!(
-            header.ref_hashes,
-            header.round,
-            header.epoch,
-            header.block_seed,
-            header.next_block_seed,
-            header.block_height,
-            header.timestamp,
-            header.txn_hash,
-            header.miner_claim,
-            header.claim_list_hash,
-            header.block_reward,
-            header.next_block_reward,
-            header.miner_signature
-        );
-
-        let cb1 = ConvergenceBlock {
-            header,
-            txns,
-            claims,
-            hash: block_hash,
-            certificate: None,
-        };
-
-        let mut chain: BullDag<Block, String> = BullDag::new();
-
-        let prop1 = build_proposal_block(&cb1.hash.clone(), 5, 5, 30_000_000, 0)
-            .unwrap()
-            .clone();
-
-        let cb1vtx = Vertex::new(Block::Convergence { block: cb1.clone() }, cb1.hash.clone());
-
-        let p1vtx = Vertex::new(
-            Block::Proposal {
-                block: prop1.clone(),
-            },
-            prop1.hash.clone(),
-        );
-
-        let edges = vec![(&cb1vtx, &p1vtx)];
-
-        chain.extend_from_edges(edges);
-
-        let cb2 = mine_convergence_block_epoch_change(
-            &vec![prop1.clone()],
-            &chain,
-            &Block::Convergence { block: cb1.clone() },
-            0,
-        )
-        .unwrap();
-
-        assert_eq!(cb2.header.next_block_reward.epoch, 1);
-        assert_eq!(cb2.header.next_block_reward.next_epoch_block, 60_000_000);
+        assert!(read_guard.is_ok());
     }
 
     #[test]
-    fn test_utility_adjustment() {
-        let (msk1, mpk1) = create_keypair();
+    fn test_sign_valid_message() {
+        let (msg, kp, sig) = create_and_sign_message();
+        let mut miner = create_miner_from_keypair(&kp);
+        let from_miner = miner.sign_message(msg.clone());
 
-        let miner = create_miner();
-        let addr = miner.address();
-
-        let ref_hashes = vec!["abcdef".to_string()];
-        let epoch = 0;
-        let round = 29_999_998;
-        let block_seed = 34_989_333;
-        let next_block_seed = 839_999_843;
-        let block_height = 29_999_998;
-        let timestamp = chrono::Utc::now().timestamp();
-        let txn_hash = "abcdef01234567890".to_string();
-
-        let miner_claim = create_claim(&mpk1, &addr.to_string(), 1);
-
-        let claim_list_hash = "01234567890abcdef".to_string();
-
-        let mut block_reward = Reward::default();
-        block_reward.current_block = block_height;
-        let next_block_reward = block_reward.clone();
-
-        let payload = create_payload!(
-            ref_hashes,
-            round,
-            epoch,
-            block_seed,
-            next_block_seed,
-            block_height,
-            timestamp,
-            txn_hash,
-            miner_claim,
-            claim_list_hash,
-            block_reward,
-            next_block_reward
-        );
-
-        let miner_signature = msk1.sign_ecdsa(payload).to_string();
-
-        let header = BlockHeader {
-            ref_hashes,
-            round,
-            epoch,
-            block_seed,
-            next_block_seed,
-            block_height,
-            timestamp,
-            txn_hash,
-            miner_claim,
-            claim_list_hash,
-            block_reward,
-            next_block_reward,
-            miner_signature,
-        };
-
-        let txns = LinkedHashMap::new();
-        let claims = LinkedHashMap::new();
-        let block_hash = hash_data!(
-            header.ref_hashes,
-            header.round,
-            header.epoch,
-            header.block_seed,
-            header.next_block_seed,
-            header.block_height,
-            header.timestamp,
-            header.txn_hash,
-            header.miner_claim,
-            header.claim_list_hash,
-            header.block_reward,
-            header.next_block_reward,
-            header.miner_signature
-        );
-
-        let cb1 = ConvergenceBlock {
-            header,
-            txns,
-            claims,
-            hash: block_hash,
-            certificate: None,
-        };
-
-        let mut chain: BullDag<Block, String> = BullDag::new();
-
-        let prop1 = build_proposal_block(&cb1.hash.clone(), 5, 5, 30_000_000, 0)
-            .unwrap()
-            .clone();
-        let cb1vtx = Vertex::new(Block::Convergence { block: cb1.clone() }, cb1.hash.clone());
-
-        let p1vtx = Vertex::new(
-            Block::Proposal {
-                block: prop1.clone(),
-            },
-            prop1.hash.clone(),
-        );
-
-        let edges = vec![(&cb1vtx, &p1vtx)];
-
-        chain.extend_from_edges(edges);
-
-        let cb2 = mine_convergence_block_epoch_change(
-            &vec![prop1.clone()],
-            &chain,
-            &Block::Convergence { block: cb1.clone() },
-            (4 * 30_000_000) as i128,
-        )
-        .unwrap();
-
-        assert_eq!(cb2.header.next_block_reward.amount, 24);
+        assert_eq!(from_miner, sig);
+            
+        let valid = sig.verify(&msg, &kp.miner_kp.1);
+        assert!(valid.is_ok());
     }
+
+    #[test]
+    fn test_generate_timestamp() {
+        let miner = create_miner();
+        let timestamp = miner.get_timestamp();
+        
+        assert_eq!(timestamp, timestamp as u128);
+    }
+
+    #[test]
+    fn test_mine_valid_convergence_block_empty_proposals() {}
+
+    #[test]
+    fn test_mine_valid_convergence_block_from_proposals_w_no_conflicts() {
+        let genesis = mine_genesis();
+    }
+
+    #[test]
+    fn test_mine_valid_convergence_block_from_proposals_conflicts_curr_round() {
+        let genesis = mine_genesis();
+    }
+
+    #[test]
+    fn test_mine_valid_convergence_block_from_proposals_conflicts_prev_rounds() {
+        let genesis = mine_genesis();
+    }
+
+    #[test]
+    fn test_miner_handles_epoch_change() {}
+
+    #[test]
+    fn test_miner_handles_utility_adjustment_upon_epoch_change() {}
 }
 
 pub(crate) mod test_helpers {
-    use std::mem;
+    #![allow(unused, deprecated, deprecated_in_future)]
+    use std::sync::{Arc, RwLock};
 
     use block::{
         invalid::InvalidBlockErrorReason,
         Block,
-        ConvergenceBlock,
         GenesisBlock,
         ProposalBlock,
         TxnList,
-        EPOCH_BLOCK,
     };
     use bulldag::graph::BullDag;
-    use primitives::{Address, PublicKey, SecretKey};
+    use primitives::{Address, PublicKey, SecretKey, Signature};
     use secp256k1::Message;
-    use sha256::digest;
-    use utils::hash_data;
+    use sha2::{Digest, Sha256};
     use vrrb_core::{
         claim::Claim,
         helpers::size_of_txn_list,
-        keypair::KeyPair,
-        txn::{NewTxnArgs, Token, Txn},
+        keypair::Keypair,
+        txn::{NewTxnArgs, Txn, TransactionDigest, generate_txn_digest_vec},
     };
 
-    use crate::{MineArgs, Miner, MinerConfig};
+    use crate::{Miner, MinerConfig, result::MinerError};
+
+    /// Move this into primitives and call it simply `BlockDag`
+    pub type MinerDag = Arc<RwLock<BullDag<Block, String>>>;
 
     pub(crate) fn create_miner() -> Miner {
         let (secret_key, public_key) = create_keypair();
-
-        let address = create_address(&public_key).to_string();
+        let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
 
         let config = MinerConfig {
             secret_key,
             public_key,
-            address,
+            dag,
+        };
+
+        Miner::new(config)
+    }
+
+    pub(crate) fn create_miner_from_keypair(kp: &Keypair) -> Miner {
+        let (secret_key, public_key) = kp.miner_kp;
+        let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
+        
+        let config = MinerConfig {
+            secret_key,
+            public_key,
+            dag
         };
 
         Miner::new(config)
     }
 
     pub(crate) fn create_keypair() -> (SecretKey, PublicKey) {
-        let kp = KeyPair::random();
+        let kp = Keypair::random();
         kp.miner_kp
     }
 
@@ -686,31 +173,44 @@ pub(crate) mod test_helpers {
         Claim::new(pk.to_string(), addr.to_string())
     }
 
+    pub(crate) fn create_and_sign_message() -> (Message, Keypair, Signature) {
+        let kp = Keypair::random();
+        let message = b"Test Message";
+        let msg = {
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(message);
+            let message = hasher.finalize();
+            Message::from_slice(&message[..]).unwrap()
+        };
+
+        let sig = kp.miner_kp.0.sign_ecdsa(msg);
+
+        return (msg, kp, sig)
+
+    }
+
     pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
-        let (sk, pk) = create_keypair();
-        let addr = create_address(&pk);
         let miner = create_miner();
 
         let claim = miner.generate_claim();
 
         let claim_list = {
-            vec![(claim.hash.clone(), claim.clone())]
+            vec![(claim.public_key.clone(), claim.clone())]
                 .iter()
                 .cloned()
                 .collect()
         };
 
-        miner.mine_genesis_block(claim_list, 1)
+        miner.mine_genesis_block(claim_list)
     }
 
-    pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (String, Txn)> {
+    pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
         (0..n)
             .map(|n| {
                 let (sk, pk) = create_keypair();
                 let raddr = "0x192abcdef01234567890".to_string();
                 let saddr = create_address(&pk);
                 let amount = (n.pow(2)) as u128;
-                let nonce = 1u128;
                 let token = None;
 
                 let txn_args = NewTxnArgs {
@@ -731,9 +231,19 @@ pub(crate) mod test_helpers {
 
                 txn.sign(&sk);
 
-                let txn_hash = hash_data!(&txn);
+                let txn_digest_vec = generate_txn_digest_vec(
+                    txn.timestamp, 
+                    txn.sender_address.clone(), 
+                    txn.sender_public_key.clone(), 
+                    txn.receiver_address.clone(), 
+                    txn.token.clone(), 
+                    txn.amount, 
+                    txn.nonce
+                ); 
 
-                (txn_hash, txn)
+                let digest = TransactionDigest::from(txn_digest_vec);
+
+                (digest, txn)
             })
             .into_iter()
     }
@@ -743,8 +253,8 @@ pub(crate) mod test_helpers {
             .map(|_| {
                 let (_, pk) = create_keypair();
                 let addr = create_address(&pk);
-                let claim = create_claim(&pk, &addr.to_string(), 1);
-                (claim.hash.clone(), claim)
+                let claim = create_claim(&pk, &addr.to_string());
+                (claim.public_key.clone(), claim)
             })
             .into_iter()
     }
@@ -756,18 +266,14 @@ pub(crate) mod test_helpers {
         round: u128,
         epoch: u128,
     ) -> Result<ProposalBlock, InvalidBlockErrorReason> {
-        let (sk, pk) = create_keypair();
         let txns: TxnList = create_txns(n_tx).collect();
 
-        let nonce = 1;
-
         let claims = create_claims(n_claims).collect();
-        let hclaim = create_claim(&pk, &create_address(&pk).to_string(), 1);
 
         let miner = create_miner();
 
         let prop_block =
-            miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims, nonce);
+            miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims);
 
         let total_txns_size = size_of_txn_list(&txns);
 
@@ -778,130 +284,15 @@ pub(crate) mod test_helpers {
         return prop_block;
     }
 
-    pub(crate) fn mine_convergence_block(
-        proposals: &Vec<ProposalBlock>,
-        chain: &BullDag<Block, String>,
-        last_block: Block,
-    ) -> Option<ConvergenceBlock> {
-        let (msk, mpk) = create_keypair();
-        let maddr = create_address(&mpk).to_string();
-        let miner_claim = create_claim(&mpk, &maddr, 1);
-        let txns = create_txns(30).collect();
-        let claims = create_claims(5).collect();
-        let claim_list_hash = Some(hash_data!(claims));
-
-        let miner = create_miner();
-        let maddr = miner.address();
-
-        let mut reward = {
-            match last_block {
-                Block::Convergence { ref block } => block.header.next_block_reward.clone(),
-                Block::Genesis { ref block } => block.header.next_block_reward.clone(),
-                _ => return None,
-            }
-        };
-
-        let epoch = {
-            match last_block {
-                Block::Convergence { ref block } => {
-                    if block.header.block_height % EPOCH_BLOCK as u128 == 0 {
-                        block.header.epoch + 1
-                    } else {
-                        block.header.epoch
-                    }
-                },
-                Block::Genesis { ref block } => 0,
-                _ => return None,
-            }
-        };
-
-        let round = {
-            match last_block {
-                Block::Convergence { ref block } => block.header.round + 1,
-                Block::Genesis { .. } => 1,
-                _ => return None,
-            }
-        };
-
-        let mine_args = MineArgs {
-            claim: miner_claim,
-            last_block: last_block.clone(),
-            txns,
-            claims,
-            claim_list_hash,
-            reward: &mut reward,
-            abandoned_claim: None,
-            secret_key: msk,
-            epoch,
-            round,
-            next_epoch_adjustment: 0,
-        };
-
-        let miner = create_miner();
-        miner.mine_convergence_block(mine_args, proposals, chain)
-        // ConvergenceBlock::mine(mine_args, proposals, chain)
+    pub(crate) fn mine_convergence_block() -> Result<Block, MinerError> {
+        let mut miner = create_miner();
+        miner.try_mine()
     }
 
     pub(crate) fn mine_convergence_block_epoch_change(
-        proposals: &Vec<ProposalBlock>,
-        chain: &BullDag<Block, String>,
-        last_block: &Block,
-        next_epoch_adjustment: i128,
-    ) -> Option<ConvergenceBlock> {
-        let (msk, mpk) = create_keypair();
-        let maddr = create_address(&mpk).to_string();
-        let miner_claim = create_claim(&mpk, &maddr, 1);
-
-        let txns = create_txns(30).collect();
-        let claims = create_claims(5).collect();
-        let claim_list_hash = Some(hash_data!(claims));
-
-        let mut reward = {
-            match last_block {
-                Block::Convergence { ref block } => block.header.next_block_reward.clone(),
-                Block::Genesis { ref block } => block.header.next_block_reward.clone(),
-                _ => return None,
-            }
-        };
-
-        let epoch = {
-            match last_block {
-                Block::Convergence { ref block } => {
-                    if block.header.block_height % EPOCH_BLOCK as u128 == 0 {
-                        block.header.epoch + 1
-                    } else {
-                        block.header.epoch
-                    }
-                },
-                Block::Genesis { ref block } => 0,
-                _ => return None,
-            }
-        };
-
-        let round = {
-            match last_block {
-                Block::Convergence { ref block } => block.header.round + 1,
-                Block::Genesis { .. } => 1,
-                _ => return None,
-            }
-        };
-
-        let mine_args = MineArgs {
-            claim: miner_claim,
-            last_block: last_block.clone(),
-            txns,
-            claims,
-            claim_list_hash,
-            reward: &mut reward,
-            abandoned_claim: None,
-            secret_key: msk,
-            epoch,
-            round,
-            next_epoch_adjustment,
-        };
-
-        let miner = create_miner();
-
-        miner.mine_convergence_block(mine_args, proposals, chain)
+    ) -> Result<Block, MinerError> {
+        let mut miner = create_miner();
+        //TODO: Add Mock Convergence Block with round height of 29.999999mm
+        miner.try_mine()
     }
 }

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -86,10 +86,10 @@ pub struct Miner {
     secret_key: MinerSk,
     public_key: MinerPk,
     address: Address,
-    claim: Claim,
-    dag: Arc<RwLock<BullDag<Block, String>>>,
-    last_block: Option<ConvergenceBlock>,
-    status: MinerStatus,
+    pub claim: Claim,
+    pub dag: Arc<RwLock<BullDag<Block, String>>>,
+    pub last_block: Option<ConvergenceBlock>,
+    pub status: MinerStatus,
 }
 
 impl Miner {
@@ -281,7 +281,7 @@ impl Miner {
         Some(genesis)
     }
 
-    fn consolidate_txns(
+    pub(crate) fn consolidate_txns(
         &self, 
         proposals: &Vec<ProposalBlock>
     ) -> ConsolidatedTxns {
@@ -297,7 +297,7 @@ impl Miner {
         }).collect()
     }
 
-    fn consolidate_claims(
+    pub(crate) fn consolidate_claims(
         &self,
         proposals: &Vec<ProposalBlock>
     ) -> ConsolidatedClaims {
@@ -314,13 +314,13 @@ impl Miner {
         }).collect()
     }
 
-    fn get_ref_hashes(&self, proposals: &Vec<ProposalBlock>) -> &Vec<RefHash> {
+    pub(crate) fn get_ref_hashes(&self, proposals: &Vec<ProposalBlock>) -> &Vec<RefHash> {
         proposals.iter().map(|b| {
             b.hash.clone()
         }).collect()
     }
 
-    fn get_txn_hash(&self, txns: &ConsolidatedTxns) -> String {
+    pub(crate) fn get_txn_hash(&self, txns: &ConsolidatedTxns) -> String {
         let mut txn_hasher = Sha256::new();
 
         let txns_hash = {
@@ -333,7 +333,7 @@ impl Miner {
         format!("{:x}", txn_hash)
     }
 
-    fn get_claim_hash(&self, claims: &ConsolidatedClaims) -> String {
+    pub(crate) fn get_claim_hash(&self, claims: &ConsolidatedClaims) -> String {
 
         let mut claim_hasher = Sha256::new();
 
@@ -347,7 +347,7 @@ impl Miner {
         format!("{:x}", claims_hash)
     }
 
-    fn build_header(&self, ref_hashes: Vec<RefHash>, txns_hash: String, claims_hash: String) -> Option<BlockHeader> {
+    pub(crate) fn build_header(&self, ref_hashes: Vec<RefHash>, txns_hash: String, claims_hash: String) -> Option<BlockHeader> {
 
         BlockHeader::new(
             self.last_block.clone(),
@@ -360,7 +360,7 @@ impl Miner {
         )
     }
 
-    fn hash_block(&self, header: &BlockHeader) -> String {
+    pub(crate) fn hash_block(&self, header: &BlockHeader) -> String {
         let block_hash = hash_data!(
             header.ref_hashes,
             header.round,
@@ -380,345 +380,3 @@ impl Miner {
     }
 }
 
-impl BlockBuilder for Miner {
-    type BlockType = ConvergenceBlock;
-    type RefType = ProposalBlock;
-
-    fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i28) {
-        self.last_block = Some(new_block);
-        self.next_epoch_adjustment = adjustment;
-    }
-
-    fn build(&self) -> Option<Self::BlockType> {
-        let proposals = self.get_references();
-        if let Some(proposals) = proposals {
-
-            let resolved = self.resolve(&proposals);
-            let txns = self.consolidate_txns(&proposals);
-            let claims = self.consolidate_claims(&proposals);
-            let ref_hashes = self.get_ref_hashes(&proposals);
-            let txn_hash = self.get_txn_hash(&txns);
-            let claim_hash = self.get_claim_hash(&claims);
-            let header = self.build_header(ref_hashes, txns_hash, claims_hash)?;
-            let hash = self.hash_block(&header);
-
-            Some(ConvergenceBlock { 
-                header,
-                txns,
-                claims,
-                hash,
-                certificate: None,
-            })
-        } else {
-            return None
-        }
-    }
-
-
-    fn get_references(&self) -> Option<Vec<Self::RefType>> {
-        let idx = self.last_block.hash;
-        if let Ok(bulldag) = self.dag.read() {
-            if let Some(vtx) = bulldag.get_vertex(idx) {
-                let p_ids = vtx.get_references();
-                let mut proposals = Vec::new();
-                p_ids.iter().for_each(|idx| {
-                    if let Some(vtx) = bulldag.get_vertex(idx) {
-                        match vtx.get_data() {
-                            Block::Proposal { ref block } => {
-                                proposals.push(vtx);
-                            },
-                            _ => {}
-                        }
-                }});
-                return proposals
-            }
-            return None
-        }
-    }
-}
-
-impl Resolver for Miner {
-    type ProposalInner = ProposalBlock;
-    type Identified = HashMap<TransactionDigest, Conflict>;
-    type SourceInner = ConvergenceBlock;
-    type BallotInfo = (Claim, RefHash);
-    
-    /// Identifies conflicts between blocks eligible for inclusion in the 
-    /// current round ConvergenceBlock.
-    /// It accomplishes this by iterating through all the blocks and 
-    /// adding a Conflict struct to a HashMap. The conflict struct 
-    /// contains a HashSet with every node that proposed a txn with 
-    /// a given transaction digest. It then filters the HashMap to 
-    /// only keep Conflicts with more than 1 proposer.
-    fn identify<I: IntoIterator<Item=Self::ProposalInner>>(
-        &self, proposals: &I
-    ) -> &Self::Identified {
-        let mut conflicts: ConflictList = HashMap::new();
-        proposals.iter().for_each(|block| {
-            let mut txn_iter = block.txns.iter();
-            let mut proposer = HashSet::new();
-
-            proposer.insert((block.from.clone(), block.hash.clone()));
-
-            while let Some((id, _)) = txn_iter.next() {
-                let conflict = Conflict {
-                    txn_id: id.to_string(),
-                    proposers: proposer.clone(),
-                    winner: None,
-                };
-
-                conflicts
-                    .entry(id.to_string())
-                    .and_modify(|e| {
-                        e.proposers.insert((block.from.clone(), block.hash.clone()));
-                    })
-                    .or_insert(conflict);
-            }
-        });
-
-        conflicts.retain(|_, conflict| conflict.proposers.len() > 1);
-        &conflicts
-    }
-
-    /// Splits proposal blocks by current round and previous rounds 
-    /// and then attempts to resolve any conflicts between earlier 
-    /// round proposal blocks (that were not appended to DAG) and 
-    /// earlier round (from which it was originally proposed).
-    /// This is to handle blocks that don't get discovered in time to be 
-    /// included in the convergence block from the round which they were 
-    /// originally proposed in. 
-    ///
-    /// After this, the method identifies conflicts, creates an election 
-    /// results map (`BTreeMap`), elects and appends winners to the conflict.
-    /// It then resolves all conflicts in the current round blocks, by removing 
-    /// the txns associated with the block proposed by the losing party in the 
-    /// conflict resolution protocol.
-    fn resolve<I>(&self, proposals: &I) -> &I 
-    where 
-        I: IntoIterator<Item=Self::ProposalInner>
-    {
-        let (curr, prev) = self.split_proposals_by_round(proposals);
-        let prev_resolved = self.resolve_earlier(&prev);
-        let mut conflicts = self.identify(&curr);
-
-        let proposers = self.get_proposers(&curr); 
-
-        // Construct a BTreeMap of all election results
-        let mut election_results = self.get_election_results(proposers); 
-        let mut curr_resolved = curr.clone();
-        curr_resolved.extend(prev_resolved);
-
-        // Iterate, mutably through all the conflicts identified
-        self.append_winner(&mut conflicts, &mut election_results);
-        self.resolve_current(&mut curr_resolved, &conflicts);
-        &curr_resolved.clone()
-    }
-
-    /// Resolves Conflicts between a block that is eligible in this current 
-    /// round, i.e. is not already appended to the DAG, but was proposed earlier 
-    /// i.e. references a ConvergenceBlock that is not equal to miner.last_block,
-    /// and blocks in previous rounds.
-    fn resolve_earlier<I: IntoIterator<Item=Self::ProposalInner>>(
-        &self, 
-        proposals: &I
-    ) -> &I {
-
-        let prev_blocks: Vec<ConvergenceBlock> = {
-            let nested: Vec<Vec<ConvergenceBlock>> = proposals
-                .iter()
-                .map(|prop_block| self.get_sources(prop_block))
-                .collect();
-
-            nested.into_iter().flatten().collect()
-        };
-
-        let mut proposals = proposals.clone();
-
-        // Flatten consolidated transactions from all previous blocks
-        let removals: LinkedHashSet<&TxnId> = {
-            // Get nested sets of all previous blocks
-            let sets: Vec<LinkedHashSet<&TxnId>> = prev_blocks
-                .iter()
-                .map(|block| {
-                    let block_set: Vec<&LinkedHashSet<TxnId>> = {
-                        block
-                            .txns
-                            .iter()
-                            .map(|(_, txn_id_set)| txn_id_set)
-                            .collect()
-                    };
-                    block_set.into_iter().flatten().collect()
-                })
-                .collect();
-
-            // Flatten the nested sets
-            sets.into_iter().flatten().collect()
-        };
-
-        proposals.retain(|block| block.round != round);
-
-        let resolved: Vec<ProposalBlock> = proposals
-            .iter_mut()
-            .map(|block| {
-                let mut resolved_block = block.clone();
-
-                resolved_block.txns.retain(|id, _| !&removals.contains(id));
-
-                resolved_block
-            })
-            .collect();
-
-        resolved
-    }
-    
-    /// Get every convergence block between the proposal block passed to this 
-    /// method, and the convergence block that this proposal blocks references, 
-    /// i.e. this proposal blocks source, and all other blocks in between 
-    /// before this current block being mined. 
-    fn get_sources<I>(&self, proposal: &Self::ProposalInner) -> &I 
-    where 
-        I: IntoIterator<Item = Self::SourceInner>
-    {
-        // TODO: Handle the case where the reference block is the genesis block
-        let source = proposal.ref_block.clone();
-        if let Ok(bulldag) = self.dag.read() {
-
-            let source_vtx: Option<&Vertex<Block, String>> = bulldag.get_vertex(source);
-
-            // Get every block between current proposal and proposals source;
-            // if the source exists
-            let source_refs: Vec<String> = match source_vtx {
-                Some(vtx) => bulldag.trace(&vtx, Direction::Reference),
-                None => {
-                    vec![]
-                },
-            };
-
-            // Get all the vertices corresponding to the references to the
-            // proposal blocks source. This will include other proposal blocks
-            // between the ProposalBlock's source and the current round.
-            // Will need to filter to only retain the convergence blocks
-            let ref_vertices: Vec<Option<&Vertex<Block, String>>> = {
-                source_refs
-                    .iter()
-                    .map(|idx| chain.get_vertex(idx.to_string())).collect()
-            };
-
-            // Initialize a stack to save ConvergenceBlock vertices to
-            // This will where all the ConvergenceBlocks between the
-            // Source of ProposalBlock and the current round will be stored
-            // and returned to check for conflicts.
-            let mut stack = vec![];
-
-            // Iterate through the ref_vertices vector
-            // Check whether the ref_vertex is Some or None
-            // If it is Some, get the data from the Vertex and
-            // match the Block variant
-            // If the block variant is a convergence block add it to the stack
-            // otherwise ignore it
-            ref_vertices.iter().for_each(|opt| {
-                if let Some(vtx) = opt {
-                    match vtx.get_data() {
-                        Block::Convergence { block } => stack.push(block),
-                        _ => {},
-                    }
-                }
-            });
-
-            return &stack;
-        }
-
-        return &vec![]
-    }
-
-    /// Splits proposal blocks into two different proposal blocks
-    /// proposal blocks which has a source convergence block that is 
-    /// equal to miner.last_block, and proposal blocks with earlier 
-    /// round source convergence blocks. 
-    fn split_proposals_by_round<I>(&self, proposals: &I) -> (I, I) 
-    where 
-        I: IntoIterator<Item = Self::ProposalInner>
-    {
-        let (mut curr, mut prev) = (Vec::new(), Vec::new());
-        for block in proposals {
-            if block.is_current_round(round) {
-                curr.push(block.clone());
-            } else {
-                prev.push(block.clone());
-            }
-        }
-        (curr.clone(), prev.clone())
-    } 
-
-    fn get_proposers<I>(&self, proposals: &I) -> Vec<Self::BallotInfo> 
-    where 
-        I: IntoIterator<Item = Self::ProposalInner>
-    {
-        proposals.iter()
-            .map(|block| (block.from.clone(), block.hash.clone()))
-            .collect()
-    }
-
-    fn append_winner(
-        &self, 
-        conflicts: &mut Self::Identified, 
-        election_results: &mut BTreeMap<U256, Self::BallotInfo>
-    ) {
-        conflicts.iter_mut().for_each(|(_, conflict)| {
-            election_results.retain(|(election_results, (claim, ref_hash))| {
-                conflict
-                    .proposers
-                    .contains(&(claim.clone(), ref_hash.clone()))
-            });
-
-            // select the first pointer sum and extract the proposal block
-            // hash from the pointer sum
-            let winner = {
-
-                let mut first: Option<U256, Self::BallotInfo> = election_results.pop_first();
-                while let None = first {
-                    first = local_pointers.pop_first();
-                }
-
-                first
-            };
-            // save it as the conflict winner
-            if let Some((res, (claim, ref_hash))) = winner {
-                conflict.winner = Some(ref_hash);
-            }
-        });
-    }
-
-    fn resolve_current<I>(&self, current: &mut I, conflicts: Self::Identified) 
-    where
-        I: IntoIterator<Item = Self::ProposalInner>
-    {
-        current.iter_mut().for_each(|block| {
-            // Clone conflicts into a mutable variable
-            let mut local_conflicts = conflicts.clone();
-
-            // retain only the conflicts that relate to current proposal block
-            local_conflicts.retain(|id, _| block.txns.contains_key(id));
-
-            // convert filtered conflicts into an iterator
-            let mut conflict_iter = local_conflicts.iter();
-
-            // initialize a hashset to save transactions that current block
-            // proposer lost conflict resolution.
-            let mut removals = HashSet::new();
-
-            // loop through all the conflicts related to current block
-            // and check if the winner is the current block hash
-            while let Some((id, conflict)) = conflict_iter.next() {
-                if Some(block.hash.clone()) != conflict.winner {
-                    // if it does insert into removals, otherwise ignore
-                    removals.insert(id.to_string());
-                }
-            }
-
-            // remove transactions for which current block lost conflict
-            // resolution from the current block
-            block.txns.retain(|id, _| !removals.contains(id));
-        });
-    }
-}

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -5,7 +5,7 @@
 //FEATURE TAG(S): Block Structure, VRF for Next Block Seed, Rewards
 use std::{
     cmp::Ordering,
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, BTreeMap},
     mem,
 };
 
@@ -43,8 +43,10 @@ use utils::{create_payload, hash_data};
 use vrrb_core::{
     claim::Claim,
     keypair::{MinerPk, MinerSk},
-    txn::Txn,
+    txn::{Txn, TransactionDigest},
 };
+use sha2::{Digest, Sha256};
+use ethereum_types::U256;
 
 use crate::result::MinerError;
 
@@ -68,8 +70,7 @@ const GENESIS_ALLOWED_MINERS: [&str; 2] = [
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MinerStatus {
     Mining,
-    Waiting,
-    Processing,
+    Waiting
 }
 
 #[derive(Debug)]
@@ -84,31 +85,27 @@ pub struct Miner {
     secret_key: MinerSk,
     public_key: MinerPk,
     address: Address,
-}
-
-pub struct MineArgs<'a> {
-    pub claim: Claim,
-    pub last_block: Block,
-    pub txns: LinkedHashMap<String, Txn>,
-    pub claims: LinkedHashMap<String, Claim>,
-    pub claim_list_hash: Option<String>,
-    #[deprecated(
-        note = "will be removed, unnecessary as last block needed to mine and contains next block reward"
-    )]
-    pub reward: &'a mut Reward,
-    pub abandoned_claim: Option<Claim>,
-    pub secret_key: SecretKey,
-    pub epoch: Epoch,
-    pub round: u128,
-    pub next_epoch_adjustment: i128,
+    claim: Claim,
+    last_block: Option<ConvergenceBlock>,
+    status: MinerStatus,
 }
 
 impl Miner {
     pub fn new(config: MinerConfig) -> Self {
+        let public_key = config.public_key.clone();
+        let address = Address::new(config.public_key.clone());
+        let claim = Claim::new(
+            config.public_key,
+            address 
+        );
+
         Miner {
             secret_key: config.secret_key,
             public_key: config.public_key,
             address: Address::new(config.public_key.clone()),
+            claim,
+            last_block: None,
+            status: MinerStatus::Waiting,
         }
     }
 
@@ -137,79 +134,66 @@ impl Miner {
         todo!()
     }
 
+    pub fn get_dag(&self) -> Event {
+        return Event::GetDag
+    }
+
+    pub fn check_claim(&self, winner: U256) -> bool {
+        winner == self.claim.hash
+    }
+
     pub fn mine_convergence_block(
-        &self,
-        args: MineArgs,
-        proposals: &Vec<ProposalBlock>,
+        &mut self,
         chain: &BullDag<Block, String>,
+        next_epoch_adjustment: i128,
     ) -> Option<ConvergenceBlock> {
         // identify and resolve all the conflicting txns between proposal blocks
+        self.miner_status = MinerStatus::Mining;
+        
+        let proposals = &self.get_proposal_blocks(chain, &self.last_block);
         let resolved_txns = {
-            match args.last_block {
-                Block::Convergence { ref block } => self.resolve_conflicts(
-                    &proposals,
-                    block.header.next_block_seed.into(),
-                    args.round.clone(),
-                    chain,
-                ),
-                Block::Genesis { ref block } => self.resolve_conflicts(
-                    &proposals,
-                    block.header.next_block_seed.into(),
-                    args.round.clone(),
-                    chain,
-                ),
-                _ => return None,
+            if let Some(last_block) = self.last_block {
+                self.get_resolved_txns(
+                    proposals, 
+                    &last_block, 
+                    &last_block.header.round, 
+                    chain
+                )            
+            } else {
+                return None 
             }
         };
 
-        // Consolidate transactions after resolving conflicts.
-        let txns: ConsolidatedTxns = resolved_txns
-            .iter()
-            .map(|block| {
-                let txn_list = block.txns.iter().map(|(id, _)| id.clone()).collect();
+        let txns: ConsolidatedTxns = self.consolidate_txns(&resolved_txns);
+        let claims: ConsolidatedClaims = self.consolidate_claims(&proposals);
+        let last_block = self.last_block.clone();
+        let claim = self.claim.clone();
+        let secret_key = self.secret_key.clone();
 
-                (block.hash.clone(), txn_list)
-            })
-            .collect();
+        let ref_hashes = proposals.iter().map(|b| {
+            b.hash.clone()
+        }).collect();
 
-        //TODO: resolve claim conflicts. This is less important because it
-        //cannot lead to double spend
-        let claims: ConsolidatedClaims = proposals
-            .iter()
-            .map(|block| {
-                let claim_hashes: LinkedHashSet<ClaimHash> = block
-                    .claims
-                    .iter()
-                    .map(|(claim_hash, _)| claim_hash.clone())
-                    .collect();
+        let mut txn_hasher = Sha256::new();
+        let mut claim_hasher = Sha256::new();
 
-                (block.hash.clone(), claim_hashes)
-            })
-            .collect();
+        let txns_hash = {
+            if let Ok(serialized_txns) = serde_json::to_string(&txn) {
+                txn_hasher.update(serialized_txns.as_bytes());
+            } 
+            txn_hasher.finalize()
+        };
 
-        // Get the convergence block from the last round
-        let last_block = args.last_block;
+        let claims_hash = {
+            if let Ok(serialized_claims) = serde_json::to_string(&txn) {
+                claim_hasher.update(serialized_claims.as_bytes());
+            }
+            claim_hasher.finalize(); 
+        };
 
-        // Get the miner claim
-        let claim = args.claim;
+        let txn_hash_string = format!("{:x}", txn_hash);
+        let claims_hash_string = format!("{:x}", claims_hash);
 
-        // Get the miner secret key
-        let secret_key = args.secret_key;
-
-        // TODO: Calculate the rolling utility and the rolling
-        // next epoch adjustment
-        let adjustment_next_epoch = args.next_epoch_adjustment;
-
-        // Get all the proposal block hashes
-        let ref_hashes = proposals.iter().map(|b| b.hash.clone()).collect();
-
-        // Hash the conflict resolved transactions
-        let txn_hash = hash_data!(txns);
-
-        // Hash the claims
-        let claim_list_hash = hash_data!(claims);
-
-        // Get the block header for the current block
         let header = BlockHeader::new(
             last_block.clone(),
             ref_hashes,
@@ -217,10 +201,9 @@ impl Miner {
             secret_key,
             txn_hash,
             claim_list_hash,
-            adjustment_next_epoch,
+            next_epoch_adjustment,
         )?;
 
-        // Hash all the header data to get the blockhash
         let block_hash = hash_data!(
             header.ref_hashes,
             header.round,
@@ -236,7 +219,8 @@ impl Miner {
             header.miner_signature
         );
 
-        // Return the ConvergenceBlock
+        self.miner_status = MinerStatus::Waiting;
+
         Some(ConvergenceBlock {
             header,
             txns,
@@ -246,6 +230,7 @@ impl Miner {
         })
     }
 
+    #[deprecated(note = "Building proposal blocks will be done in Harvester")]
     pub fn mine_proposal_block(
         &self,
         ref_block: RefHash,
@@ -255,6 +240,7 @@ impl Miner {
         claims: ClaimList,
         from: Claim,
     ) -> ProposalBlock {
+
         let payload = create_payload!(round, epoch, txns, claims, from);
 
         let signature = self.secret_key.sign_ecdsa(payload).to_string();
@@ -273,6 +259,7 @@ impl Miner {
         }
     }
 
+    #[deprecated(note = "Building proposal blocks will be done in Harvester")]
     pub fn build_proposal_block(
         &self,
         ref_block: RefHash,
@@ -280,8 +267,6 @@ impl Miner {
         epoch: Epoch,
         txns: TxnList,
         claims: ClaimList,
-        // from: Claim,
-        // secret_key: SecretKeyBytes,
     ) -> Result<ProposalBlock, InvalidBlockErrorReason> {
         let from = self.generate_claim();
         let payload = create_payload!(round, epoch, txns, claims, from);
@@ -307,6 +292,7 @@ impl Miner {
             signature,
         })
     }
+
 
     pub fn mine_genesis_block(&self, claim_list: ClaimList) -> Option<GenesisBlock> {
         let claim_list_hash = hash_data!(claim_list);
@@ -370,12 +356,45 @@ impl Miner {
         chrono::Utc::now().timestamp() as u128
     }
 
+    fn get_proposal_blocks(
+        &self, 
+        bulldag: &BullDag<Block, String>, 
+        last_block: ConvergenceBlock
+    ) -> Option<Vec<ProposalBlock>> {
+        let idx = self.last_block.hash;
+        if let Some(vtx) = bulldag.get_vertex(idx) {
+            let p_ids = vtx.get_references();
+            let mut proposals = Vec::new();
+            p_ids.iter().for_each(|idx| {
+                if let Some(vtx) = bulldag.get_vertex(idx) {
+                    match vtx.get_data() {
+                        Block::Proposal { ref block } => {
+                            proposals.push(vtx);
+                        },
+                        _ => { 
+                            /*Should throw an error here as 
+                             this shouldn't happen, so we 
+                             should change return type to 
+                             Result<Vec<ProposalBlock>>
+                             so that we can propagate 
+                             the error.
+                            */
+                        }
+                    }
+            }});
+
+            return proposals
+        }
+
+        return None
+    }
+
     // Check that conflicts with previous convergence block are removed
     // and there is no winner in current round.
     fn resolve_conflicts(
         &self,
         proposals: &Vec<ProposalBlock>,
-        seed: u128,
+        seed: u64,
         round: u128,
         chain: &BullDag<Block, String>,
     ) -> Vec<ProposalBlock> {
@@ -394,36 +413,27 @@ impl Miner {
         };
 
         // Next get all the prev_round conflicts resolved
-        let prev_resolved = self.resolve_conflicts_prev_rounds(round, &prev, chain);
+        let prev_resolved = self.resolve_conflicts_prev_rounds(
+            round, &prev, chain
+        );
 
         // Identify all conflicts
         let mut conflicts = self.identify_conflicts(&curr);
 
-        // create a vector of proposers with the claim and the proposal block
-        // hash.
         let proposers: Vec<(Claim, RefHash)> = curr
             .iter()
             .map(|block| (block.from.clone(), block.hash.clone()))
             .collect();
 
-        // calculate the pointer sums for all propsers and save into a vector
-        // of thruples with the claim, ref_hash and pointer sum
-        let mut pointer_sums: Vec<(Claim, RefHash, Option<u128>)> = {
-            proposers
+        // Construct a BTreeMap of all election results
+        let mut pointer_sums: BTreeMap<U256, (Claim, RefHash)> = proposers
                 .iter()
                 .map(|(claim, ref_hash)| {
-                    (claim.clone(), ref_hash.to_string(), claim.get_pointer(seed))
+                    (claim.get_election_result(seed),
+                     (claim.clone(), 
+                     ref_hash.to_string()))
                 })
-                .collect()
-        };
-
-        // Sort all the pointer sums
-        pointer_sums.sort_by(|a, b| match (a.2, b.2) {
-            (Some(x), Some(y)) => x.cmp(&y),
-            (None, Some(_)) => Ordering::Greater,
-            (Some(_), None) => Ordering::Less,
-            (None, None) => Ordering::Equal,
-        });
+                .collect();
 
         // Iterate, mutably through all the conflicts identified
         conflicts.iter_mut().for_each(|(_, conflict)| {
@@ -431,7 +441,7 @@ impl Miner {
             let mut local_pointers = pointer_sums.clone();
 
             // retain only the pointer sum related to the current conflict
-            local_pointers.retain(|(claim, ref_hash, _)| {
+            local_pointers.retain(|(election_results, (claim, ref_hash))| {
                 conflict
                     .proposers
                     .contains(&(claim.clone(), ref_hash.clone()))
@@ -439,10 +449,20 @@ impl Miner {
 
             // select the first pointer sum and extract the proposal block
             // hash from the pointer sum
-            let winner = local_pointers[0].1.clone();
+            let winner = {
 
+                let mut first: Option<U256,(Claim, RefHash)> = local_pointers.pop_first();
+
+                while let None = first {
+                    first = local_pointers.pop_first();
+                }
+
+                first
+            };
             // save it as the conflict winner
-            conflict.winner = Some(winner);
+            if let Some((res, (claim, ref_hash))) = winner {
+                conflict.winner = Some(ref_hash);
+            }
         });
 
         let mut curr_resolved = curr.clone();
@@ -615,5 +635,65 @@ impl Miner {
         });
 
         return stack;
+    }
+
+    fn get_resolved_txns(
+        &self,
+        proposals: &Vec<ProposalBlock>,
+        last_block: &Block,
+        round: &u128,
+        chain: &BullDag<Block, String>,
+    ) -> Vec<ProposalBlock> {
+        match last_block {
+            Block::Convergence { ref block } => {
+                self.resolve_conflicts(
+                    proposals, 
+                    &block.header.next_block_seed, 
+                    round, 
+                    chain
+                )
+            },
+            Block::Genesis { ref block } => {
+                self.resolve_conflicts(
+                    proposals,
+                    &block.head.next_block_seed,
+                    round,
+                    chain
+                )
+            },
+            _ => return None,
+        }
+    }
+
+    fn consolidate_txns(
+        &self, 
+        proposals: &Vec<ProposalBlock>
+    ) -> ConsolidatedTxns {
+
+        propsals.iter()
+            .map(|block| {
+                let txn_list = block.txns.iter()
+                    .map(|(id, _)| { 
+                        id.clone()
+                    }).collect();
+
+            (block.hash.clone(), txn_list)
+        }).collect()
+    }
+
+    fn consolidate_claims(
+        proposals: &Vec<ProposalBlock>
+    ) -> ConsolidatedClaims {
+
+        proposals.iter()
+            .map(|block| {
+                let claim_hashes: LinkedHashSet<ClaimHash> = block
+                    .claims
+                    .iter()
+                    .map(|(claim_hash, _)| claim_hash.clone())
+                    .collect();
+
+            (block.hash.clone(), claim_hashes)
+        }).collect()
     }
 }

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -42,7 +42,6 @@ impl<'a> BlockBuilder for Miner<'a> {
                 certificate: None,
             })
         } else {
-            println!("Couldn't find references");
             return None
         }
     }
@@ -56,7 +55,6 @@ impl<'a> BlockBuilder for Miner<'a> {
     /// been referenced. We need to add this functionality so that 
     /// blocks don't get "orphaned"
     fn get_references(&self) -> Option<Vec<Self::RefType>> {
-        println!("Getting last block");
         let last_block = self.last_block.clone();
         if let Some(last_block) = last_block {
             let idx = last_block.get_hash();
@@ -81,7 +79,6 @@ impl<'a> BlockBuilder for Miner<'a> {
                 return None 
         }
     }
-    println!("Couldn't find last block");
     None
     }
 }

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -1,13 +1,15 @@
 use crate::{block_builder::BlockBuilder, Miner, conflict_resolver::Resolver};
-use block::{Block, ConvergenceBlock, ProposalBlock, ConflictList, Conflict, RefHash};
+use block::{Block, ConvergenceBlock, ProposalBlock, ConflictList, Conflict, RefHash, InnerBlock, header::BlockHeader};
+use reward::reward::Reward;
 use std::collections::{BTreeMap, HashSet, HashMap};
 use bulldag::vertex::{Direction, Vertex};
 use ethereum_types::U256;
 use ritelinked::LinkedHashSet;
 use vrrb_core::{claim::Claim, txn::TransactionDigest};
+use std::sync::Arc;
 
 
-impl<'a> BlockBuilder for Miner<'a> {
+impl BlockBuilder for Miner {
     type BlockType = ConvergenceBlock;
     type RefType = ProposalBlock;
 
@@ -16,7 +18,12 @@ impl<'a> BlockBuilder for Miner<'a> {
     /// We should make sure that the new `ConvergenceBlock` is actually
     /// pulled from the `miner.dag` instance instead of just passing it 
     // into this method. 
-    fn update(&mut self, adjustment: &i128) {
+    fn update(
+        &mut self, 
+        last_block: Option<Arc<dyn InnerBlock<Header = BlockHeader, RewardType = Reward>>>, 
+        adjustment: &i128
+    ) {
+        self.last_block = last_block;
         self.next_epoch_adjustment = *adjustment;
     }
 
@@ -24,7 +31,6 @@ impl<'a> BlockBuilder for Miner<'a> {
     fn build(&self) -> Option<Self::BlockType> {
         let proposals = self.get_references();
         if let Some(proposals) = proposals {
-
             let resolved = self.resolve(&proposals, self.get_round(), self.get_seed());
             let txns = self.consolidate_txns(&resolved);
             let claims = self.consolidate_claims(&resolved);
@@ -34,7 +40,7 @@ impl<'a> BlockBuilder for Miner<'a> {
             let header = self.build_header(ref_hashes.clone(), txns_hash, claims_hash)?;
             let hash = self.hash_block(&header);
 
-            Some(ConvergenceBlock { 
+            return Some(ConvergenceBlock { 
                 header,
                 txns,
                 claims,
@@ -56,98 +62,26 @@ impl<'a> BlockBuilder for Miner<'a> {
     /// blocks don't get "orphaned"
     fn get_references(&self) -> Option<Vec<Self::RefType>> {
         if let Ok(bulldag) = self.dag.read() {
-            if let Some(vtx) = self.get_last_block_vertex(None) {
-                let p_ids = vtx.get_references();
-                let mut proposals = Vec::new();
-                p_ids.iter().for_each(|idx| {
-                if let Some(vtx) = bulldag.get_vertex(idx.to_string()) {
+            
+            let leaf_ids = bulldag.get_leaves();
+            let mut proposals = Vec::new();
+            
+            leaf_ids.iter().for_each(|leaf| {
+                if let Some(vtx) = bulldag.get_vertex(leaf.clone()) {
                     match vtx.get_data() {
-                        Block::Proposal { ref block } => {
+                        Block::Proposal { block } => {
                             proposals.push(block.clone());
                         },
                         _ => {}
                     }
-                }});
-                
-                let orphans = self.get_orphaned_references(
-                    vtx.get_index(), 
-                    0, 
-                    5
-                );
-                proposals.extend(orphans);
-                return Some(proposals)
-            } 
-        }
+                }
+            });
+
+            return Some(proposals)
+
+        } 
 
         return None
-    }
-
-    /// Gets all the orphaned ProposalBlocks from the past n rounds.
-    fn get_orphaned_references(
-        &self, 
-        idx: RefHash, 
-        current_round: usize, 
-        n_rounds: usize
-    ) -> Vec<Self::RefType> {
-
-        let source_cbs = self.get_n_rounds_convergence(idx, current_round, n_rounds);
-        let mut orphaned = vec![];
-
-        source_cbs.iter().for_each(|ref_hash| {
-            if let Ok(guard) = self.dag.read() {
-                if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
-                    let references = vtx.get_references();
-                    for ref_hash in references {
-                        if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
-                            if let Block::Proposal { block } = vtx.get_data() { 
-                                if vtx.get_references().len() == 0 {
-                                    orphaned.push(block.clone());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        });
-
-        orphaned
-    }
-
-    /// Gets the ConvegenceBlock from the past n rounds.
-    fn get_n_rounds_convergence(&self, idx: RefHash, current_round: usize, n_rounds: usize) -> HashSet<RefHash> {
-        if current_round > n_rounds {
-            return HashSet::new() 
-        }
-
-        let mut source_cbs = HashSet::new();
-        
-        if let Ok(guard) = self.dag.read() {
-            if let Some(vtx) = guard.get_vertex(idx) {
-                if let Block::Convergence { .. } = vtx.get_data() {
-                    let sources = vtx.get_sources();
-                    sources.iter().for_each(|ref_hash| {
-                        if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
-                            if let Block::Proposal { .. } = vtx.get_data() {
-                                let sources = vtx.get_sources();
-                                for source in sources {
-                                    source_cbs.insert(source.to_string());
-                                }
-                            }
-                        }
-                    });
-
-                    source_cbs.iter().for_each(|ref_hash| {
-                        source_cbs.extend(
-                            self.get_n_rounds_convergence(
-                                ref_hash.clone().to_string(), current_round + 1, n_rounds
-                            )
-                        )
-                    });
-                }
-            }
-        }
-        
-        return source_cbs 
     }
 
     /// Gets the vertex from the last Convergence (or Genesis) block.
@@ -173,7 +107,7 @@ impl<'a> BlockBuilder for Miner<'a> {
     }
 }
 
-impl<'a> Resolver for Miner<'a> {
+impl Resolver for Miner {
     type Proposal = ProposalBlock;
     type Identified = HashMap<TransactionDigest, Conflict>;
     type Source = ConvergenceBlock;
@@ -235,16 +169,14 @@ impl<'a> Resolver for Miner<'a> {
         round: u128, 
         seed: u64
     ) -> Vec<Self::Proposal> {
-        let (curr, prev) = self.split_proposals_by_round(proposals);
+        let (mut curr, prev) = self.split_proposals_by_round(proposals);
         let prev_resolved = self.resolve_earlier(&prev, round);
+        curr.extend(prev_resolved.clone());
         let mut conflicts = self.identify(&curr);
-
         let proposers = self.get_proposers(&curr); 
-
         // Construct a BTreeMap of all election results
         let mut election_results = self.get_election_results(&proposers, seed); 
         let mut curr_resolved = curr.clone();
-        curr_resolved.extend(prev_resolved.clone());
 
         // Iterate, mutably through all the conflicts identified
         self.append_winner(&mut conflicts, &mut election_results);
@@ -327,7 +259,9 @@ impl<'a> Resolver for Miner<'a> {
             // Get every block between current proposal and proposals source;
             // if the source exists
             let source_refs: Vec<String> = match source_vtx {
-                Some(vtx) => bulldag.trace(&vtx, Direction::Reference),
+                Some(vtx) => {
+                    bulldag.trace(&vtx, Direction::Reference)
+                },
                 None => {
                     vec![]
                 },

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -1,0 +1,346 @@
+use crate::{block_builder::BlockBuilder, Miner, conflict_resolver::Resolver};
+use block::{ConvergenceBlock, ProposalBlock};
+
+
+impl BlockBuilder for Miner {
+    type BlockType = ConvergenceBlock;
+    type RefType = ProposalBlock;
+
+    fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128) {
+        self.last_block = Some(new_block);
+        self.next_epoch_adjustment = adjustment;
+    }
+
+    fn build(&self) -> Option<Self::BlockType> {
+        let proposals = self.get_references();
+        if let Some(proposals) = proposals {
+
+            let resolved = self.resolve(&proposals);
+            let txns = self.consolidate_txns(&proposals);
+            let claims = self.consolidate_claims(&proposals);
+            let ref_hashes = self.get_ref_hashes(&proposals);
+            let txn_hash = self.get_txn_hash(&txns);
+            let claim_hash = self.get_claim_hash(&claims);
+            let header = self.build_header(ref_hashes, txns_hash, claims_hash)?;
+            let hash = self.hash_block(&header);
+
+            Some(ConvergenceBlock { 
+                header,
+                txns,
+                claims,
+                hash,
+                certificate: None,
+            })
+        } else {
+            return None
+        }
+    }
+
+
+    fn get_references(&self) -> Option<Vec<Self::RefType>> {
+        let idx = self.last_block.hash;
+        if let Ok(bulldag) = self.dag.read() {
+            if let Some(vtx) = bulldag.get_vertex(idx) {
+                let p_ids = vtx.get_references();
+                let mut proposals = Vec::new();
+                p_ids.iter().for_each(|idx| {
+                    if let Some(vtx) = bulldag.get_vertex(idx) {
+                        match vtx.get_data() {
+                            Block::Proposal { ref block } => {
+                                proposals.push(vtx);
+                            },
+                            _ => {}
+                        }
+                }});
+                return proposals
+            }
+            return None
+        }
+    }
+}
+
+impl Resolver for Miner {
+    type ProposalInner = ProposalBlock;
+    type Identified = HashMap<TransactionDigest, Conflict>;
+    type SourceInner = ConvergenceBlock;
+    type BallotInfo = (Claim, RefHash);
+    
+    /// Identifies conflicts between blocks eligible for inclusion in the 
+    /// current round ConvergenceBlock.
+    /// It accomplishes this by iterating through all the blocks and 
+    /// adding a Conflict struct to a HashMap. The conflict struct 
+    /// contains a HashSet with every node that proposed a txn with 
+    /// a given transaction digest. It then filters the HashMap to 
+    /// only keep Conflicts with more than 1 proposer.
+    fn identify<I: IntoIterator<Item=Self::ProposalInner>>(
+        &self, proposals: &I
+    ) -> &Self::Identified {
+        let mut conflicts: ConflictList = HashMap::new();
+        proposals.iter().for_each(|block| {
+            let mut txn_iter = block.txns.iter();
+            let mut proposer = HashSet::new();
+
+            proposer.insert((block.from.clone(), block.hash.clone()));
+
+            while let Some((id, _)) = txn_iter.next() {
+                let conflict = Conflict {
+                    txn_id: id.to_string(),
+                    proposers: proposer.clone(),
+                    winner: None,
+                };
+
+                conflicts
+                    .entry(id.to_string())
+                    .and_modify(|e| {
+                        e.proposers.insert((block.from.clone(), block.hash.clone()));
+                    })
+                    .or_insert(conflict);
+            }
+        });
+
+        conflicts.retain(|_, conflict| conflict.proposers.len() > 1);
+        &conflicts
+    }
+
+    /// Splits proposal blocks by current round and previous rounds 
+    /// and then attempts to resolve any conflicts between earlier 
+    /// round proposal blocks (that were not appended to DAG) and 
+    /// earlier round (from which it was originally proposed).
+    /// This is to handle blocks that don't get discovered in time to be 
+    /// included in the convergence block from the round which they were 
+    /// originally proposed in. 
+    ///
+    /// After this, the method identifies conflicts, creates an election 
+    /// results map (`BTreeMap`), elects and appends winners to the conflict.
+    /// It then resolves all conflicts in the current round blocks, by removing 
+    /// the txns associated with the block proposed by the losing party in the 
+    /// conflict resolution protocol.
+    fn resolve<I>(&self, proposals: &I) -> &I 
+    where 
+        I: IntoIterator<Item=Self::ProposalInner>
+    {
+        let (curr, prev) = self.split_proposals_by_round(proposals);
+        let prev_resolved = self.resolve_earlier(&prev);
+        let mut conflicts = self.identify(&curr);
+
+        let proposers = self.get_proposers(&curr); 
+
+        // Construct a BTreeMap of all election results
+        let mut election_results = self.get_election_results(proposers); 
+        let mut curr_resolved = curr.clone();
+        curr_resolved.extend(prev_resolved);
+
+        // Iterate, mutably through all the conflicts identified
+        self.append_winner(&mut conflicts, &mut election_results);
+        self.resolve_current(&mut curr_resolved, &conflicts);
+        &curr_resolved.clone()
+    }
+
+    /// Resolves Conflicts between a block that is eligible in this current 
+    /// round, i.e. is not already appended to the DAG, but was proposed earlier 
+    /// i.e. references a ConvergenceBlock that is not equal to miner.last_block,
+    /// and blocks in previous rounds.
+    fn resolve_earlier<I: IntoIterator<Item=Self::ProposalInner>>(
+        &self, 
+        proposals: &I
+    ) -> &I {
+
+        let prev_blocks: Vec<ConvergenceBlock> = {
+            let nested: Vec<Vec<ConvergenceBlock>> = proposals
+                .iter()
+                .map(|prop_block| self.get_sources(prop_block))
+                .collect();
+
+            nested.into_iter().flatten().collect()
+        };
+
+        let mut proposals = proposals.clone();
+
+        // Flatten consolidated transactions from all previous blocks
+        let removals: LinkedHashSet<&TxnId> = {
+            // Get nested sets of all previous blocks
+            let sets: Vec<LinkedHashSet<&TxnId>> = prev_blocks
+                .iter()
+                .map(|block| {
+                    let block_set: Vec<&LinkedHashSet<TxnId>> = {
+                        block
+                            .txns
+                            .iter()
+                            .map(|(_, txn_id_set)| txn_id_set)
+                            .collect()
+                    };
+                    block_set.into_iter().flatten().collect()
+                })
+                .collect();
+
+            // Flatten the nested sets
+            sets.into_iter().flatten().collect()
+        };
+
+        proposals.retain(|block| block.round != round);
+
+        let resolved: Vec<ProposalBlock> = proposals
+            .iter_mut()
+            .map(|block| {
+                let mut resolved_block = block.clone();
+
+                resolved_block.txns.retain(|id, _| !&removals.contains(id));
+
+                resolved_block
+            })
+            .collect();
+
+        resolved
+    }
+    
+    /// Get every convergence block between the proposal block passed to this 
+    /// method, and the convergence block that this proposal blocks references, 
+    /// i.e. this proposal blocks source, and all other blocks in between 
+    /// before this current block being mined. 
+    fn get_sources<I>(&self, proposal: &Self::ProposalInner) -> &I 
+    where 
+        I: IntoIterator<Item = Self::SourceInner>
+    {
+        // TODO: Handle the case where the reference block is the genesis block
+        let source = proposal.ref_block.clone();
+        if let Ok(bulldag) = self.dag.read() {
+
+            let source_vtx: Option<&Vertex<Block, String>> = bulldag.get_vertex(source);
+
+            // Get every block between current proposal and proposals source;
+            // if the source exists
+            let source_refs: Vec<String> = match source_vtx {
+                Some(vtx) => bulldag.trace(&vtx, Direction::Reference),
+                None => {
+                    vec![]
+                },
+            };
+
+            // Get all the vertices corresponding to the references to the
+            // proposal blocks source. This will include other proposal blocks
+            // between the ProposalBlock's source and the current round.
+            // Will need to filter to only retain the convergence blocks
+            let ref_vertices: Vec<Option<&Vertex<Block, String>>> = {
+                source_refs
+                    .iter()
+                    .map(|idx| chain.get_vertex(idx.to_string())).collect()
+            };
+
+            // Initialize a stack to save ConvergenceBlock vertices to
+            // This will where all the ConvergenceBlocks between the
+            // Source of ProposalBlock and the current round will be stored
+            // and returned to check for conflicts.
+            let mut stack = vec![];
+
+            // Iterate through the ref_vertices vector
+            // Check whether the ref_vertex is Some or None
+            // If it is Some, get the data from the Vertex and
+            // match the Block variant
+            // If the block variant is a convergence block add it to the stack
+            // otherwise ignore it
+            ref_vertices.iter().for_each(|opt| {
+                if let Some(vtx) = opt {
+                    match vtx.get_data() {
+                        Block::Convergence { block } => stack.push(block),
+                        _ => {},
+                    }
+                }
+            });
+
+            return &stack;
+        }
+
+        return &vec![]
+    }
+
+    /// Splits proposal blocks into two different proposal blocks
+    /// proposal blocks which has a source convergence block that is 
+    /// equal to miner.last_block, and proposal blocks with earlier 
+    /// round source convergence blocks. 
+    fn split_proposals_by_round<I>(&self, proposals: &I) -> (I, I) 
+    where 
+        I: IntoIterator<Item = Self::ProposalInner>
+    {
+        let (mut curr, mut prev) = (Vec::new(), Vec::new());
+        for block in proposals {
+            if block.is_current_round(round) {
+                curr.push(block.clone());
+            } else {
+                prev.push(block.clone());
+            }
+        }
+        (curr.clone(), prev.clone())
+    } 
+
+    fn get_proposers<I>(&self, proposals: &I) -> Vec<Self::BallotInfo> 
+    where 
+        I: IntoIterator<Item = Self::ProposalInner>
+    {
+        proposals.iter()
+            .map(|block| (block.from.clone(), block.hash.clone()))
+            .collect()
+    }
+
+    fn append_winner(
+        &self, 
+        conflicts: &mut Self::Identified, 
+        election_results: &mut BTreeMap<U256, Self::BallotInfo>
+    ) {
+        conflicts.iter_mut().for_each(|(_, conflict)| {
+            election_results.retain(|(election_results, (claim, ref_hash))| {
+                conflict
+                    .proposers
+                    .contains(&(claim.clone(), ref_hash.clone()))
+            });
+
+            // select the first pointer sum and extract the proposal block
+            // hash from the pointer sum
+            let winner = {
+
+                let mut first: Option<U256, Self::BallotInfo> = election_results.pop_first();
+                while let None = first {
+                    first = local_pointers.pop_first();
+                }
+
+                first
+            };
+            // save it as the conflict winner
+            if let Some((res, (claim, ref_hash))) = winner {
+                conflict.winner = Some(ref_hash);
+            }
+        });
+    }
+
+    fn resolve_current<I>(&self, current: &mut I, conflicts: Self::Identified) 
+    where
+        I: IntoIterator<Item = Self::ProposalInner>
+    {
+        current.iter_mut().for_each(|block| {
+            // Clone conflicts into a mutable variable
+            let mut local_conflicts = conflicts.clone();
+
+            // retain only the conflicts that relate to current proposal block
+            local_conflicts.retain(|id, _| block.txns.contains_key(id));
+
+            // convert filtered conflicts into an iterator
+            let mut conflict_iter = local_conflicts.iter();
+
+            // initialize a hashset to save transactions that current block
+            // proposer lost conflict resolution.
+            let mut removals = HashSet::new();
+
+            // loop through all the conflicts related to current block
+            // and check if the winner is the current block hash
+            while let Some((id, conflict)) = conflict_iter.next() {
+                if Some(block.hash.clone()) != conflict.winner {
+                    // if it does insert into removals, otherwise ignore
+                    removals.insert(id.to_string());
+                }
+            }
+
+            // remove transactions for which current block lost conflict
+            // resolution from the current block
+            block.txns.retain(|id, _| !removals.contains(id));
+        });
+    }
+}

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -55,31 +55,121 @@ impl<'a> BlockBuilder for Miner<'a> {
     /// been referenced. We need to add this functionality so that 
     /// blocks don't get "orphaned"
     fn get_references(&self) -> Option<Vec<Self::RefType>> {
-        let last_block = self.last_block.clone();
-        if let Some(last_block) = last_block {
-            let idx = last_block.get_hash();
+        if let Ok(bulldag) = self.dag.read() {
+            if let Some(vtx) = self.get_last_block_vertex(None) {
+                let p_ids = vtx.get_references();
+                let mut proposals = Vec::new();
+                p_ids.iter().for_each(|idx| {
+                if let Some(vtx) = bulldag.get_vertex(idx.to_string()) {
+                    match vtx.get_data() {
+                        Block::Proposal { ref block } => {
+                            proposals.push(block.clone());
+                        },
+                        _ => {}
+                    }
+                }});
+                
+                let orphans = self.get_orphaned_references(
+                    vtx.get_index(), 
+                    0, 
+                    5
+                );
+                proposals.extend(orphans);
+                return Some(proposals)
+            } 
+        }
+
+        return None
+    }
+
+    /// Gets all the orphaned ProposalBlocks from the past n rounds.
+    fn get_orphaned_references(
+        &self, 
+        idx: RefHash, 
+        current_round: usize, 
+        n_rounds: usize
+    ) -> Vec<Self::RefType> {
+
+        let source_cbs = self.get_n_rounds_convergence(idx, current_round, n_rounds);
+        let mut orphaned = vec![];
+
+        source_cbs.iter().for_each(|ref_hash| {
+            if let Ok(guard) = self.dag.read() {
+                if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
+                    let references = vtx.get_references();
+                    for ref_hash in references {
+                        if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
+                            if let Block::Proposal { block } = vtx.get_data() { 
+                                if vtx.get_references().len() == 0 {
+                                    orphaned.push(block.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        orphaned
+    }
+
+    /// Gets the ConvegenceBlock from the past n rounds.
+    fn get_n_rounds_convergence(&self, idx: RefHash, current_round: usize, n_rounds: usize) -> HashSet<RefHash> {
+        if current_round > n_rounds {
+            return HashSet::new() 
+        }
+
+        let mut source_cbs = HashSet::new();
+        
+        if let Ok(guard) = self.dag.read() {
+            if let Some(vtx) = guard.get_vertex(idx) {
+                if let Block::Convergence { .. } = vtx.get_data() {
+                    let sources = vtx.get_sources();
+                    sources.iter().for_each(|ref_hash| {
+                        if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
+                            if let Block::Proposal { .. } = vtx.get_data() {
+                                let sources = vtx.get_sources();
+                                for source in sources {
+                                    source_cbs.insert(source.to_string());
+                                }
+                            }
+                        }
+                    });
+
+                    source_cbs.iter().for_each(|ref_hash| {
+                        source_cbs.extend(
+                            self.get_n_rounds_convergence(
+                                ref_hash.clone().to_string(), current_round + 1, n_rounds
+                            )
+                        )
+                    });
+                }
+            }
+        }
+        
+        return source_cbs 
+    }
+
+    /// Gets the vertex from the last Convergence (or Genesis) block.
+    fn get_last_block_vertex(&self, idx: Option<RefHash>) -> Option<Vertex<Block, String>> {
+        if let Some(idx) = idx {
             if let Ok(bulldag) = self.dag.read() {
                 if let Some(vtx) = bulldag.get_vertex(idx) {
-                    let p_ids = vtx.get_references();
-                    let mut proposals = Vec::new();
-                    p_ids.iter().for_each(|idx| {
-                        if let Some(vtx) = bulldag.get_vertex(idx.to_string()) {
-                            match vtx.get_data() {
-                                Block::Proposal { ref block } => {
-                                    proposals.push(block.clone());
-                                },
-                                _ => {}
-                            }
-                    }});
-                    return Some(proposals)
-                } else {
-                    return None
+                    return Some(vtx.clone())
                 }
-            } else {
-                return None 
+            }
+        } else {
+            let last_block = self.last_block.clone();
+            if let Some(last_block) = last_block {
+                let idx = last_block.get_hash();
+                if let Ok(bulldag) = self.dag.read() {
+                    if let Some(vtx) = bulldag.get_vertex(idx) {
+                        return Some(vtx.clone())
+                    }
+                }
+            }
         }
-    }
-    None
+        None
     }
 }
 

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -1,0 +1,515 @@
+#![cfg(test)]
+use std::sync::{Arc, RwLock};
+
+use block::{
+    invalid::InvalidBlockErrorReason,
+    Block,
+    GenesisBlock,
+    ProposalBlock,
+    TxnList, ConvergenceBlock, InnerBlock,
+};
+use bulldag::{graph::BullDag, vertex::Vertex};
+use primitives::{Address, PublicKey, SecretKey, Signature};
+use ritelinked::LinkedHashMap;
+use secp256k1::Message;
+use sha2::{Digest, Sha256};
+use vrrb_core::{
+    claim::Claim,
+    helpers::size_of_txn_list,
+    keypair::Keypair,
+    txn::{NewTxnArgs, Txn, TransactionDigest, generate_txn_digest_vec},
+};
+
+use crate::{Miner, MinerConfig, result::MinerError};
+
+/// Move this into primitives and call it simply `BlockDag`
+pub type MinerDag = Arc<RwLock<BullDag<Block, String>>>;
+
+/// Helper function to create a random Miner.
+pub(crate) fn create_miner() -> Miner<'static> {
+    let (secret_key, public_key) = create_keypair();
+    let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
+
+    let config = MinerConfig {
+        secret_key,
+        public_key,
+        dag,
+    };
+
+    Miner::new(config)
+}
+
+/// Helper function to create a miner from a `Keypair`
+pub(crate) fn create_miner_from_keypair(kp: &Keypair) -> Miner<'static> {
+    let (secret_key, public_key) = kp.miner_kp;
+    let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
+    
+    let config = MinerConfig {
+        secret_key,
+        public_key,
+        dag
+    };
+
+    Miner::new(config)
+}
+
+pub(crate) fn create_miner_from_keypair_return_dag(kp: &Keypair) -> (Miner<'static>, MinerDag) {
+    let miner = create_miner_from_keypair(kp);
+    (miner.clone(), miner.dag.clone())
+}
+
+pub(crate) fn create_miner_from_keypair_and_dag(kp: &Keypair, dag: MinerDag) -> Miner<'static> {
+    let mut miner = create_miner_from_keypair(kp);
+    miner.dag = dag;
+    miner
+}
+
+/// Helper function to create a `MinerKeypair` which is 
+/// simply `(SecretKey, PublicKey)`
+pub(crate) fn create_keypair() -> (SecretKey, PublicKey) {
+    let kp = Keypair::random();
+    kp.miner_kp
+}
+
+/// Helper function to create an address from a `&PublicKey`
+pub(crate) fn create_address(pubkey: &PublicKey) -> Address {
+    Address::new(pubkey.clone())
+}
+
+/// Helper function to create a claim from a `&PublicKey` and 
+/// `&Address`
+pub(crate) fn create_claim(pk: &PublicKey, addr: &Address) -> Claim {
+    Claim::new(pk.to_string(), addr.to_string())
+}
+
+/// Helper function to create a random message and signature 
+/// returning `(Message, Keypair, Signature)`
+pub(crate) fn create_and_sign_message() -> (Message, Keypair, Signature) {
+    let kp = Keypair::random();
+    let message = b"Test Message";
+    let msg = {
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(message);
+        let message = hasher.finalize();
+        Message::from_slice(&message[..]).unwrap()
+    };
+
+    let sig = kp.miner_kp.0.sign_ecdsa(msg);
+
+    return (msg, kp, sig)
+
+}
+
+/// Helper function to mine a `GenesisBlock` and 
+/// return an `Option<GenesisBlock>`
+/// This is currently using a deprecated method 
+/// `miner.mine_genesis_block` will be removed soon 
+/// and replaced by a different method.
+pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
+    let miner = create_miner();
+
+    let claim = miner.generate_claim();
+
+    let claim_list = {
+        vec![(claim.public_key.clone(), claim.clone())]
+            .iter()
+            .cloned()
+            .collect()
+    };
+
+    miner.mine_genesis_block(claim_list)
+}
+
+/// Helper function to create `n` number of `Txn` and 
+/// return an `Iterator` of `(TransactionDigest, Txn)`
+/// to be collected by the caller.
+pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
+    (0..n)
+        .map(|n| {
+            let (sk, pk) = create_keypair();
+            let raddr = "0x192abcdef01234567890".to_string();
+            let saddr = create_address(&pk);
+            let amount = (n.pow(2)) as u128;
+            let token = None;
+
+            let txn_args = NewTxnArgs {
+                timestamp: 0,
+                sender_address: saddr.to_string(),
+                sender_public_key: pk.clone(),
+                receiver_address: raddr,
+                token,
+                amount,
+                signature: sk.sign_ecdsa(Message::from_hashed_data::<
+                    secp256k1::hashes::sha256::Hash,
+                >(b"vrrb")),
+                validators: None,
+                nonce: n.clone() as u128,
+            };
+
+            let mut txn = Txn::new(txn_args);
+
+            txn.sign(&sk);
+
+            let txn_digest_vec = generate_txn_digest_vec(
+                txn.timestamp, 
+                txn.sender_address.clone(), 
+                txn.sender_public_key.clone(), 
+                txn.receiver_address.clone(), 
+                txn.token.clone(), 
+                txn.amount, 
+                txn.nonce
+            ); 
+
+            let digest = TransactionDigest::from(txn_digest_vec);
+
+            (digest, txn)
+        })
+        .into_iter()
+}
+
+/// Helper function to create `n` number of `Claim`s and 
+/// return an `Iterator` of `(String, Claim)` to be collected 
+/// by the caller
+pub(crate) fn create_claims(n: usize) -> impl Iterator<Item = (String, Claim)> {
+    (0..n)
+        .map(|_| {
+            let (_, pk) = create_keypair();
+            let addr = create_address(&pk);
+            let claim = create_claim(&pk, &addr);
+            (claim.public_key.clone(), claim)
+        })
+        .into_iter()
+}
+
+/// A helper function to build a `ProposalBlock`. This function has been 
+/// deprecated and replaced by the `build_single_proposal_block` function
+#[deprecated(note = "use `build_single_proposal_block` function instead")]
+pub(crate) fn build_proposal_block(
+    ref_hash: &String,
+    n_tx: usize,
+    n_claims: usize,
+    round: u128,
+    epoch: u128,
+) -> Result<ProposalBlock, InvalidBlockErrorReason> {
+    let txns: TxnList = create_txns(n_tx).collect();
+
+    let claims = create_claims(n_claims).collect();
+
+    let miner = create_miner();
+
+    let prop_block =
+        miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims);
+
+    let total_txns_size = size_of_txn_list(&txns);
+
+    if total_txns_size > 2000 {
+        return Err(InvalidBlockErrorReason::InvalidBlockSize);
+    }
+
+    return prop_block;
+}
+
+/// A helper function to attempt to mine a `ConvergenceBlock`
+/// with a random `miner`
+pub(crate) fn mine_convergence_block() -> Result<Block, MinerError> {
+    let mut miner = create_miner();
+    miner.try_mine()
+}
+
+/// A helper function to attempt to mine a `ConvergenceBlock`
+/// that signals a change in `Epoch` i.e. a block 
+/// with a `round % Epoch == 0`
+pub(crate) fn mine_convergence_block_epoch_change(
+) -> Result<Block, MinerError> {
+    let mut miner = create_miner();
+    //TODO: Add Mock Convergence Block with round height of 29.999999mm
+    miner.try_mine()
+}
+
+/// A helper function that creates a `Miner` and returns both the 
+/// `Miner` and the `MinerDag`
+pub(crate) fn create_miner_return_dag() -> (Miner<'static>, MinerDag) {
+    let mut miner = create_miner();
+    let dag = miner.dag.clone();
+
+    (miner, dag)
+}
+
+/// A helper function that creates a random `Miner` and provides 
+/// an existing `MinerDag` to replace the default one in the 
+/// `Miner`. Returns both the `Miner` and the `MinerDag`
+pub(crate) fn create_miner_from_dag(dag: &MinerDag) -> (Miner<'static>, MinerDag) {
+    let mut miner = create_miner();
+    miner.dag = dag.clone(); 
+
+    (miner, dag.clone())
+}
+
+/// A helper function to build a single `ProposalBlock` and return it.
+pub(crate) fn build_single_proposal_block(
+    last_block_hash: String,
+    n_txns: usize, 
+    n_claims: usize,
+    round: u128,
+    epoch: u128,
+    from: Claim,
+    sk: SecretKey,
+) -> ProposalBlock {
+    let txns = create_txns(n_txns).collect();
+    let claims = create_claims(n_claims).collect();
+    ProposalBlock::build(
+        last_block_hash,
+        round,
+        epoch,
+        txns,
+        claims,
+        from,
+        sk 
+    )
+}
+
+/// A helper function to build `n` number of porposal blocks 
+/// from random `Claim`s and return a `Vec<ProposalBlock>` 
+pub(crate) fn build_multiple_proposal_blocks_single_round(
+    n_blocks: usize,
+    last_block_hash: String,
+    n_txns: usize,
+    n_claims: usize,
+    round: u128,
+    epoch: u128,
+) -> Vec<ProposalBlock> {
+    
+    (0..n_blocks).into_iter().map(|n| {
+
+        let keypair = Keypair::random();
+        let address = Address::new(keypair.miner_kp.1.clone());
+        let claim = Claim::new(keypair.miner_kp.1.clone().to_string(), address.to_string());
+        let prop = build_single_proposal_block(
+            last_block_hash.clone(), 
+            n_txns, 
+            n_claims, 
+            round, 
+            epoch, 
+            claim, 
+            keypair.miner_kp.0.clone()
+        );
+        prop
+    }).collect()
+}
+
+/// A recursive helper function that takes in a mutable 
+/// `MinerDag` and some information regarding the number 
+/// of rounds, number of blocks (`ProposalBlock`) per round 
+/// The current round (as a mutable reference), and the epoch,
+/// as well as the `last_block_hash` which is either 
+/// the hash of the `GenesisBlock` or a hash of the most recent 
+/// `ConvergenceBlock`
+///
+/// The function checks whether the current `round` that it is 
+/// building is less than the number of rounds (`n_rounds`) the 
+/// caller is asking for. 
+///
+/// If so, then it stops, otherwise it proceeds with the following logic:
+///     
+///     Check if the DAG has a GenesisBlock.
+///
+///         If so: 
+///             Mine a ConvergenceBlock and append it to the MinerDag 
+///             referencing the previous round ProposalBlocks
+///
+///             Add 1 to the round
+///
+///             Build ProposalBlocks that reference the new ConvergenceBlock. 
+///
+///             Append the new ProposalBlocks to the DAG referencing 
+///             the most recent ConvergenceBlock.
+///
+///             Recursively calls itself passing in the most recent 
+///             ConvergenceBlock hash as the `last_block_hash` and the 
+///             updated round, as well as the rest of the information.
+///
+///        Otherwise:
+///             Add a genesis block, and a single, random, empty ProposalBlock 
+///             to the DAG as the root vertex and first leaf the two make
+///             up the first edge.
+///
+///             Add 1 to the round
+///
+///             Recursively calls itself passing in the GenesisBlock hash 
+///             as the last_block_hash and the updated round as the 
+///             round, as well as all the other data.
+pub(crate) fn build_multiple_rounds(
+    dag: &mut MinerDag,
+    last_block_hash: String, 
+    n_blocks: usize, 
+    n_txns: usize,
+    n_claims: usize,
+    n_rounds: usize,
+    round: &mut usize,
+    epoch: usize,
+) {
+    if n_rounds > round.clone() {
+        if dag_has_genesis(&mut dag.clone()) {
+            if let Some(hash) = mine_next_convergence_block(&mut dag.clone()) {
+                *round += 1usize;
+                let proposals = build_multiple_proposal_blocks_single_round(
+                    n_blocks, hash.clone(), n_txns, n_claims, round.clone() as u128, epoch as u128
+                );
+                append_proposal_blocks_to_dag(&mut dag.clone(), proposals);
+                build_multiple_rounds(
+                    &mut dag.clone(), hash, n_blocks, n_txns,
+                    n_claims, n_rounds, round, epoch,
+                );
+            };
+            
+        } else {
+            if let Some(hash) = add_genesis_to_dag(&mut dag.clone()) {
+                *round += 1usize;
+                build_multiple_rounds(
+                    &mut dag.clone(), hash, n_blocks, n_txns, 
+                    n_claims, n_rounds, round, epoch
+                );
+            }
+        }
+    }
+}
+
+/// Checks whether the DAG already has a root vertex
+/// returns true if so, false if not
+pub(crate) fn dag_has_genesis(dag: &mut MinerDag) -> bool {
+    dag.read().unwrap().len() > 0
+}
+
+/// build and adds a `GenesisBlock` to the `MinerDag` 
+/// returns the `Some(hash)` if successful otherwise returns None
+pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
+    let mut prop_vertices = Vec::new();
+    let genesis = mine_genesis();
+    let keypair = Keypair::random();
+    let miner = create_miner_from_keypair(&keypair);
+
+    if let Some(genesis) = genesis {
+        let gblock = Block::Genesis { block: genesis.clone() };
+        let gvtx: Vertex<Block, String> = gblock.into();
+        let prop1 = ProposalBlock::build(
+            genesis.hash.clone(),
+            0,
+            0,
+            LinkedHashMap::new(),
+            LinkedHashMap::new(),
+            miner.claim.clone(),
+            keypair.miner_kp.0.clone()
+        );
+        let pblock = Block::Proposal { block: prop1.clone() };
+        let pvtx: Vertex<Block, String> = pblock.into(); 
+        prop_vertices.push(pvtx.clone());
+        if let Ok(mut guard) = dag.write() {
+            let edge = (&gvtx, &pvtx);
+            guard.add_edge(edge);
+            return Some(genesis.get_hash().clone())
+        }
+    }
+    None
+}
+
+/// Mines the next `ConvergenceBlock` in the `MinerDag`
+/// Returns `Some(hash)` if successful otherwise returns `None`
+pub(crate) fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> {
+    let keypair = Keypair::random();
+    let mut miner = create_miner_from_keypair(&keypair);
+    miner.dag = dag.clone();
+    if let Ok(cblock) = miner.try_mine() {
+        if let Block::Convergence { ref block } = cblock.clone() {
+            let cvtx: Vertex<Block, String> = cblock.into();
+            let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![]; 
+            if let Ok(guard) = dag.read() {
+                block.clone().get_ref_hashes().iter().for_each(|t| {
+                    if let Some(pvtx) = guard.get_vertex(t.clone()) {
+                        edges.push((pvtx.clone(), cvtx.clone()));
+                    }
+                });
+            }
+
+            if let Ok(mut guard) = dag.write() {
+                let edges = edges.iter().map(|(source, reference)| {
+                    (source, reference)
+                }).collect();
+                guard.extend_from_edges(edges);
+                return Some(block.get_hash())
+            }
+        }
+    }
+
+    None
+}
+
+/// Appends `ProposalBlock`s to the `MinerDag`
+pub(crate) fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
+    let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
+    for block in proposals.iter() {
+        let ref_hash = block.ref_block.clone();
+        if let Ok(guard) = dag.read() {
+            if let Some(cvtx) = guard.get_vertex(ref_hash) {
+                let pblock = Block::Proposal { block: block.clone() };
+                let pvtx: Vertex<Block, String> = pblock.into();
+                let edge = (cvtx.clone(), pvtx.clone());
+                edges.push(edge);
+            }
+        }
+    }
+
+    let edges: Vec<(&Vertex<Block, String>, &Vertex<Block, String>)> = edges.iter().map(|(source, reference)| {
+        (source, reference)
+    }).collect();
+
+    if let Ok(mut guard) = dag.write() {
+        guard.extend_from_edges(edges);
+    }
+}
+
+/// Builds 2 `ProposalBlock`s which contain 5 of the same `Txn`s 
+/// this is used to test conflict resolution mechanism of the `Miner`
+pub(crate) fn build_conflicting_proposal_blocks(
+    last_block_hash: String,
+    round: u128,
+    epoch: u128,
+) -> (ProposalBlock, ProposalBlock) {
+    let txns: LinkedHashMap<TransactionDigest, Txn> = create_txns(5).collect();
+    let prop1 = build_single_proposal_block_from_txns(
+        last_block_hash.clone(), txns.clone(), round, epoch
+    );  
+
+    let prop2 = build_single_proposal_block_from_txns(
+        last_block_hash, txns, round, epoch
+    );
+
+    (prop1, prop2)
+
+}
+
+/// Builds a single `ProposalBlock` and extends the `TxnList` of the 
+/// `ProposalBlock` with transactions provided in the function call.
+pub(crate) fn build_single_proposal_block_from_txns(
+    last_block_hash: String, 
+    txns: impl IntoIterator<Item = (TransactionDigest, Txn)>,
+    round: u128,
+    epoch: u128,
+) -> ProposalBlock {
+    
+    let kp = Keypair::random();
+    let miner = create_miner_from_keypair(&kp);
+    let mut prop = build_single_proposal_block(
+        last_block_hash, 
+        5, 
+        4, 
+        round, 
+        epoch, 
+        miner.claim, 
+        kp.miner_kp.0
+    );
+
+    prop.txns.extend(txns);
+
+    prop
+
+}

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-secp256k1 = { version = "0.25.0", features = ["rand", "bitcoin-hashes"] }
-sha256 = "1.0.2"
-chrono = "0.4.23"
+secp256k1 = { workspace = true }
+sha2 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/utils/src/payload.rs
+++ b/crates/utils/src/payload.rs
@@ -1,9 +1,3 @@
-#![allow(unused_imports)]
-use secp256k1::{
-    hashes::{sha256 as s256, Hash},
-    Message,
-};
-
 #[macro_export]
 macro_rules! create_payload {
     ($($x:expr),*) => {{

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -6,9 +6,8 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use sha2::{Sha256, Digest};
 use ethereum_types::U256;
-use sha256::digest;
 
-use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable, keypair::Keypair};
+use crate::{ownable::Ownable, verifiable::Verifiable, keypair::Keypair};
 
 /// A custom error type for invalid claims that are used/attempted to be used
 /// in the mining of a block.
@@ -51,6 +50,10 @@ impl Claim {
             // collects threshold of votes on its validity
             eligible: true,
         }
+    }
+
+    pub fn get_ballot_info(&self) -> (U256, Claim) {
+        (self.hash, self.clone())
     }
 
     /// Uses XOR of the ClaimHash as a U256 against a block seed of u64

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -161,12 +161,13 @@ impl Verifiable for Claim {
         true
     }
 
-    #[allow(unused_variables)]
     fn valid(
         &self,
         item: &Self::Item,
         dependancies: &Self::Dependencies,
     ) -> Result<bool, InvalidClaimError> {
+        let _ = item;
+        let _ = dependancies;
         Ok(true)
     }
 }

--- a/crates/vrrb_core/src/helpers.rs
+++ b/crates/vrrb_core/src/helpers.rs
@@ -5,7 +5,7 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use ritelinked::LinkedHashMap;
 use secp256k1::generate_keypair;
 
-use crate::{txn::Txn, Error};
+use crate::{txn::{Txn, TransactionDigest}, Error};
 
 pub fn gen_hex_encoded_string<T: AsRef<[u8]>>(data: T) -> String {
     hex::encode(data)
@@ -32,7 +32,7 @@ macro_rules! is_enum_variant {
     };
 }
 
-pub fn size_of_txn_list(txns: &LinkedHashMap<String, Txn>) -> usize {
+pub fn size_of_txn_list(txns: &LinkedHashMap<TransactionDigest, Txn>) -> usize {
     txns.iter()
         .map(|(_, set)| set)
         .map(|txn| std::mem::size_of_val(&txn))

--- a/crates/vrrb_core/src/ledger.rs
+++ b/crates/vrrb_core/src/ledger.rs
@@ -1,10 +1,10 @@
 use ritelinked::LinkedHashMap;
 use serde::{Deserialize, Serialize};
 
-use crate::{claim::Claim, nonceable::Nonceable, ownable::Ownable};
+use crate::{claim::Claim, ownable::Ownable};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Ledger<C: Clone + Ownable + Nonceable + Serialize> {
+pub struct Ledger<C: Clone + Ownable + Serialize> {
     pub credits: LinkedHashMap<String, u128>,
     pub debits: LinkedHashMap<String, u128>,
     pub claims: LinkedHashMap<String, C>,


### PR DESCRIPTION
Currently miner still does conflict resolution internally. 

We will want to shift this off to the ElectionModule but for now to keep the PR small and clean, we just:

- refactored it to make sure it works with updated Proof of Claim 

- can request and receive the DAG from the blockchain module by emitting an event to send as a request for the DAG, 

- can extract the last_block's references from the DAG (i.e. the proposal blocks from the current round), 

- and to resolve any conflicts among proposal blocks, both inter and intraround, 

- and build a convergence block which can be emitted to the harvesters for certification. 

We will also need to add some additional Event handling for the mining_module handler method to handle the events, and will need to add some new Event variants to use in this flow