### PR TITLE
Implement Election runtime module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,6 @@ laminar = "0.5.0"
 futures = { version = "0.3.24", features = ["thread-pool"] }
 qp2p = "0.30.0"
 
-
 [dev-dependencies]
 cuckoofilter.workspace = true
 reqwest.workspace = true

--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -27,3 +27,4 @@ bulldag = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
+ethereum-types = { workspace = true }

--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -26,3 +26,4 @@ vrrb_vrf = { workspace = true }
 bulldag = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
+tokio = { workspace = true }

--- a/crates/block/src/block.rs
+++ b/crates/block/src/block.rs
@@ -1,5 +1,6 @@
 // This file contains code for creating blocks to be proposed, including the
 // genesis block and blocks being mined.
+#![allow(unused_imports)]
 
 use std::fmt;
 
@@ -72,21 +73,21 @@ impl Block {
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|(txn)| std::mem::size_of_val(&txn))
+                .map(|txn| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
 
             Block::Proposal { block } => block
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|(txn)| std::mem::size_of_val(&txn))
+                .map(|txn| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
 
             Block::Genesis { block } => block
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|(txn)| std::mem::size_of_val(&txn))
+                .map(|txn| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
         }
     }

--- a/crates/block/src/block.rs
+++ b/crates/block/src/block.rs
@@ -45,6 +45,7 @@ pub trait InnerBlock: std::fmt::Debug {
     fn get_next_block_reward(&self) -> Self::RewardType;
     fn is_genesis(&self) -> bool;
     fn get_hash(&self) -> String;
+    fn get_ref_hashes(&self) -> Vec<String>;
     fn into_static_convergence(&self) -> Option<ConvergenceBlock>;
     fn into_static_genesis(&self) -> Option<GenesisBlock>;
 }
@@ -157,6 +158,10 @@ impl InnerBlock for ConvergenceBlock {
     fn into_static_genesis(&self) -> Option<GenesisBlock> {
         None
     }
+
+    fn get_ref_hashes(&self) -> Vec<String> {
+        self.header.ref_hashes.clone()
+    }
 }
 
 impl InnerBlock for GenesisBlock {
@@ -189,6 +194,10 @@ impl InnerBlock for GenesisBlock {
     
     fn into_static_genesis(&self) -> Option<GenesisBlock> {
         Some(self.clone())
+    }
+
+    fn get_ref_hashes(&self) -> Vec<String> {
+        self.header.ref_hashes.clone()
     }
 }
 

--- a/crates/block/src/block.rs
+++ b/crates/block/src/block.rs
@@ -1,9 +1,10 @@
 // This file contains code for creating blocks to be proposed, including the
 // genesis block and blocks being mined.
-#![allow(unused_imports)]
+
 
 use std::fmt;
 
+use bulldag::vertex::Vertex;
 use primitives::{Epoch, SecretKey as SecretKeyBytes};
 use reward::reward::Reward;
 #[cfg(mainnet)]
@@ -35,7 +36,7 @@ use crate::{
     ProposalBlock,
 };
 
-pub trait InnerBlock {
+pub trait InnerBlock: std::fmt::Debug {
     type Header;
     type RewardType;
 
@@ -44,6 +45,8 @@ pub trait InnerBlock {
     fn get_next_block_reward(&self) -> Self::RewardType;
     fn is_genesis(&self) -> bool;
     fn get_hash(&self) -> String;
+    fn into_static_convergence(&self) -> Option<ConvergenceBlock>;
+    fn into_static_genesis(&self) -> Option<GenesisBlock>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -73,21 +76,21 @@ impl Block {
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|txn| std::mem::size_of_val(&txn))
+                .map(|(txn)| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
 
             Block::Proposal { block } => block
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|txn| std::mem::size_of_val(&txn))
+                .map(|(txn)| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
 
             Block::Genesis { block } => block
                 .txns
                 .iter()
                 .map(|(_, set)| set)
-                .map(|txn| std::mem::size_of_val(&txn))
+                .map(|(txn)| std::mem::size_of_val(&txn))
                 .fold(0, |acc, item| acc + item),
         }
     }
@@ -146,6 +149,14 @@ impl InnerBlock for ConvergenceBlock {
     fn get_hash(&self) -> String {
         self.hash.clone()
     }
+
+    fn into_static_convergence(&self) -> Option<ConvergenceBlock> {
+        Some(self.clone())
+    }
+    
+    fn into_static_genesis(&self) -> Option<GenesisBlock> {
+        None
+    }
 }
 
 impl InnerBlock for GenesisBlock {
@@ -170,5 +181,29 @@ impl InnerBlock for GenesisBlock {
 
     fn get_hash(&self) -> String {
         self.hash.clone()
+    }
+
+    fn into_static_convergence(&self) -> Option<ConvergenceBlock> {
+        None
+    }
+    
+    fn into_static_genesis(&self) -> Option<GenesisBlock> {
+        Some(self.clone())
+    }
+}
+
+impl From<Block> for Vertex<Block, String> {
+    fn from(item: Block) -> Vertex<Block, String> {
+        match item {
+            Block::Convergence { ref block } => {
+                return Vertex::new(item.clone(), block.hash.clone());
+            },
+            Block::Proposal { ref block } => {
+                return Vertex::new(item.clone(), block.hash.clone());
+            },
+            Block::Genesis { ref block } => {
+                return Vertex::new(item.clone(), block.hash.clone());
+            }
+        }
     }
 }

--- a/crates/block/src/convergence_block.rs
+++ b/crates/block/src/convergence_block.rs
@@ -35,6 +35,7 @@ use vrrb_core::{
     txn::Txn,
     verifiable::Verifiable,
 };
+use vrrb_core::txn::TransactionDigest;
 
 #[cfg(mainnet)]
 use crate::genesis;
@@ -53,7 +54,6 @@ use crate::{
     GenesisBlock,
     ProposalBlock,
     RefHash,
-    TxnId,
 };
 
 pub struct MineArgs<'a> {
@@ -88,7 +88,7 @@ impl ConvergenceBlock {
         self.certificate = Some(cert);
     }
 
-    pub fn txn_id_set(&self) -> LinkedHashSet<&TxnId> {
+    pub fn txn_id_set(&self) -> LinkedHashSet<&TransactionDigest> {
         self.txns.iter().flat_map(|(_, set)| set).collect()
     }
 }

--- a/crates/block/src/convergence_block.rs
+++ b/crates/block/src/convergence_block.rs
@@ -1,54 +1,21 @@
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, HashSet},
-    fmt,
-};
-
-use bulldag::{
-    graph::BullDag,
-    index::Index,
-    vertex::{Direction, Vertex},
-};
 use primitives::{
     Epoch,
-    RawSignature,
     SecretKey as SecretKeyBytes,
-    GENESIS_EPOCH,
-    SECOND,
-    VALIDATOR_THRESHOLD,
 };
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;
-use reward::reward::{Reward, NUMBER_OF_BLOCKS_PER_EPOCH};
+use reward::reward::Reward;
 use ritelinked::{LinkedHashMap, LinkedHashSet};
-use secp256k1::{
-    hashes::{sha256 as s256, Hash},
-    Message,
-};
 use serde::{Deserialize, Serialize};
-use sha256::digest;
-use utils::{create_payload, hash_data};
-use vrrb_core::{
-    accountable::Accountable,
-    claim::Claim,
-    keypair::KeyPair,
-    txn::Txn,
-    verifiable::Verifiable,
-};
-use vrrb_core::txn::TransactionDigest;
+use vrrb_core::{claim::Claim, txn::{Txn, TransactionDigest}};
 
 #[cfg(mainnet)]
 use crate::genesis;
 use crate::{
-    genesis,
     header::BlockHeader,
-    invalid::{BlockError, InvalidBlockErrorReason},
     Block,
     BlockHash,
     Certificate,
-    ClaimHash,
-    Conflict,
-    ConflictList,
     ConsolidatedClaims,
     ConsolidatedTxns,
     GenesisBlock,

--- a/crates/block/src/genesis.rs
+++ b/crates/block/src/genesis.rs
@@ -1,13 +1,6 @@
-#![allow(unused_imports)]
-use primitives::SecretKey as SecretKeyBytes;
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;
-use ritelinked::LinkedHashMap;
-use secp256k1::{hashes::Hash, SecretKey};
 use serde::{Deserialize, Serialize};
-use sha256::digest;
-use utils::{create_payload, hash_data};
-use vrrb_core::claim::Claim;
 
 #[cfg(mainnet)]
 use crate::genesis;

--- a/crates/block/src/genesis.rs
+++ b/crates/block/src/genesis.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use primitives::SecretKey as SecretKeyBytes;
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;

--- a/crates/block/src/header.rs
+++ b/crates/block/src/header.rs
@@ -153,7 +153,7 @@ impl BlockHeader {
 
         // Get current epoch which is the same as last epoch unless it's an
         // epoch change block.
-        let epoch = last_block.get_header().epoch;
+        let epoch = block_reward.epoch;
         // Get the reward for current block which is last_block.round + 1
         let round = last_block.get_header().round + 1;
 

--- a/crates/block/src/header.rs
+++ b/crates/block/src/header.rs
@@ -1,24 +1,20 @@
 // FEATURE TAG(S): Block Structure, Rewards
 use chrono;
-use primitives::{Epoch, SecretKey, SerializedSecretKey};
+use primitives::{Epoch, SecretKey};
 use reward::reward::Reward;
 use secp256k1::{
     hashes::{sha256 as s256, Hash},
     Message,
 };
 use serde::{Deserialize, Serialize};
-use sha256::digest;
 use utils::{create_payload, hash_data};
-use vrrb_core::{claim::Claim, keypair::KeyPair};
+use vrrb_core::claim::Claim;
 use vrrb_vrf::{vrng::VRNG, vvrf::VVRF};
 
 use crate::{
     block::Block,
-    ConvergenceBlock,
-    GenesisBlock,
     InnerBlock,
     NextEpochAdjustment,
-    ProposalBlock,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -54,19 +50,19 @@ impl BlockHeader {
         //TODO: Determine data fields to be used as message in VPRNG, must be
         // known/revealed within block but cannot be predictable or gameable.
         // Leading candidates are some combination of last_hash and last_block_seed
-        let ref_hashes = vec![hash_data!("Genesis_Ref_Hash")];
+        let ref_hashes = vec![format!("{:x}", hash_data!("Genesis_Ref_Hash".to_string()))];
         let message = {
-            hash_data!(ref_hashes, hash_data!("Genesis_Last_Hash"))
-                .as_bytes()
-                .to_vec()
+            let genesis_message = format!("{:x}", hash_data!("Genesis_Last_Hash".to_string()));
+            let hash = hash_data!(ref_hashes, genesis_message);
+            let hash_string = format!("{:x}", hash); 
+            hash_string.as_bytes().to_vec()
         };
 
         let mut vrf = VVRF::new(&message, &secret_key.secret_bytes().to_vec());
-
         let next_block_seed = vrf.generate_u64_in_range(u32::MAX as u64, u64::MAX);
 
         let timestamp = chrono::Utc::now().timestamp();
-        let txn_hash = hash_data!("Genesis_Txn_Hash");
+        let txn_hash = format!("{:x}", hash_data!("Genesis_Txn_Hash".to_string()));
         let block_reward = Reward::genesis(Some(miner_claim.address.clone()));
         let block_height = 0;
         let next_block_reward = Reward::default();
@@ -115,6 +111,8 @@ impl BlockHeader {
         adjustment_next_epoch: NextEpochAdjustment,
     ) -> Option<BlockHeader> {
         // Get the last block
+        let timestamp = chrono::Utc::now().timestamp();
+
         let last_block: &dyn InnerBlock<Header = BlockHeader, RewardType = Reward> = {
             match last_block {
                 Block::Convergence { ref block } => block,
@@ -133,7 +131,7 @@ impl BlockHeader {
         // last_block.certificate
         let message = {
             let hash = hash_data!(last_block.get_hash(), ref_hashes);
-            hash.as_bytes().to_vec()
+            hash
         };
 
         let sk_bytes = &secret_key.secret_bytes();
@@ -141,9 +139,6 @@ impl BlockHeader {
         // Generate next_block_seed
         let mut vrf = VVRF::new(&message, sk_bytes);
         let next_block_seed = vrf.generate_u64_in_range(u32::MAX as u64, u64::MAX);
-
-        // generate timestamp
-        let timestamp = chrono::Utc::now().timestamp();
 
         // Get current block reward, which is last_block.next_block_reward
         let mut block_reward = last_block.get_next_block_reward();

--- a/crates/block/src/proposal_block.rs
+++ b/crates/block/src/proposal_block.rs
@@ -10,6 +10,28 @@ use vrrb_core::{claim::Claim, txn::TransactionDigest};
 
 use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnList};
 
+/// A Block type that goes between two ConvergenceBlocks in the 
+/// VRRB Dag.
+///
+/// ```
+/// use serde::{Serialize, Deserialize};
+/// use block::{BlockHash, RefHash, TxnList};
+/// use primitives::Epoch;
+///
+/// #[derive(Clone, Debug, Serialize, Deserialize)]
+/// #[repr(C)]
+/// pub struct ProposalBlock {
+///     pub ref_block: RefHash;
+///     pub round: u128,
+///     pub epoch: Epoch,
+///     pub txns: TxnList,
+///     pub claims: ClaimList,
+///     pub from: Claim,
+///     pub hash: BlockHash,
+///     pub signature: String,
+/// }
+/// ```
+///
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[repr(C)]
 pub struct ProposalBlock {

--- a/crates/block/src/proposal_block.rs
+++ b/crates/block/src/proposal_block.rs
@@ -6,7 +6,7 @@ use secp256k1::{
 };
 use serde::{Deserialize, Serialize};
 use utils::{create_payload, hash_data};
-use vrrb_core::{claim::Claim, txn::TransactionDigest};
+use vrrb_core::{claim::Claim, txn::{Txn, TransactionDigest}};
 
 use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnList};
 
@@ -59,7 +59,12 @@ impl ProposalBlock {
 
         let payload = create_payload!(round, epoch, txns, claims, from);
         let signature = secret_key.sign_ecdsa(payload).to_string();
-        let hash = hash_data!(round, epoch, txns, claims, from, signature);
+        let hashable_txns: Vec<(String, Txn)> = {
+            txns.clone().iter().map(|(k, v)| {
+                (k.digest_string(), v.clone())
+            }).collect()
+        };
+        let hash = hash_data!(round, epoch, hashable_txns, claims, from, signature);
         let hash_string = format!("{:x}", hash);
 
         ProposalBlock {

--- a/crates/block/src/proposal_block.rs
+++ b/crates/block/src/proposal_block.rs
@@ -5,10 +5,8 @@ use secp256k1::{
     Message,
 };
 use serde::{Deserialize, Serialize};
-use sha256::digest;
 use utils::{create_payload, hash_data};
-use vrrb_core::claim::Claim;
-use vrrb_core::txn::TransactionDigest;
+use vrrb_core::{claim::Claim, txn::TransactionDigest};
 
 use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnList};
 
@@ -26,6 +24,7 @@ pub struct ProposalBlock {
 }
 
 impl ProposalBlock {
+
     pub fn build(
         ref_block: RefHash,
         round: u128,
@@ -35,9 +34,11 @@ impl ProposalBlock {
         from: Claim,
         secret_key: SecretKeyBytes,
     ) -> ProposalBlock {
+
         let payload = create_payload!(round, epoch, txns, claims, from);
         let signature = secret_key.sign_ecdsa(payload).to_string();
         let hash = hash_data!(round, epoch, txns, claims, from, signature);
+        let hash_string = format!("{:x}", hash);
 
         ProposalBlock {
             ref_block,
@@ -45,7 +46,7 @@ impl ProposalBlock {
             epoch,
             txns,
             claims,
-            hash,
+            hash: hash_string,
             from,
             signature,
         }
@@ -65,9 +66,9 @@ impl ProposalBlock {
 
         let curr_set: LinkedHashSet<&TransactionDigest> = { curr_txns.iter().map(|(id, _)| id).collect() };
 
-        let prev_confirmed: LinkedHashSet<&TransactionDigest> = {
+        let prev_confirmed: LinkedHashSet<TransactionDigest> = {
             let intersection = curr_set.intersection(&prev_block_set);
-            intersection.into_iter().map(|id| id.clone()).collect()
+            intersection.into_iter().map(|id| id.clone().to_owned()).collect()
         };
 
         self.txns.retain(|id, _| prev_confirmed.contains(id));

--- a/crates/block/src/proposal_block.rs
+++ b/crates/block/src/proposal_block.rs
@@ -8,8 +8,9 @@ use serde::{Deserialize, Serialize};
 use sha256::digest;
 use utils::{create_payload, hash_data};
 use vrrb_core::claim::Claim;
+use vrrb_core::txn::TransactionDigest;
 
-use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnId, TxnList};
+use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnList};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[repr(C)]
@@ -55,24 +56,24 @@ impl ProposalBlock {
     }
 
     pub fn remove_confirmed_txs(&mut self, prev_blocks: Vec<ConvergenceBlock>) {
-        let sets: Vec<LinkedHashSet<&TxnId>> =
+        let sets: Vec<LinkedHashSet<&TransactionDigest>> =
             { prev_blocks.iter().map(|block| block.txn_id_set()).collect() };
 
-        let prev_block_set: LinkedHashSet<&TxnId> = { sets.into_iter().flatten().collect() };
+        let prev_block_set: LinkedHashSet<&TransactionDigest> = { sets.into_iter().flatten().collect() };
 
         let curr_txns = self.txns.clone();
 
-        let curr_set: LinkedHashSet<&TxnId> = { curr_txns.iter().map(|(id, _)| id).collect() };
+        let curr_set: LinkedHashSet<&TransactionDigest> = { curr_txns.iter().map(|(id, _)| id).collect() };
 
-        let prev_confirmed: LinkedHashSet<TxnId> = {
+        let prev_confirmed: LinkedHashSet<&TransactionDigest> = {
             let intersection = curr_set.intersection(&prev_block_set);
-            intersection.into_iter().map(|id| id.to_string()).collect()
+            intersection.into_iter().map(|id| id.clone()).collect()
         };
 
         self.txns.retain(|id, _| prev_confirmed.contains(id));
     }
 
-    pub fn txn_id_set(&self) -> LinkedHashSet<TxnId> {
+    pub fn txn_id_set(&self) -> LinkedHashSet<TransactionDigest> {
         self.txns.iter().map(|(id, _)| id.clone()).collect()
     }
 }

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -1,53 +1,21 @@
 // This file contains code for creating blocks to be proposed, including the
 // genesis block and blocks being mined.
 
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, HashSet},
-    fmt,
-};
+use std::collections::{HashMap, HashSet};
 
-use bulldag::{
-    graph::BullDag,
-    index::Index,
-    vertex::{Direction, Vertex},
-};
-use primitives::{
-    Epoch,
-    RawSignature,
-    SecretKey as SecretKeyBytes,
-    GENESIS_EPOCH,
-    SECOND,
-    VALIDATOR_THRESHOLD,
-};
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;
-use reward::reward::{Reward, NUMBER_OF_BLOCKS_PER_EPOCH};
 use ritelinked::{LinkedHashMap, LinkedHashSet};
-use secp256k1::{
-    hashes::{sha256 as s256, Hash},
-    Message,
-};
 use serde::{Deserialize, Serialize};
-use sha256::digest;
-use utils::{create_payload, hash_data};
 use vrrb_core::{
-    accountable::Accountable,
     claim::Claim,
-    keypair::KeyPair,
     txn::{Txn, TransactionDigest},
-    verifiable::Verifiable,
 };
 use tokio::task::JoinHandle;
 use std::error::Error;
 
 #[cfg(mainnet)]
 use crate::genesis;
-use crate::{
-    genesis,
-    header::BlockHeader,
-    invalid::{BlockError, InvalidBlockErrorReason},
-};
 
 pub const GROSS_UTILITY_PERCENTAGE: f64 = 0.01;
 pub const PERCENTAGE_CHANGE_SUPPLY_CAP: f64 = 0.25;
@@ -58,7 +26,7 @@ pub type NextEpochAdjustment = i128;
 pub type ClaimHash = String;
 pub type RefHash = String;
 pub type TxnList = LinkedHashMap<TransactionDigest, Txn>;
-pub type ClaimList = LinkedHashMap<ClaimHash, Claim>;
+pub type ClaimList = LinkedHashMap<String, Claim>;
 pub type ConsolidatedTxns = LinkedHashMap<RefHash, LinkedHashSet<TransactionDigest>>;
 pub type ConsolidatedClaims = LinkedHashMap<RefHash, LinkedHashSet<ClaimHash>>;
 pub type BlockHash = String;

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -35,9 +35,11 @@ use vrrb_core::{
     accountable::Accountable,
     claim::Claim,
     keypair::KeyPair,
-    txn::Txn,
+    txn::{Txn, TransactionDigest},
     verifiable::Verifiable,
 };
+use tokio::task::JoinHandle;
+use std::error::Error;
 
 #[cfg(mainnet)]
 use crate::genesis;
@@ -53,18 +55,18 @@ pub const EPOCH_BLOCK: u32 = 30_000_000;
 
 pub type CurrentUtility = i128;
 pub type NextEpochAdjustment = i128;
-pub type TxnId = String;
 pub type ClaimHash = String;
 pub type RefHash = String;
-pub type TxnList = LinkedHashMap<TxnId, Txn>;
+pub type TxnList = LinkedHashMap<TransactionDigest, Txn>;
 pub type ClaimList = LinkedHashMap<ClaimHash, Claim>;
-pub type ConsolidatedTxns = LinkedHashMap<RefHash, LinkedHashSet<TxnId>>;
+pub type ConsolidatedTxns = LinkedHashMap<RefHash, LinkedHashSet<TransactionDigest>>;
 pub type ConsolidatedClaims = LinkedHashMap<RefHash, LinkedHashSet<ClaimHash>>;
 pub type BlockHash = String;
 pub type QuorumId = String;
 pub type QuorumPubkey = String;
 pub type QuorumPubkeys = LinkedHashMap<QuorumId, QuorumPubkey>;
-pub type ConflictList = HashMap<TxnId, Conflict>;
+pub type ConflictList = HashMap<TransactionDigest, Conflict>;
+pub type ResolvedConflicts = Vec<JoinHandle<Result<Conflict, Box<dyn Error>>>>; 
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[repr(C)]
@@ -78,7 +80,7 @@ pub struct Certificate {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[repr(C)]
 pub struct Conflict {
-    pub txn_id: TxnId,
+    pub txn_id: TransactionDigest,
     pub proposers: HashSet<(Claim, RefHash)>,
     pub winner: Option<RefHash>,
 }

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -12,7 +12,7 @@ use vrrb_core::{
     txn::{Txn, TransactionDigest},
 };
 use tokio::task::JoinHandle;
-use std::error::Error;
+use std::{error::Error, hash::{Hash, Hasher}};
 
 #[cfg(mainnet)]
 use crate::genesis;
@@ -36,7 +36,7 @@ pub type QuorumPubkeys = LinkedHashMap<QuorumId, QuorumPubkey>;
 pub type ConflictList = HashMap<TransactionDigest, Conflict>;
 pub type ResolvedConflicts = Vec<JoinHandle<Result<Conflict, Box<dyn Error>>>>; 
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[repr(C)]
 pub struct Certificate {
     pub signature: String,
@@ -45,10 +45,39 @@ pub struct Certificate {
     pub next_root_hash: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[repr(C)]
 pub struct Conflict {
     pub txn_id: TransactionDigest,
     pub proposers: HashSet<(Claim, RefHash)>,
     pub winner: Option<RefHash>,
+}
+
+
+impl Hash for Conflict {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.txn_id.hash(state);
+
+        let mut sorted_proposers: Vec<_> = self.proposers.iter().collect();
+        sorted_proposers.sort_unstable_by(|a, b| {
+            let mut a_hasher = std::collections::hash_map::DefaultHasher::new();
+            let mut b_hasher = std::collections::hash_map::DefaultHasher::new();
+            a.0.hash(&mut a_hasher);
+            a.1.hash(&mut a_hasher);
+
+            b.0.hash(&mut b_hasher);
+            b.1.hash(&mut b_hasher);
+            
+            let a_key = a_hasher.finish();
+            let b_key = b_hasher.finish();
+
+            a_key.cmp(&b_key)
+        });
+
+        for proposer in &sorted_proposers {
+            proposer.hash(state);
+        }
+
+        self.winner.hash(state);
+    }
 }

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -81,10 +81,10 @@ pub struct RunOpts {
     pub disable_networking: bool,
 
     #[clap(long, value_parser ,default_value=DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
-    pub rendzevous_local_address: SocketAddr,
+    pub rendezvous_local_address: SocketAddr,
 
     #[clap(long, value_parser, default_value = DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
-    pub rendzevous_server_address: SocketAddr,
+    pub rendezvous_server_address: SocketAddr,
 }
 
 impl From<RunOpts> for NodeConfig {
@@ -110,7 +110,7 @@ impl From<RunOpts> for NodeConfig {
             node_type,
             raptorq_gossip_address: opts.raptorq_gossip_address,
             udp_gossip_address: opts.udp_gossip_address,
-            rendzevous_local_address: opts.rendzevous_local_address,
+            rendezvous_local_address: opts.rendezvous_local_address,
             http_api_address: opts.http_api_address,
             http_api_title,
             http_api_version: opts.http_api_version,
@@ -128,7 +128,7 @@ impl From<RunOpts> for NodeConfig {
             // a hack, but it works for now.
             keypair: default_node_config.keypair,
             disable_networking: opts.disable_networking,
-            rendzevous_server_address: opts.rendzevous_server_address,
+            rendezvous_server_address: opts.rendezvous_server_address,
         }
     }
 }
@@ -155,8 +155,8 @@ impl Default for RunOpts {
             http_api_title: Default::default(),
             http_api_version: Default::default(),
             disable_networking: Default::default(),
-            rendzevous_local_address: ipv4_localhost_with_random_port,
-            rendzevous_server_address: ipv4_localhost_with_random_port,
+            rendezvous_local_address: ipv4_localhost_with_random_port,
+            rendezvous_server_address: ipv4_localhost_with_random_port,
         }
     }
 }
@@ -240,8 +240,8 @@ impl RunOpts {
             http_api_title,
             http_api_version,
             disable_networking: false,
-            rendzevous_local_address: other.rendzevous_local_address,
-            rendzevous_server_address: other.rendzevous_server_address,
+            rendezvous_local_address: other.rendezvous_local_address,
+            rendezvous_server_address: other.rendezvous_server_address,
         }
     }
 }

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -81,10 +81,10 @@ pub struct RunOpts {
     pub disable_networking: bool,
 
     #[clap(long, value_parser ,default_value=DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
-    pub rendezvous_local_address: SocketAddr,
+    pub rendzevous_local_address: SocketAddr,
 
     #[clap(long, value_parser, default_value = DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
-    pub rendezvous_server_address: SocketAddr,
+    pub rendzevous_server_address: SocketAddr,
 }
 
 impl From<RunOpts> for NodeConfig {
@@ -110,8 +110,7 @@ impl From<RunOpts> for NodeConfig {
             node_type,
             raptorq_gossip_address: opts.raptorq_gossip_address,
             udp_gossip_address: opts.udp_gossip_address,
-            rendezvous_local_address: opts.rendezvous_local_address,
-            rendezvous_server_address: opts.rendezvous_server_address,
+            rendzevous_local_address: opts.rendzevous_local_address,
             http_api_address: opts.http_api_address,
             http_api_title,
             http_api_version: opts.http_api_version,
@@ -129,6 +128,7 @@ impl From<RunOpts> for NodeConfig {
             // a hack, but it works for now.
             keypair: default_node_config.keypair,
             disable_networking: opts.disable_networking,
+            rendzevous_server_address: opts.rendzevous_server_address,
         }
     }
 }
@@ -155,8 +155,8 @@ impl Default for RunOpts {
             http_api_title: Default::default(),
             http_api_version: Default::default(),
             disable_networking: Default::default(),
-            rendezvous_local_address: ipv4_localhost_with_random_port,
-            rendezvous_server_address: ipv4_localhost_with_random_port,
+            rendzevous_local_address: ipv4_localhost_with_random_port,
+            rendzevous_server_address: ipv4_localhost_with_random_port,
         }
     }
 }
@@ -240,8 +240,8 @@ impl RunOpts {
             http_api_title,
             http_api_version,
             disable_networking: false,
-            rendezvous_local_address: other.rendezvous_local_address,
-            rendezvous_server_address: other.rendezvous_server_address,
+            rendzevous_local_address: other.rendzevous_local_address,
+            rendzevous_server_address: other.rendzevous_server_address,
         }
     }
 }

--- a/crates/consensus/dkg_engine/src/types/mod.rs
+++ b/crates/consensus/dkg_engine/src/types/mod.rs
@@ -163,7 +163,7 @@ impl DkgEngine {
     }
 
     /// It clears the state of the DKG. it happens during change of Epoch
-    pub fn clear_dkg_state(&mut self) {
+    pub fn clear_state(&mut self) {
         self.dkg_state.part_message_store.clear();
         self.dkg_state.ack_message_store.clear();
         self.dkg_state.sync_key_gen = None;

--- a/crates/consensus/dkg_engine/src/types/mod.rs
+++ b/crates/consensus/dkg_engine/src/types/mod.rs
@@ -163,7 +163,7 @@ impl DkgEngine {
     }
 
     /// It clears the state of the DKG. it happens during change of Epoch
-    pub fn clear_state(&mut self) {
+    pub fn clear_dkg_state(&mut self) {
         self.dkg_state.part_message_store.clear();
         self.dkg_state.ack_message_store.clear();
         self.dkg_state.sync_key_gen = None;

--- a/crates/consensus/quorum/Cargo.toml
+++ b/crates/consensus/quorum/Cargo.toml
@@ -16,4 +16,5 @@ thiserror = { workspace = true }
 rand = { workspace = true }
 sha256 = { workspace = true }
 hex = { workspace = true }
-
+ethereum-types = { workspace = true }
+serde = { workspace = true }

--- a/crates/consensus/quorum/Cargo.toml
+++ b/crates/consensus/quorum/Cargo.toml
@@ -12,7 +12,6 @@ vrrb_vrf = { workspace = true }
 rand_chacha = { workspace = true }
 format-bytes = { workspace = true }
 thread_local = { workspace = true }
-node = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true }
 sha256 = { workspace = true }

--- a/crates/consensus/quorum/src/election.rs
+++ b/crates/consensus/quorum/src/election.rs
@@ -12,11 +12,4 @@ pub trait Election {
     fn generate_seed(payload: Self::Payload, kp: KeyPair) -> Result<Self::Seed, Self::Error>;
     ///runs the election
     fn run_election(&mut self, ballot: Self::Ballot) -> Result<&Self::Return, Self::Error>;
-    ///re-make seed and nonce up claims to run a new election in case of
-    /// electoin failure
-    fn nonce_claims_and_new_seed(
-        &mut self,
-        claims: Self::Ballot,
-        kp: KeyPair,
-    ) -> Result<Self::Ballot, Self::Error>;
 }

--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -45,10 +45,10 @@ mod tests {
         // Is this double hash neccesary?
         let hash = digest(digest(&*pub_key_bytes).as_bytes());
 
-        let payload1 = (10, 10, hash);
+        let payload1 = (10, hash);
 
         if let Ok(seed) = Quorum::generate_seed(payload1, keypair.clone()) {
-            if let Ok(mut quorum) = Quorum::new(seed, 11, 11, keypair) {
+            if let Ok(mut quorum) = Quorum::new(seed,  11, keypair) {
                 assert!(quorum.run_election(dummy_claims).is_err());
             };
         }
@@ -77,7 +77,7 @@ mod tests {
 
         let hash = digest(digest(&*pub_key_bytes).as_bytes());
 
-        let payload1 = (10, 0, hash);
+        let payload1 = (0, hash);
 
         assert!(Quorum::generate_seed(payload1, keypair).is_err());
     }
@@ -104,7 +104,7 @@ mod tests {
 
         let hash = digest(digest(&*pub_key_bytes).as_bytes());
 
-        let payload1 = (0, 10, hash);
+        let payload1 = (10, hash);
 
         assert!(Quorum::generate_seed(payload1, keypair).is_err());
     }
@@ -130,12 +130,12 @@ mod tests {
 
         let hash = digest(digest(&*pub_key_bytes).as_bytes());
 
-        let payload1 = (10, 10, hash);
+        let payload1 = (10, hash);
 
         let seed = Quorum::generate_seed(payload1, keypair.clone());
 
         if let Ok(seed) = seed {
-            assert!(Quorum::new(seed, 11, 0, keypair).is_err());
+            assert!(Quorum::new(seed,  0, keypair).is_err());
         }
     }
 
@@ -159,10 +159,10 @@ mod tests {
 
         let hash = digest(digest(&*pub_key_bytes).as_bytes());
 
-        let payload1 = (10, 10, hash);
+        let payload1 = (10, hash);
 
         if let Ok(seed) = Quorum::generate_seed(payload1, keypair.clone()) {
-            assert!(Quorum::new(seed, 0, 11, keypair).is_err());
+            assert!(Quorum::new(seed,  11, keypair).is_err());
         }
     }
 
@@ -187,10 +187,10 @@ mod tests {
 
         let hash = digest(digest(&*pub_key_bytes).as_bytes());
 
-        let payload1 = (10, 10, hash);
+        let payload1 = (10, hash);
 
         if let Ok(seed) = Quorum::generate_seed(payload1, keypair.clone()) {
-            if let Ok(mut quorum) = Quorum::new(seed, 11, 11, keypair.clone()) {
+            if let Ok(mut quorum) = Quorum::new(seed,  11, keypair.clone()) {
                 if quorum.run_election(dummy_claims.clone()).is_ok() {
                     assert!(quorum.master_pubkeys.len() == 13);
                 } else {
@@ -243,12 +243,12 @@ mod tests {
 
         let hash = digest(digest(&*pub_key_bytes).as_bytes());
 
-        let payload = (10, 10, hash);
+        let payload = (10, hash);
 
         if let Ok(seed1) = Quorum::generate_seed(payload.clone(), keypair.clone()) {
             if let Ok(seed2) = Quorum::generate_seed(payload.clone(), keypair.clone()) {
-                if let Ok(mut quorum1) = Quorum::new(seed1, 11, 11, keypair.clone()) {
-                    if let Ok(mut quorum2) = Quorum::new(seed2, 11, 11, keypair) {
+                if let Ok(mut quorum1) = Quorum::new(seed1, 11,  keypair.clone()) {
+                    if let Ok(mut quorum2) = Quorum::new(seed2, 11,  keypair) {
                         if let Ok(q1) = quorum1.run_election(dummy_claims1) {
                             if let Ok(q2) = quorum2.run_election(dummy_claims2) {
                                 assert!(q1.master_pubkeys == q2.master_pubkeys);

--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -193,22 +193,6 @@ mod tests {
             if let Ok(mut quorum) = Quorum::new(seed,  11, keypair.clone()) {
                 if quorum.run_election(dummy_claims.clone()).is_ok() {
                     assert!(quorum.master_pubkeys.len() == 13);
-                } else {
-                    //first run w dummy claims, THEN if that fails enter loop
-                    let new_claims1 = quorum
-                        .nonce_claims_and_new_seed(dummy_claims, keypair.clone())
-                        .unwrap();
-                    if quorum.run_election(new_claims1.clone()).is_err() {
-                        let new_claims2 = quorum
-                            .nonce_claims_and_new_seed(new_claims1.clone(), keypair.clone())
-                            .unwrap();
-                        while quorum.run_election(new_claims2.clone()).is_err() {
-                            let new_claims2 = quorum
-                                .nonce_claims_and_new_seed(new_claims2.clone(), keypair.clone())
-                                .unwrap();
-                        }
-                    }
-                    assert!(quorum.master_pubkeys.len() == 13);
                 }
             };
         }

--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -24,11 +24,11 @@ mod tests {
     fn not_enough_claims() {
         let mut dummy_claims: Vec<Claim> = Vec::new();
 
-        (0..3).for_each(|i| {
+        (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key().serialize().to_vec();
             let claim: Claim =
-                Claim::new(hex::encode(public_key), TEST_ADDR.to_string(), i as u128);
+                Claim::new(hex::encode(public_key), TEST_ADDR.to_string());
 
             //let claim_box = Box::new(claim);
             dummy_claims.push(claim);
@@ -58,10 +58,10 @@ mod tests {
     fn invalid_seed_block_height() {
         let mut dummy_claims: Vec<Claim> = Vec::new();
 
-        (0..3).for_each(|i| {
+        (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key();
-            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string(), i as u128);
+            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string());
 
             dummy_claims.push(claim);
         });
@@ -86,10 +86,10 @@ mod tests {
     fn invalid_seed_block_timestamp() {
         let mut dummy_claims: Vec<Claim> = Vec::new();
 
-        (0..3).for_each(|i| {
+        (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key();
-            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string(), i as u128);
+            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string());
 
             dummy_claims.push(claim);
         });
@@ -112,10 +112,10 @@ mod tests {
     #[test]
     fn invalid_election_block_height() {
         let mut dummy_claims: Vec<Claim> = Vec::new();
-        (0..3).for_each(|i| {
+        (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key();
-            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string(), i as u128);
+            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string());
 
             dummy_claims.push(claim);
         });
@@ -142,10 +142,10 @@ mod tests {
     #[test]
     fn invalid_election_block_timestamp() {
         let mut dummy_claims: Vec<Claim> = Vec::new();
-        (0..20).for_each(|i| {
+        (0..20).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key();
-            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string(), i as u128);
+            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string());
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -170,10 +170,10 @@ mod tests {
     #[ignore = "temporarily disabled while the crate is refactored"]
     fn elect_quorum() {
         let mut dummy_claims: Vec<Claim> = Vec::new();
-        (0..25).for_each(|i| {
+        (0..25).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key();
-            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string(), i as u128);
+            let claim: Claim = Claim::new(public_key.to_string(), TEST_ADDR.to_string());
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -219,13 +219,12 @@ mod tests {
         let mut dummy_claims1: Vec<Claim> = Vec::new();
         let mut dummy_claims2: Vec<Claim> = Vec::new();
 
-        (0..3).for_each(|i| {
+        (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key();
             let claim: Claim = Claim::new(
                 public_key.to_string(),
-                TEST_ADDR.to_string().clone(),
-                i as u128,
+                TEST_ADDR.to_string().clone()
             );
             //let boxed_claim = Box::new(claim);
 

--- a/crates/consensus/quorum/src/quorum.rs
+++ b/crates/consensus/quorum/src/quorum.rs
@@ -92,7 +92,8 @@ impl Election for Quorum {
 
         Ok(elected_quorum)
     }
-
+    
+    #[deprecated(note = "Noncing no longer applies to PoC Elections")]
     fn nonce_claims_and_new_seed(
         &mut self,
         claims: Vec<Claim>,
@@ -115,7 +116,7 @@ impl Election for Quorum {
 
         for claim in claims {
             let mut nonce_up_claim = claim;
-            nonce_up_claim.nonce += 1;
+            // nonce_up_claim.nonce += 1;
             nonce_up_claims.push(nonce_up_claim);
         }
         Ok(nonce_up_claims)

--- a/crates/consensus/quorum/src/quorum.rs
+++ b/crates/consensus/quorum/src/quorum.rs
@@ -1,9 +1,8 @@
-use std::u32::MAX as u32MAX;
-
 use thiserror::Error;
-use vrrb_core::{claim::Claim, keypair::KeyPair};
+use vrrb_core::{claim::Claim, keypair::KeyPair, ownable::Ownable};
 use vrrb_vrf::{vrng::VRNG, vvrf::VVRF};
-
+use ethereum_types::U256;
+use serde::{Serialize, Deserialize};
 use crate::election::Election;
 
 ///Error type for Quorum
@@ -29,7 +28,7 @@ pub enum InvalidQuorum {
 }
 
 ///Quorum struct which is created and modified when an election is run
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub struct Quorum {
     pub quorum_seed: u64,
     pub master_pubkeys: Vec<String>,
@@ -39,7 +38,6 @@ pub struct Quorum {
 }
 
 ///generic types from Election trait defined here for Quorums
-type Timestamp = u128;
 type Height = u128;
 type BlockHash = String;
 type Seed = u64;
@@ -55,7 +53,7 @@ impl Election for Quorum {
     ///a miner calls this fxn to generate a u64 seed for the election using the
     /// vrrb_vrf crate
     fn generate_seed(payload: Self::Payload, kp: KeyPair) -> Result<Seed, InvalidQuorum> {
-        if !Quorum::check_validity( payload.0) {
+        if !Quorum::is_valid_height( payload.0) {
             return Err(InvalidQuorum::InvalidChildBlockError());
         }
         let mut vvrf = VVRF::new(
@@ -92,33 +90,6 @@ impl Election for Quorum {
 
         Ok(elected_quorum)
     }
-
-    fn nonce_claims_and_new_seed(
-        &mut self,
-        claims: Vec<Claim>,
-        kp: KeyPair,
-    ) -> Result<Vec<Claim>, InvalidQuorum> {
-        let seed = match Quorum::generate_seed(
-            (
-                self.election_block_height,
-                self.quorum_pk.clone(),
-            ),
-            kp,
-        ) {
-            Ok(seed) => seed,
-            Err(e) => return Err(e),
-        };
-        self.quorum_seed = seed;
-
-        let mut nonce_up_claims = Vec::new();
-
-        for claim in claims {
-            let mut nonce_up_claim = claim;
-            // nonce_up_claim.nonce += 1;
-            nonce_up_claims.push(nonce_up_claim);
-        }
-        Ok(nonce_up_claims)
-    }
 }
 
 impl Quorum {
@@ -129,7 +100,7 @@ impl Quorum {
         height: u128,
         kp: KeyPair,
     ) -> Result<Quorum, InvalidQuorum> {
-        if !Quorum::check_validity(height) {
+        if !Quorum::is_valid_height(height) {
             Err(InvalidQuorum::InvalidChildBlockError())
         } else {
             Ok(Quorum {
@@ -143,7 +114,7 @@ impl Quorum {
     }
 
     ///checks if the child block height is valid ,its used at seed and quorum creation
-    pub fn check_validity(height: Height) -> bool {
+    pub fn is_valid_height(height: Height) -> bool {
         height > 0
     }
 
@@ -174,13 +145,9 @@ impl Quorum {
 
         let num_claims = ((claims.len() as f32) * 0.51).ceil() as usize;
 
-        let mut claim_tuples: Vec<(u128, &String)> = Vec::new();
-
-        for x in 0..claims.len() {
-            if let Some(pointer) = claims[x].get_pointer(self.quorum_seed as u128) {
-                claim_tuples.push((pointer, &claims[x].public_key));
-            }
-        }
+        let mut claim_tuples: Vec<(U256, Claim)> = claims.iter().map(|claim| {
+            claim.get_election_result(self.quorum_seed as u64)
+        }).collect();
 
         if claim_tuples.len() < (((claims.len() as f32) * 0.65).ceil() as usize) {
             return Err(InvalidQuorum::InvalidPointerSumError(claims));
@@ -189,8 +156,8 @@ impl Quorum {
         claim_tuples.sort_by_key(|claim_tuple| claim_tuple.0);
 
         let pubkeys: Vec<String> = claim_tuples
-            .into_iter()
-            .map(|claim_tuple| claim_tuple.1.clone())
+            .iter()
+            .map(|(_, claim)| claim.get_pubkey())
             .take(num_claims)
             .collect();
 
@@ -202,7 +169,7 @@ impl Quorum {
 
     pub fn get_trusted_peers(&mut self, claims: Vec<Claim>) -> Self {
         //get the weighted value hashmap
-        //calcualte all the t values
+        //calcualte all the t values 
 
         todo!();
     }

--- a/crates/consensus/reward/src/reward.rs
+++ b/crates/consensus/reward/src/reward.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, deprecated_in_future)]
 //FEATURE TAG(S): Rewards, Block Structure
 
 use serde::{Deserialize, Serialize};
@@ -54,7 +53,7 @@ impl Reward {
     pub fn genesis(miner: Option<String>) -> Reward {
         Reward {
             current_block: 0,
-            epoch: 1,
+            epoch: 0,
             next_epoch_block: NUMBER_OF_BLOCKS_PER_EPOCH,
             miner,
             amount: BASELINE_REWARD,

--- a/crates/consensus/reward/src/reward.rs
+++ b/crates/consensus/reward/src/reward.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated, deprecated_in_future)]
 //FEATURE TAG(S): Rewards, Block Structure
 
 use serde::{Deserialize, Serialize};

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -32,6 +32,7 @@ async-trait = { workspace = true }
 theater = { workspace = true }
 utils = { workspace = true }
 cuckoofilter = { workspace = true }
+quorum = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -33,6 +33,7 @@ theater = { workspace = true }
 utils = { workspace = true }
 cuckoofilter = { workspace = true }
 quorum = { workspace = true }
+ethereum-types = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, net::SocketAddr};
 
-use block::convergence_block::ConvergenceBlock;
+use block::{convergence_block::ConvergenceBlock, Conflict, ResolvedConflicts};
 use primitives::{
     Address,
     ByteVec,
@@ -9,21 +9,26 @@ use primitives::{
     NodeIdx,
     NodeType,
     PeerId,
+    NodeId,
     QuorumPublicKey,
     QuorumType,
     RawSignature,
+    TransactionDigest,
     TxHashString,
 };
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
-use tokio::sync::{
-    broadcast::{self, Receiver, Sender},
-    mpsc::{UnboundedReceiver, UnboundedSender},
+use tokio::{
+    sync::{
+        broadcast::{self, Sender},
+        mpsc::{UnboundedReceiver, UnboundedSender},
+    },
+    task::JoinHandle,
 };
-use vrrb_core::txn::{TransactionDigest, Txn};
-
+use vrrb_core::{
+    account::Account, txn::{TransactionDigest, Txn},
+};
 pub type Result<T> = std::result::Result<T, Error>;
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("io error: {0}")]
@@ -35,10 +40,12 @@ pub enum Error {
     #[error("{0}")]
     Other(String),
 }
-
 pub type Subscriber = UnboundedSender<Event>;
 pub type Publisher = UnboundedSender<(Topic, Event)>;
 pub type AccountBytes = Vec<u8>;
+pub type BlockBytes = Vec<u8>;
+pub type HeaderBytes = Vec<u8>;
+pub type ConflictBytes = Vec<u8>;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerData {
@@ -49,7 +56,7 @@ pub struct PeerData {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct SyncPeerData {
-    pub address: SocketAddr,
+    pub address: String,
     pub raptor_udp_port: u16,
     pub quic_port: u16,
     pub node_type: NodeType,
@@ -68,6 +75,21 @@ pub struct Vote {
     /// Partial Signature
     pub signature: RawSignature,
     pub txn: Txn,
+    pub execution_result: Option<String>,
+    pub quorum_public_key: Vec<u8>,
+    pub quorum_threshold: usize,
+    // May want to serialize this as a vector of bytes
+    pub execution_result: Option<String>,
+}
+
+pub type SerializedConvergenceBlock = ByteVec;
+
+#[derive(Debug, Deserialize, Serialize, Hash, Clone, PartialEq, Eq)]
+pub struct BlockVote {
+    pub harvester_id: Vec<u8>,
+    pub harvester_node_id: NodeIdx,
+    pub signature: RawSignature,
+    pub convergence_block: SerializedConvergenceBlock,
     pub quorum_public_key: Vec<u8>,
     pub quorum_threshold: usize,
     // May want to serialize this as a vector of bytes
@@ -131,8 +153,6 @@ pub enum Event {
     SlashClaims(Vec<String>),
     CheckAbandoned,
     SyncPeers(Vec<SyncPeerData>),
-    EmptyPeerSync,
-    PeerSyncFailed(Vec<SocketAddr>),
     PeerRequestedStateSync(PeerData),
 
     //Event to tell Farmer node to sign the Transaction
@@ -178,6 +198,66 @@ pub enum Event {
 
     AccountUpdateRequested((Address, AccountBytes)),
     UpdatedAccount(AccountBytes),
+    MinerElection(HeaderBytes),
+    // Should we make this the ClaimHash instead of the NodeId
+    ElectedMiner((U256, NodeId)),
+    QuorumElection(HeaderBytes),
+    ConflictResolution(ConflictBytes, HeaderBytes),
+    ResolvedConflict(Conflict),
+    // SendTxn(u32, String, u128), // address number, receiver address, amount
+    // ProcessTxnValidator(Vec<u8>),
+    // PendingBlock(Vec<u8>, String),
+    // InvalidBlock(Vec<u8>),
+    // ProcessClaim(Vec<u8>),
+    // CheckStateUpdateStatus((u128, Vec<u8>, u128)),
+    // StateUpdateCompleted(Vec<u8>),
+    // StoreStateDbChunk(Vec<u8>, Vec<u8>, u32, u32),
+    // SendState(String, u128),
+    // SendMessage(SocketAddr, Message),
+    // GetBalance(u32),
+    // SendGenesis(String),
+    // SendStateComponents(String, Vec<u8>, String),
+    // GetStateComponents(String, Vec<u8>, String),
+    // RequestedComponents(String, Vec<u8>, String, String),
+    // StoreStateComponents(Vec<u8>, ComponentTypes),
+    // StoreChild(Vec<u8>),
+    // StoreParent(Vec<u8>),
+    // StoreGenesis(Vec<u8>),
+    // StoreLedger(Vec<u8>),
+    // StoreNetworkState(Vec<u8>),
+    // StateUpdateComponents(Vec<u8>, ComponentTypes),
+    // UpdateAppMiner(Vec<u8>),
+    // UpdateAppBlockchain(Vec<u8>),
+    // UpdateAppMessageCache(Vec<u8>),
+    // UpdateAppWallet(Vec<u8>),
+    // Publish(Vec<u8>),
+    // Gossip(Vec<u8>),
+    // AddNewPeer(String, String),
+    // AddKnownPeers(Vec<u8>),
+    // AddExplicitPeer(String, String),
+    // ProcessPacket((Packet, SocketAddr)),
+    // Bootstrap(String, String),
+    // SendPing(String),
+    // ReturnPong(Vec<u8>, String),
+    // InitHandshake(String),
+    // ReciprocateHandshake(String, String, String),
+    // CompleteHandshake(String, String, String),
+    // ProcessAck(String, u32, String),
+    // CleanInbox(String),
+    // StartMiner,
+    // GetHeight,
+    // MineBlock,
+    // MineGenesis,
+    // StopMine,
+    // GetState,
+    // ProcessBacklog,
+    // SendAddress,
+    // NonceUp,
+    // InitDKG,
+    // SendPartMessage(Vec<u8>),
+    // SendAckMessage(Vec<u8>),
+    // PublicKeySetSync,
+>>>>>>> a1ff216 (scaffold integration with mining module)
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,20 +1,31 @@
 use std::{collections::HashMap, net::SocketAddr};
 
-use block::{convergence_block::ConvergenceBlock, Conflict, ResolvedConflicts};
-use primitives::{Address, ByteVec, FarmerQuorumThreshold, HarvesterQuorumThreshold, NodeIdx, NodeType, PeerId, NodeId, QuorumPublicKey, QuorumType, RawSignature, TransactionDigest, TxHashString, LastBlockHeight};
+use block::Conflict;
+use primitives::{
+    Address, 
+    ByteVec, 
+    FarmerQuorumThreshold, 
+    NodeIdx, 
+    NodeType, 
+    PeerId, 
+    QuorumPublicKey, 
+    QuorumType, 
+    RawSignature, 
+};
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
-use tokio::{
-    sync::{
-        broadcast::{self, Sender},
-        mpsc::{UnboundedReceiver, UnboundedSender},
+use tokio::sync::{
+    broadcast::{
+        self, Sender, Receiver
     },
-    task::JoinHandle,
+    mpsc::{
+        UnboundedReceiver, 
+        UnboundedSender
+    },
 };
-use vrrb_core::{
-    account::Account, txn::{TransactionDigest, Txn},
-};
-use vrrb_core::keypair::{Keypair, MinerPk};
+use ethereum_types::U256;
+
+use vrrb_core::{txn::{TransactionDigest, Txn}, keypair::Keypair, claim::Claim};
 
 pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
@@ -177,7 +188,7 @@ pub enum Event {
     // the overhead of deserializing
     MinerElection(HeaderBytes),
     // We make this the ClaimHash or Claim instead of the NodeId
-    ElectedMiner((U256, NodeId)),
+    ElectedMiner((U256, Claim)),
 
     ElectedQuorum(quorum::quorum::Quorum),
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -198,66 +198,18 @@ pub enum Event {
 
     AccountUpdateRequested((Address, AccountBytes)),
     UpdatedAccount(AccountBytes),
+    // May want to just use the `BlockHeader` struct to reduce 
+    // the overhead of deserializing
     MinerElection(HeaderBytes),
-    // Should we make this the ClaimHash instead of the NodeId
+    // We make this the ClaimHash or Claim instead of the NodeId
     ElectedMiner((U256, NodeId)),
+    // May want to just use the `BlockHeader` struct to reduce 
+    // the overhead of deserializing
     QuorumElection(HeaderBytes),
+    // May want to just use the ConflictList & `BlockHeader` types 
+    // to reduce the overhead of deserializing
     ConflictResolution(ConflictBytes, HeaderBytes),
     ResolvedConflict(Conflict),
-    // SendTxn(u32, String, u128), // address number, receiver address, amount
-    // ProcessTxnValidator(Vec<u8>),
-    // PendingBlock(Vec<u8>, String),
-    // InvalidBlock(Vec<u8>),
-    // ProcessClaim(Vec<u8>),
-    // CheckStateUpdateStatus((u128, Vec<u8>, u128)),
-    // StateUpdateCompleted(Vec<u8>),
-    // StoreStateDbChunk(Vec<u8>, Vec<u8>, u32, u32),
-    // SendState(String, u128),
-    // SendMessage(SocketAddr, Message),
-    // GetBalance(u32),
-    // SendGenesis(String),
-    // SendStateComponents(String, Vec<u8>, String),
-    // GetStateComponents(String, Vec<u8>, String),
-    // RequestedComponents(String, Vec<u8>, String, String),
-    // StoreStateComponents(Vec<u8>, ComponentTypes),
-    // StoreChild(Vec<u8>),
-    // StoreParent(Vec<u8>),
-    // StoreGenesis(Vec<u8>),
-    // StoreLedger(Vec<u8>),
-    // StoreNetworkState(Vec<u8>),
-    // StateUpdateComponents(Vec<u8>, ComponentTypes),
-    // UpdateAppMiner(Vec<u8>),
-    // UpdateAppBlockchain(Vec<u8>),
-    // UpdateAppMessageCache(Vec<u8>),
-    // UpdateAppWallet(Vec<u8>),
-    // Publish(Vec<u8>),
-    // Gossip(Vec<u8>),
-    // AddNewPeer(String, String),
-    // AddKnownPeers(Vec<u8>),
-    // AddExplicitPeer(String, String),
-    // ProcessPacket((Packet, SocketAddr)),
-    // Bootstrap(String, String),
-    // SendPing(String),
-    // ReturnPong(Vec<u8>, String),
-    // InitHandshake(String),
-    // ReciprocateHandshake(String, String, String),
-    // CompleteHandshake(String, String, String),
-    // ProcessAck(String, u32, String),
-    // CleanInbox(String),
-    // StartMiner,
-    // GetHeight,
-    // MineBlock,
-    // MineGenesis,
-    // StopMine,
-    // GetState,
-    // ProcessBacklog,
-    // SendAddress,
-    // NonceUp,
-    // InitDKG,
-    // SendPartMessage(Vec<u8>),
-    // SendAckMessage(Vec<u8>),
-    // PublicKeySetSync,
->>>>>>> a1ff216 (scaffold integration with mining module)
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports, deprecated_in_future, deprecated)]
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports, deprecated_in_future, deprecated)]
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
@@ -9,12 +8,9 @@ use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
 use left_right::{Absorb, ReadHandle, ReadHandleFactory, WriteHandle};
 use serde::{Deserialize, Serialize};
-use telemetry::{error, info, warn};
-use tokio;
 use vrrb_core::txn::{TransactionDigest, TxTimestamp, Txn};
 
 use super::error::MempoolError;
-use crate::create_tx_indexer;
 
 pub type Result<T> = StdResult<T, MempoolError>;
 

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -191,21 +191,7 @@ impl LeftRightMempool {
 
     pub fn insert(&mut self, txn: Txn) -> Result<usize> {
         let txn_record = TxnRecord::new(txn);
-
-        self.write
-            .append(MempoolOp::Add(txn_record.to_owned()))
-            .publish();
-
-        tokio::spawn(async move {
-            match create_tx_indexer(&txn_record).await {
-                Ok(_) => {
-                    info!("Successfully sent TxnRecord to block explorer indexer");
-                },
-                Err(e) => {
-                    warn!("Error sending TxnRecord to block explorer indexer {}", e);
-                },
-            }
-        });
+        self.write.append(MempoolOp::Add(txn_record)).publish();
 
         Ok(self.size_in_kilobytes())
     }

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated, deprecated_in_future)]
 //FEATURE TAG(S): Left-Right Mempool, Validator Cores, Tx Validation, Tx Writes
 // to Confirmed, Block Validation & Confirmation, Block Structure
 use std::{cmp::Eq, hash::Hash};

--- a/crates/miner/Cargo.toml
+++ b/crates/miner/Cargo.toml
@@ -21,3 +21,5 @@ block = { workspace = true }
 mempool = { workspace = true }
 thiserror = { workspace = true }
 utils = { workspace = true }
+sha2 = { workspace = true }
+ethereum-types = { workspace = true }

--- a/crates/miner/Cargo.toml
+++ b/crates/miner/Cargo.toml
@@ -23,3 +23,4 @@ thiserror = { workspace = true }
 utils = { workspace = true }
 sha2 = { workspace = true }
 ethereum-types = { workspace = true }
+tokio = { workspace = true }

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,3 +1,8 @@
+use std::collections::HashSet;
+
+use block::{RefHash, Block};
+use bulldag::vertex::Vertex;
+
 use crate::conflict_resolver::Resolver;
 /// A trait that can be implemented on any type that can build blocks.
 /// For current purposes, this is to be implemented on both Miner struct 
@@ -24,4 +29,28 @@ pub trait BlockBuilder: Resolver {
     fn update(&mut self, adjustment: &i128); 
     fn build(&self) -> Option<Self::BlockType>;
     fn get_references(&self) -> Option<Vec<Self::RefType>>;
+
+    fn get_orphaned_references(
+        &self, 
+        idx: RefHash, 
+        current_round: usize, 
+        n_rounds: usize
+    ) -> Vec<Self::RefType> {
+        let _ = n_rounds;
+        let _ = current_round;
+        let _ = idx;
+        vec![]
+    }
+
+    fn get_last_block_vertex(&self, idx: Option<RefHash>) -> Option<Vertex<Block, String>> {
+        let _ = idx;
+        None
+    }
+
+    fn get_n_rounds_convergence(&self, idx: RefHash, current_round: usize, n_rounds: usize) -> HashSet<RefHash> {
+        let _ = idx;
+        let _ = current_round;
+        let _ = n_rounds;
+        vec![]
+    }
 }

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,0 +1,29 @@
+use std::error::Error;
+use events::Event;
+use block::{Block, ConvergenceBlock, ProposalBlock};
+use bulldag::graph::BullDag;
+use crate::conflict_resolver::Resolver;
+
+/// A trait that can be implemented on any type that can build blocks.
+/// For current purposes, this is to be implemented on both Miner struct 
+/// and Harvester. 
+///     
+/// ```
+/// pub trait BlockBuilder: Resolver {
+///     type BlockType;
+///     type RefType;
+///     
+///     fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128);
+///     fn build(&self) -> Option<Self::BlockType>;
+///     fn get_references(&self) -> Vec<Self::RefType>; 
+/// }
+///
+// TODO: This should be moved to a separate crate
+pub trait BlockBuilder: Resolver {
+    type BlockType;
+    type RefType;
+
+    fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128); 
+    fn build(&self) -> Option<Self::BlockType>;
+    fn get_references(&self) -> Option<Vec<Self::RefType>>;
+}

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
-use block::{RefHash, Block};
+use block::{RefHash, Block, header::BlockHeader, InnerBlock};
 use bulldag::vertex::Vertex;
+use reward::reward::Reward;
+use std::sync::Arc;
 
 use crate::conflict_resolver::Resolver;
 /// A trait that can be implemented on any type that can build blocks.
@@ -26,7 +28,11 @@ pub trait BlockBuilder: Resolver {
     type BlockType;
     type RefType;
 
-    fn update(&mut self, adjustment: &i128); 
+    fn update(
+        &mut self, 
+        last_block: Option<Arc<dyn InnerBlock<Header = BlockHeader, RewardType = Reward>>>,
+        adjustment: &i128
+    ); 
     fn build(&self) -> Option<Self::BlockType>;
     fn get_references(&self) -> Option<Vec<Self::RefType>>;
 
@@ -51,6 +57,6 @@ pub trait BlockBuilder: Resolver {
         let _ = idx;
         let _ = current_round;
         let _ = n_rounds;
-        vec![]
+        HashSet::new()
     }
 }

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,4 +1,3 @@
-use block::ConvergenceBlock;
 use crate::conflict_resolver::Resolver;
 /// A trait that can be implemented on any type that can build blocks.
 /// For current purposes, this is to be implemented on both Miner struct 
@@ -12,7 +11,7 @@ use crate::conflict_resolver::Resolver;
 ///     type BlockType;
 ///     type RefType;
 ///     
-///     fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128);
+///     fn update(&mut self, adjustment: &i128);
 ///     fn build(&self) -> Option<Self::BlockType>;
 ///     fn get_references(&self) -> Vec<Self::RefType>; 
 /// }
@@ -22,7 +21,7 @@ pub trait BlockBuilder: Resolver {
     type BlockType;
     type RefType;
 
-    fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128); 
+    fn update(&mut self, adjustment: &i128); 
     fn build(&self) -> Option<Self::BlockType>;
     fn get_references(&self) -> Option<Vec<Self::RefType>>;
 }

--- a/crates/miner/src/block_builder.rs
+++ b/crates/miner/src/block_builder.rs
@@ -1,14 +1,13 @@
-use std::error::Error;
-use events::Event;
-use block::{Block, ConvergenceBlock, ProposalBlock};
-use bulldag::graph::BullDag;
+use block::ConvergenceBlock;
 use crate::conflict_resolver::Resolver;
-
 /// A trait that can be implemented on any type that can build blocks.
 /// For current purposes, this is to be implemented on both Miner struct 
 /// and Harvester. 
 ///     
 /// ```
+/// use miner::conflict_resolver::Resolver;
+/// use block::ConvergenceBlock;
+///
 /// pub trait BlockBuilder: Resolver {
 ///     type BlockType;
 ///     type RefType;

--- a/crates/miner/src/conflict_resolver.rs
+++ b/crates/miner/src/conflict_resolver.rs
@@ -55,10 +55,10 @@ pub trait Resolver {
     fn get_proposers(&self, proposals: &Vec<Self::Proposal>) -> Vec<Self::BallotInfo>; 
     fn append_winner(&self, conflicts: &mut Self::Identified, election_results: &mut BTreeMap<U256, Self::BallotInfo>); 
     fn resolve_current(&self, current: &mut Vec<Self::Proposal>, conflicts: &Self::Identified);
-    #[allow(unused)]
     fn split_proposals_by_round(
         &self, proposals: &Vec<Self::Proposal>
     ) -> (Vec<Self::Proposal>, Vec<Self::Proposal>) {
+        let _ = proposals;
         (vec![], vec![])
     }
 }

--- a/crates/miner/src/conflict_resolver.rs
+++ b/crates/miner/src/conflict_resolver.rs
@@ -1,0 +1,61 @@
+use std::collections::BTreeMap;
+
+use ethereum_types::U256;
+use vrrb_core::claim::Claim;
+
+/// A trait that can be implemented on any type that may need to resolve 
+/// any kind of conflict in the process of working. In particular, the 
+/// Miner and Harvester should implement this trait. 
+///
+/// Miners will use the methods to resolve conflicts between 
+/// proposal blocks 
+///
+/// Harvesters will use this trait as an MEV engine to reduce the subset 
+/// of transactions that it may want to include in a block to only those 
+/// that it has a high probability of winning. 
+/// ```
+/// pub trait Resolver {
+///   type ProposalInner;
+///   type Identified: IntoIterator;
+///   type SourceInner;
+///   type BallotInfo; 
+///
+///    fn identify<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &Self::Identified;
+///    fn resolve<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &I;
+///    fn resolve_earlier<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &I;
+///    fn get_sources<I: IntoIterator<Item = Self::SourceInner>>(&self, proposals: &I) -> &I;
+///    fn get_election_results<I: IntoIterator<Item = Self::BallotInfo>>(&self, proposers: &I) -> BTreeMap<U256, Self::BallotInfo>; 
+///    fn get_proposers<I: IntoIterator<Item = Self::ProposalInner>, E: IntoIterator<Item = Self::BallotInfo>>(&self, proposals: &I) -> &E; 
+///    fn append_winner(&self, conflicts: &mut Self::Identified, election_results: &mut BTreeMap<U256, Self::BallotInfo>); 
+///    fn resolve_current<I: IntoIterator<Item = Self::ProposalInner>>(&self, current: &mut I, conflicts: &Self::Identified);
+///    fn split_proposals_by_round<I: IntoIterator<Item = Self::ProposalInner>>(
+///        &self, proposals: &I
+///    ) -> (I, I) {
+///        (vec![], vec![])
+///    }
+/// }
+/// ``` 
+///
+///
+// TODO: This should be moved to a separate crate
+// TODO: We should add a basic doctest example of implementing this
+pub trait Resolver {
+    type ProposalInner;
+    type Identified: IntoIterator + Default;
+    type SourceInner;
+    type BallotInfo;
+    
+    fn identify<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &Self::Identified;
+    fn resolve<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &I;
+    fn resolve_earlier<I: IntoIterator<Item = Self::ProposalInner>>(&self, proposals: &I) -> &I;
+    fn get_sources<I: IntoIterator<Item = Self::SourceInner>>(&self, proposals: &I) -> &I;
+    fn get_election_results<I: IntoIterator<Item = Self::BallotInfo>>(&self, proposers: &I) -> BTreeMap<U256, Self::BallotInfo>; 
+    fn get_proposers<I: IntoIterator<Item = Self::ProposalInner>, E: IntoIterator<Item = Self::BallotInfo>>(&self, proposals: &I) -> &E; 
+    fn append_winner(&self, conflicts: &mut Self::Identified, election_results: &mut BTreeMap<U256, Self::BallotInfo>); 
+    fn resolve_current<I: IntoIterator<Item = Self::ProposalInner>>(&self, current: &mut I, conflicts: &Self::Identified);
+    fn split_proposals_by_round<I: IntoIterator<Item = Self::ProposalInner>>(
+        &self, proposals: &I
+    ) -> (I, I) {
+        (vec![], vec![])
+    }
+}

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -421,7 +421,7 @@ mod tests {
         let block_height = 29_999_998;
         let timestamp = chrono::Utc::now().timestamp();
         let txn_hash = "abcdef01234567890".to_string();
-        let miner_claim = miner.generate_claim(nonce);
+        let miner_claim = miner.generate_claim();
         let claim_list_hash = "01234567890abcdef".to_string();
         let mut block_reward = Reward::default();
         block_reward.current_block = block_height;
@@ -679,8 +679,8 @@ pub(crate) mod test_helpers {
         Address::new(pubkey.clone())
     }
 
-    pub(crate) fn create_claim(pk: &PublicKey, addr: &str, nonce: u128) -> Claim {
-        Claim::new(pk.to_string(), addr.to_string(), nonce)
+    pub(crate) fn create_claim(pk: &PublicKey, addr: &str) -> Claim {
+        Claim::new(pk.to_string(), addr.to_string())
     }
 
     pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
@@ -688,7 +688,7 @@ pub(crate) mod test_helpers {
         let addr = create_address(&pk);
         let miner = create_miner();
 
-        let claim = miner.generate_claim(1);
+        let claim = miner.generate_claim();
 
         let claim_list = {
             vec![(claim.hash.clone(), claim.clone())]

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -35,7 +35,7 @@ mod tests {
             create_miner, 
             create_miner_from_keypair, 
             create_keypair, 
-            create_and_sign_message, MinerDag, create_miner_return_dag, build_proposal_block, add_edges_to_dag
+            create_and_sign_message, MinerDag, create_miner_return_dag, build_proposal_block, create_txns
         }, MinerConfig
     };
 
@@ -131,7 +131,44 @@ mod tests {
 
     #[test]
     fn test_mine_valid_convergence_block_from_proposals_w_no_conflicts() {
+        let (mut miner, mut dag) = create_miner_return_dag();
+        let keypair = Keypair::random();
+        let other_miner = create_miner_from_keypair(&keypair); 
+        
         let genesis = mine_genesis();
+        if let Some(genesis) = genesis {
+            miner.last_block = Some(&genesis);
+            let gblock = Block::Genesis { block: genesis.clone() };
+            let gvtx: Vertex<Block, String> = gblock.into();
+            let prop1 = ProposalBlock::build(
+                genesis.hash.clone(),
+                0,
+                0,
+                LinkedHashMap::new(),
+                LinkedHashMap::new(),
+                other_miner.claim.clone(),
+                keypair.miner_kp.0.clone()
+            );
+            let pblock1 = Block::Proposal { block: prop1.clone() };
+            let pvtx1: Vertex<Block, String> = pblock1.into(); 
+            if let Ok(mut guard) = dag.write() {
+                let edge = (&gvtx, &pvtx1);
+                guard.add_edge(edge);
+            }
+
+            let convergence = miner.try_mine(); 
+            if let Ok(cblock) = convergence {
+                let cvtx: Vertex<Block, String> = cblock.into();
+                if let Ok(mut guard) = dag.write() {
+                    let edge = (&pvtx1, &cvtx);
+                    guard.add_edge(edge);
+                }
+            }
+
+            if let Ok(guard) = dag.read() {
+                assert_eq!(guard.len(), 3);
+            }
+        }
     }
 
     #[test]
@@ -160,10 +197,11 @@ pub(crate) mod test_helpers {
         Block,
         GenesisBlock,
         ProposalBlock,
-        TxnList, ConvergenceBlock,
+        TxnList, ConvergenceBlock, InnerBlock,
     };
     use bulldag::{graph::BullDag, vertex::Vertex};
     use primitives::{Address, PublicKey, SecretKey, Signature};
+    use ritelinked::LinkedHashMap;
     use secp256k1::Message;
     use sha2::{Digest, Sha256};
     use vrrb_core::{
@@ -360,85 +398,195 @@ pub(crate) mod test_helpers {
         (miner, dag)
     }
 
-    pub(crate) fn add_edges_to_dag(
-        dag: &mut MinerDag, 
-        genesis: bool, 
-        n_proposals: u32, 
-        n_rounds: u32, 
-    ) {
-        let mut batch = BatchEdges {
-            genesis: None,
-            proposals: vec![],
-            convergence: vec![],
-        };
+    pub(crate) fn create_miner_from_dag(dag: MinerDag) -> (Miner<'static>, MinerDag) {
+        let mut miner = create_miner();
+        miner.dag = dag.clone(); 
+
+        (miner, dag)
+    }
+
+    pub(crate) fn build_single_proposal_block(
+        last_block_hash: String,
+        n_txns: usize, 
+        n_claims: usize,
+        round: u128,
+        epoch: u128,
+        from: Claim,
+        sk: SecretKey,
+    ) -> ProposalBlock {
+        let txns = create_txns(n_txns).collect();
+        let claims = create_claims(n_claims).collect();
+        ProposalBlock::build(
+            last_block_hash,
+            round,
+            epoch,
+            txns,
+            claims,
+            from,
+            sk 
+        )
+    }
+
+    pub(crate) fn build_multiple_proposal_blocks_single_round(
+        n_blocks: usize,
+        last_block_hash: String,
+        n_txns: usize,
+        n_claims: usize,
+        round: u128,
+        epoch: u128,
+    ) -> Vec<ProposalBlock> {
         
-        let genesis: Option<Vertex<Block, String>> = {
-            if genesis {
-                if let Some(genesis) = mine_genesis() {
-                    let gblock = Block::Genesis { block: genesis.clone() };
-                    Some(gblock.clone().into())
-                } else {
-                    None
-                }
+        (0..n_blocks).into_iter().map(|n| {
+
+            let keypair = Keypair::random();
+            let address = Address::new(keypair.miner_kp.1.clone());
+            let claim = Claim::new(keypair.miner_kp.1.clone().to_string(), address.to_string());
+            let prop = build_single_proposal_block(
+                last_block_hash.clone(), 
+                n_txns, 
+                n_claims, 
+                round, 
+                epoch, 
+                claim, 
+                keypair.miner_kp.0.clone()
+            );
+            prop
+        }).collect()
+    }
+
+    pub(crate) fn build_multiple_rounds(
+        dag: &mut MinerDag,
+        last_block_hash: String, 
+        n_blocks: usize, 
+        n_txns: usize,
+        n_claims: usize,
+        n_rounds: usize,
+        round: &mut usize,
+        epoch: usize,
+    ) {
+        // Recursively add rounds of blocks to the DAG
+        // Need to ensure that there is a genesis block in the dag already.
+        if n_rounds > round.clone() {
+            if dag_has_genesis(&mut dag.clone()) {
+                if let Some(hash) = mine_next_convergence_block(&mut dag.clone()) {
+                    *round += 1usize;
+                    let proposals = build_multiple_proposal_blocks_single_round(
+                        n_blocks, hash.clone(), n_txns, n_claims, round.clone() as u128, epoch as u128
+                    );
+                    append_proposal_blocks_to_dag(&mut dag.clone(), proposals);
+                    build_multiple_rounds(
+                        &mut dag.clone(),
+                        hash,
+                        n_blocks,
+                        n_txns,
+                        n_claims,
+                        n_rounds,
+                        round,
+                        epoch,
+                    );
+                };
+                
             } else {
-                None 
+                if let Some(hash) = add_genesis_to_dag(&mut dag.clone()) {
+                    *round += 1usize;
+                    build_multiple_rounds(
+                        &mut dag.clone(),
+                        hash,
+                        n_blocks,
+                        n_txns,
+                        n_claims,
+                        n_rounds,
+                        round,
+                        epoch
+                    );
+                }
             }
-        };
+        }
+    }
 
-        batch.genesis = genesis;
+    pub(crate) fn dag_has_genesis(dag: &mut MinerDag) -> bool {
+        dag.read().unwrap().len() > 0
+    }
 
-        if batch.genesis.is_none() {
-            return 
+    pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
+        let mut prop_vertices = Vec::new();
+        let genesis = mine_genesis();
+        let keypair = Keypair::random();
+        let miner = create_miner_from_keypair(&keypair);
+
+        if let Some(genesis) = genesis {
+            let gblock = Block::Genesis { block: genesis.clone() };
+            let gvtx: Vertex<Block, String> = gblock.into();
+            let prop1 = ProposalBlock::build(
+                genesis.hash.clone(),
+                0,
+                0,
+                LinkedHashMap::new(),
+                LinkedHashMap::new(),
+                miner.claim.clone(),
+                keypair.miner_kp.0.clone()
+            );
+            let pblock = Block::Proposal { block: prop1.clone() };
+            let pvtx: Vertex<Block, String> = pblock.into(); 
+            prop_vertices.push(pvtx.clone());
+            if let Ok(mut guard) = dag.write() {
+                let edge = (&gvtx, &pvtx);
+                guard.add_edge(edge);
+                return Some(genesis.get_hash().clone())
+            }
+        }
+        None
+    }
+
+    pub(crate) fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> {
+        let keypair = Keypair::random();
+        let mut miner = create_miner_from_keypair(&keypair);
+        miner.dag = dag.clone();
+        if let Ok(cblock) = miner.try_mine() {
+            if let Block::Convergence { ref block } = cblock.clone() {
+                let cvtx: Vertex<Block, String> = cblock.into();
+                let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![]; 
+                if let Ok(guard) = dag.read() {
+                    block.clone().get_ref_hashes().iter().for_each(|t| {
+                        if let Some(pvtx) = guard.get_vertex(t.clone()) {
+                            edges.push((pvtx.clone(), cvtx.clone()));
+                        }
+                    });
+                }
+    
+                if let Ok(mut guard) = dag.write() {
+                    let edges = edges.iter().map(|(source, reference)| {
+                        (source, reference)
+                    }).collect();
+                    guard.extend_from_edges(edges);
+                    return Some(block.get_hash())
+                }
+            }
+        }
+    
+        None
+    }
+
+    pub(crate) fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
+        let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
+        for block in proposals.iter() {
+            let ref_hash = block.ref_block.clone();
+            if let Ok(guard) = dag.read() {
+                if let Some(cvtx) = guard.get_vertex(ref_hash) {
+                    let pblock = Block::Proposal { block: block.clone() };
+                    let pvtx: Vertex<Block, String> = pblock.into();
+                    let edge = (cvtx.clone(), pvtx.clone());
+                    edges.push(edge);
+                }
+            }
         }
 
-        for round in (0..n_rounds).into_iter() {  
-            if round == 0 {
-                match batch.genesis.clone().unwrap().get_data() {
-                    Block::Genesis { ref block } => {
-                        let proposals: Vec<Vertex<Block, String>> = (0..n_proposals)
-                            .into_iter()
-                            .map(|_| {
-                                let proposal = build_proposal_block(
-                                    &block.hash, 5, 4, round as u128, 0
-                                    ).unwrap();  
-                                let block = Block::from(proposal);
-                                block.into()
-                            }).collect();
-    
-                        batch.proposals.push(proposals);
-                        
-                        let mut miner = create_miner();
-                        miner.dag = dag.clone();
-                        if let Ok(block) = miner.try_mine() {
-                            batch.convergence.push(block.into());
-                        }
-                    },
-                    _ => {}
-                }
-            } else {
-                match batch.convergence.clone()[round as usize].get_data() {
-                    Block::Convergence { ref block } => {
-                        let proposals: Vec<Vertex<Block, String>> = (0..n_proposals)
-                            .into_iter()
-                            .map(|_| {
-                                let proposal = build_proposal_block(
-                                    &block.hash, 5, 4, round as u128, 0
-                                    ).unwrap();  
-                                let block = Block::from(proposal);
-                                block.into()
-                            }).collect();
-    
-                        batch.proposals.push(proposals);
+        let edges: Vec<(&Vertex<Block, String>, &Vertex<Block, String>)> = edges.iter().map(|(source, reference)| {
+            (source, reference)
+        }).collect();
 
-                        let mut miner = create_miner();
-                        miner.dag = dag.clone();
-                        if let Ok(block) = miner.try_mine() {
-                            batch.convergence.push(block.into());
-                        }
-                    },
-                    _ => {}
-                }
-            }
+        if let Ok(mut guard) = dag.write() {
+            guard.extend_from_edges(edges);
         }
     }
 }

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -3,6 +3,7 @@ pub mod result;
 pub use crate::miner::*;
 pub mod block_builder;
 pub mod conflict_resolver;
+pub mod miner_impl;
 // mod miner_v1;
 
 /// Legacy miner implementation

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -4,6 +4,7 @@ pub use crate::miner::*;
 pub mod block_builder;
 pub mod conflict_resolver;
 pub mod miner_impl;
+pub(crate) mod test_helpers;
 // mod miner_v1;
 
 /// Legacy miner implementation
@@ -18,25 +19,18 @@ pub mod v2 {
 
 #[cfg(test)]
 mod tests {
-    #![allow(unused, deprecated, deprecated_in_future)]
     use bulldag::vertex::Vertex;
-    use patriecia::common::Key;
     use primitives::Address;
     use ritelinked::LinkedHashMap;
-    use secp256k1::Message;
-    use vrrb_core::{keypair::Keypair, claim::Claim};
-    use sha2::{Digest, Sha256};
+    use vrrb_core::{keypair::Keypair, claim::Claim, txn::{TransactionDigest, Txn}};
     use block::{Block, ProposalBlock};
-    use tokio;
 
-    use crate::{
-        test_helpers::{
-            mine_genesis, 
-            create_miner, 
-            create_miner_from_keypair, 
-            create_keypair, 
-            create_and_sign_message, MinerDag, create_miner_return_dag, build_proposal_block, create_txns
-        }, MinerConfig
+    use crate::test_helpers::{
+        mine_genesis, 
+        create_miner, 
+        create_miner_from_keypair, 
+        create_and_sign_message, 
+        create_miner_return_dag, build_single_proposal_block, create_miner_from_keypair_and_dag, create_miner_from_keypair_return_dag, build_single_proposal_block_from_txns, create_txns
     };
 
     #[test]
@@ -61,7 +55,6 @@ mod tests {
     #[test]
     fn test_get_miner_publickey() {
         let kp = Keypair::random();
-        let address = Address::new(kp.miner_kp.1.clone());
         let miner = create_miner_from_keypair(&kp);
 
         assert_eq!(miner.public_key(), kp.miner_kp.1);
@@ -78,7 +71,7 @@ mod tests {
     #[test]
     fn test_sign_valid_message() {
         let (msg, kp, sig) = create_and_sign_message();
-        let mut miner = create_miner_from_keypair(&kp);
+        let miner = create_miner_from_keypair(&kp);
         let from_miner = miner.sign_message(msg.clone());
 
         assert_eq!(from_miner, sig);
@@ -89,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_mine_valid_convergence_block_empty_proposals() {
-        let (mut miner, mut dag) = create_miner_return_dag();
+        let (mut miner, dag) = create_miner_return_dag();
         let keypair = Keypair::random();
         let other_miner = create_miner_from_keypair(&keypair); 
         
@@ -131,55 +124,123 @@ mod tests {
 
     #[test]
     fn test_mine_valid_convergence_block_from_proposals_w_no_conflicts() {
-        let (mut miner, mut dag) = create_miner_return_dag();
-        let keypair = Keypair::random();
-        let other_miner = create_miner_from_keypair(&keypair); 
+        let m1kp = Keypair::random();
+        let m2kp = Keypair::random();
+        let (mut miner, dag) = create_miner_from_keypair_return_dag(&m1kp); 
+        let mut other_miner = create_miner_from_keypair_and_dag(
+            &m2kp, 
+            dag.clone()
+        ); 
         
         let genesis = mine_genesis();
         if let Some(genesis) = genesis {
             miner.last_block = Some(&genesis);
+            other_miner.last_block = Some(&genesis);
             let gblock = Block::Genesis { block: genesis.clone() };
             let gvtx: Vertex<Block, String> = gblock.into();
-            let prop1 = ProposalBlock::build(
+            let prop1 = build_single_proposal_block(
                 genesis.hash.clone(),
+                5,
+                4,
                 0,
                 0,
-                LinkedHashMap::new(),
-                LinkedHashMap::new(),
-                other_miner.claim.clone(),
-                keypair.miner_kp.0.clone()
+                miner.claim.clone(),
+                m1kp.miner_kp.0.clone()
             );
+            let prop2 = build_single_proposal_block(
+                genesis.hash.clone(),
+                5,
+                4,
+                0,
+                0,
+                other_miner.claim.clone(),
+                m2kp.miner_kp.0.clone()
+            );
+
             let pblock1 = Block::Proposal { block: prop1.clone() };
             let pvtx1: Vertex<Block, String> = pblock1.into(); 
+            let pblock2 = Block::Proposal { block: prop2.clone() };
+            let pvtx2: Vertex<Block, String> = pblock2.into(); 
             if let Ok(mut guard) = dag.write() {
-                let edge = (&gvtx, &pvtx1);
-                guard.add_edge(edge);
+                let edge1 = (&gvtx, &pvtx1);
+                let edge2 = (&gvtx, &pvtx2);
+                guard.add_edge(edge1);
+                guard.add_edge(edge2);
             }
 
             let convergence = miner.try_mine(); 
             if let Ok(cblock) = convergence {
                 let cvtx: Vertex<Block, String> = cblock.into();
                 if let Ok(mut guard) = dag.write() {
-                    let edge = (&pvtx1, &cvtx);
-                    guard.add_edge(edge);
+                    let edge1 = (&pvtx1, &cvtx);
+                    let edge2 = (&pvtx2, &cvtx);
+                    guard.add_edge(edge1);
+                    guard.add_edge(edge2);
                 }
             }
 
             if let Ok(guard) = dag.read() {
-                assert_eq!(guard.len(), 3);
+                assert_eq!(guard.len(), 4);
             }
         }
     }
 
     #[test]
     fn test_mine_valid_convergence_block_from_proposals_conflicts_curr_round() {
+        let m1kp = Keypair::random();
+        let (mut miner, dag) = create_miner_from_keypair_return_dag(&m1kp); 
+        
         let genesis = mine_genesis();
+        if let Some(genesis) = genesis {
+            miner.last_block = Some(&genesis);
+            let gblock = Block::Genesis { block: genesis.clone() };
+            let gvtx: Vertex<Block, String> = gblock.into();
+            let txns: LinkedHashMap<TransactionDigest, Txn> = create_txns(5).collect();
+            let prop1 = build_single_proposal_block_from_txns(
+                genesis.hash.clone(), txns.clone(), 0, 0
+            );
+            let prop2 = build_single_proposal_block_from_txns(
+                genesis.hash.clone(), txns.clone(), 0, 0
+            );
+
+            let pblock1 = Block::Proposal { block: prop1.clone() };
+            let pvtx1: Vertex<Block, String> = pblock1.into(); 
+            let pblock2 = Block::Proposal { block: prop2.clone() };
+            let pvtx2: Vertex<Block, String> = pblock2.into(); 
+            if let Ok(mut guard) = dag.write() {
+                let edge1 = (&gvtx, &pvtx1);
+                let edge2 = (&gvtx, &pvtx2);
+                guard.add_edge(edge1);
+                guard.add_edge(edge2);
+            }
+
+            let convergence = miner.try_mine(); 
+            if let Ok(cblock) = convergence {
+                let cvtx: Vertex<Block, String> = cblock.clone().into();
+                if let Ok(mut guard) = dag.write() {
+                    let edge1 = (&pvtx1, &cvtx);
+                    let edge2 = (&pvtx2, &cvtx);
+                    guard.add_edge(edge1);
+                    guard.add_edge(edge2);
+                }
+
+                match cblock {
+                    Block::Convergence { ref block } => {
+                        let total_len: usize = block.txns.iter().map(|(_, v)| {v.len()}).sum();
+                        assert_eq!(total_len, 15usize);
+                    },
+                    _ => {}
+                }
+            }
+
+            if let Ok(guard) = dag.read() {
+                assert_eq!(guard.len(), 4);
+            }
+        }
     }
 
     #[test]
-    fn test_mine_valid_convergence_block_from_proposals_conflicts_prev_rounds() {
-        let genesis = mine_genesis();
-    }
+    fn test_mine_valid_convergence_block_from_proposals_conflicts_prev_rounds() {}
 
     #[test]
     fn test_miner_handles_epoch_change() {}
@@ -188,405 +249,3 @@ mod tests {
     fn test_miner_handles_utility_adjustment_upon_epoch_change() {}
 }
 
-pub(crate) mod test_helpers {
-    #![allow(unused, deprecated, deprecated_in_future)]
-    use std::sync::{Arc, RwLock};
-
-    use block::{
-        invalid::InvalidBlockErrorReason,
-        Block,
-        GenesisBlock,
-        ProposalBlock,
-        TxnList, ConvergenceBlock, InnerBlock,
-    };
-    use bulldag::{graph::BullDag, vertex::Vertex};
-    use primitives::{Address, PublicKey, SecretKey, Signature};
-    use ritelinked::LinkedHashMap;
-    use secp256k1::Message;
-    use sha2::{Digest, Sha256};
-    use vrrb_core::{
-        claim::Claim,
-        helpers::size_of_txn_list,
-        keypair::Keypair,
-        txn::{NewTxnArgs, Txn, TransactionDigest, generate_txn_digest_vec},
-    };
-
-    use crate::{Miner, MinerConfig, result::MinerError};
-
-    /// Move this into primitives and call it simply `BlockDag`
-    pub type MinerDag = Arc<RwLock<BullDag<Block, String>>>;
-
-    /// Helper struct to build out DAG for testing 
-    ///
-    /// fields:
-    ///     `genesis: Option<Vertex<Block, String>>`
-    ///     `proposals: Vec<Vec<Vertex<Block, String>>>`
-    ///     `convergence: Vec<Vec<Vertex<Block, String>>>`
-    #[derive(Debug, Clone)]
-    pub(crate) struct BatchEdges {
-        genesis: Option<Vertex<Block, String>>,
-        proposals: Vec<Vec<Vertex<Block, String>>>,
-        convergence: Vec<Vertex<Block, String>>
-    }
-
-    pub(crate) fn create_miner() -> Miner<'static> {
-        let (secret_key, public_key) = create_keypair();
-        let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
-
-        let config = MinerConfig {
-            secret_key,
-            public_key,
-            dag,
-        };
-
-        Miner::new(config)
-    }
-
-    pub(crate) fn create_miner_from_keypair(kp: &Keypair) -> Miner {
-        let (secret_key, public_key) = kp.miner_kp;
-        let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
-        
-        let config = MinerConfig {
-            secret_key,
-            public_key,
-            dag
-        };
-
-        Miner::new(config)
-    }
-
-    pub(crate) fn create_keypair() -> (SecretKey, PublicKey) {
-        let kp = Keypair::random();
-        kp.miner_kp
-    }
-
-    pub(crate) fn create_address(pubkey: &PublicKey) -> Address {
-        Address::new(pubkey.clone())
-    }
-
-    pub(crate) fn create_claim(pk: &PublicKey, addr: &str) -> Claim {
-        Claim::new(pk.to_string(), addr.to_string())
-    }
-
-    pub(crate) fn create_and_sign_message() -> (Message, Keypair, Signature) {
-        let kp = Keypair::random();
-        let message = b"Test Message";
-        let msg = {
-            let mut hasher = sha2::Sha256::new();
-            hasher.update(message);
-            let message = hasher.finalize();
-            Message::from_slice(&message[..]).unwrap()
-        };
-
-        let sig = kp.miner_kp.0.sign_ecdsa(msg);
-
-        return (msg, kp, sig)
-
-    }
-
-    pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
-        let miner = create_miner();
-
-        let claim = miner.generate_claim();
-
-        let claim_list = {
-            vec![(claim.public_key.clone(), claim.clone())]
-                .iter()
-                .cloned()
-                .collect()
-        };
-
-        miner.mine_genesis_block(claim_list)
-    }
-
-    pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
-        (0..n)
-            .map(|n| {
-                let (sk, pk) = create_keypair();
-                let raddr = "0x192abcdef01234567890".to_string();
-                let saddr = create_address(&pk);
-                let amount = (n.pow(2)) as u128;
-                let token = None;
-
-                let txn_args = NewTxnArgs {
-                    timestamp: 0,
-                    sender_address: saddr.to_string(),
-                    sender_public_key: pk.clone(),
-                    receiver_address: raddr,
-                    token,
-                    amount,
-                    signature: sk.sign_ecdsa(Message::from_hashed_data::<
-                        secp256k1::hashes::sha256::Hash,
-                    >(b"vrrb")),
-                    validators: None,
-                    nonce: n.clone() as u128,
-                };
-
-                let mut txn = Txn::new(txn_args);
-
-                txn.sign(&sk);
-
-                let txn_digest_vec = generate_txn_digest_vec(
-                    txn.timestamp, 
-                    txn.sender_address.clone(), 
-                    txn.sender_public_key.clone(), 
-                    txn.receiver_address.clone(), 
-                    txn.token.clone(), 
-                    txn.amount, 
-                    txn.nonce
-                ); 
-
-                let digest = TransactionDigest::from(txn_digest_vec);
-
-                (digest, txn)
-            })
-            .into_iter()
-    }
-
-    pub(crate) fn create_claims(n: usize) -> impl Iterator<Item = (String, Claim)> {
-        (0..n)
-            .map(|_| {
-                let (_, pk) = create_keypair();
-                let addr = create_address(&pk);
-                let claim = create_claim(&pk, &addr.to_string());
-                (claim.public_key.clone(), claim)
-            })
-            .into_iter()
-    }
-
-    pub(crate) fn build_proposal_block(
-        ref_hash: &String,
-        n_tx: usize,
-        n_claims: usize,
-        round: u128,
-        epoch: u128,
-    ) -> Result<ProposalBlock, InvalidBlockErrorReason> {
-        let txns: TxnList = create_txns(n_tx).collect();
-
-        let claims = create_claims(n_claims).collect();
-
-        let miner = create_miner();
-
-        let prop_block =
-            miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims);
-
-        let total_txns_size = size_of_txn_list(&txns);
-
-        if total_txns_size > 2000 {
-            return Err(InvalidBlockErrorReason::InvalidBlockSize);
-        }
-
-        return prop_block;
-    }
-
-    pub(crate) fn mine_convergence_block() -> Result<Block, MinerError> {
-        let mut miner = create_miner();
-        miner.try_mine()
-    }
-
-    pub(crate) fn mine_convergence_block_epoch_change(
-    ) -> Result<Block, MinerError> {
-        let mut miner = create_miner();
-        //TODO: Add Mock Convergence Block with round height of 29.999999mm
-        miner.try_mine()
-    }
-
-    pub(crate) fn create_miner_return_dag() -> (Miner<'static>, MinerDag) {
-        let mut miner = create_miner();
-        let dag = miner.dag.clone();
-
-        (miner, dag)
-    }
-
-    pub(crate) fn create_miner_from_dag(dag: MinerDag) -> (Miner<'static>, MinerDag) {
-        let mut miner = create_miner();
-        miner.dag = dag.clone(); 
-
-        (miner, dag)
-    }
-
-    pub(crate) fn build_single_proposal_block(
-        last_block_hash: String,
-        n_txns: usize, 
-        n_claims: usize,
-        round: u128,
-        epoch: u128,
-        from: Claim,
-        sk: SecretKey,
-    ) -> ProposalBlock {
-        let txns = create_txns(n_txns).collect();
-        let claims = create_claims(n_claims).collect();
-        ProposalBlock::build(
-            last_block_hash,
-            round,
-            epoch,
-            txns,
-            claims,
-            from,
-            sk 
-        )
-    }
-
-    pub(crate) fn build_multiple_proposal_blocks_single_round(
-        n_blocks: usize,
-        last_block_hash: String,
-        n_txns: usize,
-        n_claims: usize,
-        round: u128,
-        epoch: u128,
-    ) -> Vec<ProposalBlock> {
-        
-        (0..n_blocks).into_iter().map(|n| {
-
-            let keypair = Keypair::random();
-            let address = Address::new(keypair.miner_kp.1.clone());
-            let claim = Claim::new(keypair.miner_kp.1.clone().to_string(), address.to_string());
-            let prop = build_single_proposal_block(
-                last_block_hash.clone(), 
-                n_txns, 
-                n_claims, 
-                round, 
-                epoch, 
-                claim, 
-                keypair.miner_kp.0.clone()
-            );
-            prop
-        }).collect()
-    }
-
-    pub(crate) fn build_multiple_rounds(
-        dag: &mut MinerDag,
-        last_block_hash: String, 
-        n_blocks: usize, 
-        n_txns: usize,
-        n_claims: usize,
-        n_rounds: usize,
-        round: &mut usize,
-        epoch: usize,
-    ) {
-        // Recursively add rounds of blocks to the DAG
-        // Need to ensure that there is a genesis block in the dag already.
-        if n_rounds > round.clone() {
-            if dag_has_genesis(&mut dag.clone()) {
-                if let Some(hash) = mine_next_convergence_block(&mut dag.clone()) {
-                    *round += 1usize;
-                    let proposals = build_multiple_proposal_blocks_single_round(
-                        n_blocks, hash.clone(), n_txns, n_claims, round.clone() as u128, epoch as u128
-                    );
-                    append_proposal_blocks_to_dag(&mut dag.clone(), proposals);
-                    build_multiple_rounds(
-                        &mut dag.clone(),
-                        hash,
-                        n_blocks,
-                        n_txns,
-                        n_claims,
-                        n_rounds,
-                        round,
-                        epoch,
-                    );
-                };
-                
-            } else {
-                if let Some(hash) = add_genesis_to_dag(&mut dag.clone()) {
-                    *round += 1usize;
-                    build_multiple_rounds(
-                        &mut dag.clone(),
-                        hash,
-                        n_blocks,
-                        n_txns,
-                        n_claims,
-                        n_rounds,
-                        round,
-                        epoch
-                    );
-                }
-            }
-        }
-    }
-
-    pub(crate) fn dag_has_genesis(dag: &mut MinerDag) -> bool {
-        dag.read().unwrap().len() > 0
-    }
-
-    pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
-        let mut prop_vertices = Vec::new();
-        let genesis = mine_genesis();
-        let keypair = Keypair::random();
-        let miner = create_miner_from_keypair(&keypair);
-
-        if let Some(genesis) = genesis {
-            let gblock = Block::Genesis { block: genesis.clone() };
-            let gvtx: Vertex<Block, String> = gblock.into();
-            let prop1 = ProposalBlock::build(
-                genesis.hash.clone(),
-                0,
-                0,
-                LinkedHashMap::new(),
-                LinkedHashMap::new(),
-                miner.claim.clone(),
-                keypair.miner_kp.0.clone()
-            );
-            let pblock = Block::Proposal { block: prop1.clone() };
-            let pvtx: Vertex<Block, String> = pblock.into(); 
-            prop_vertices.push(pvtx.clone());
-            if let Ok(mut guard) = dag.write() {
-                let edge = (&gvtx, &pvtx);
-                guard.add_edge(edge);
-                return Some(genesis.get_hash().clone())
-            }
-        }
-        None
-    }
-
-    pub(crate) fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> {
-        let keypair = Keypair::random();
-        let mut miner = create_miner_from_keypair(&keypair);
-        miner.dag = dag.clone();
-        if let Ok(cblock) = miner.try_mine() {
-            if let Block::Convergence { ref block } = cblock.clone() {
-                let cvtx: Vertex<Block, String> = cblock.into();
-                let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![]; 
-                if let Ok(guard) = dag.read() {
-                    block.clone().get_ref_hashes().iter().for_each(|t| {
-                        if let Some(pvtx) = guard.get_vertex(t.clone()) {
-                            edges.push((pvtx.clone(), cvtx.clone()));
-                        }
-                    });
-                }
-    
-                if let Ok(mut guard) = dag.write() {
-                    let edges = edges.iter().map(|(source, reference)| {
-                        (source, reference)
-                    }).collect();
-                    guard.extend_from_edges(edges);
-                    return Some(block.get_hash())
-                }
-            }
-        }
-    
-        None
-    }
-
-    pub(crate) fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
-        let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
-        for block in proposals.iter() {
-            let ref_hash = block.ref_block.clone();
-            if let Ok(guard) = dag.read() {
-                if let Some(cvtx) = guard.get_vertex(ref_hash) {
-                    let pblock = Block::Proposal { block: block.clone() };
-                    let pvtx: Vertex<Block, String> = pblock.into();
-                    let edge = (cvtx.clone(), pvtx.clone());
-                    edges.push(edge);
-                }
-            }
-        }
-
-        let edges: Vec<(&Vertex<Block, String>, &Vertex<Block, String>)> = edges.iter().map(|(source, reference)| {
-            (source, reference)
-        }).collect();
-
-        if let Ok(mut guard) = dag.write() {
-            guard.extend_from_edges(edges);
-        }
-    }
-}

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod miner;
 pub mod result;
 pub use crate::miner::*;
+pub mod block_builder;
+pub mod conflict_resolver;
 // mod miner_v1;
 
 /// Legacy miner implementation

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -18,663 +18,150 @@ pub mod v2 {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr};
+    #![allow(unused, deprecated, deprecated_in_future)]
+    use primitives::Address;
+    use secp256k1::Message;
+    use vrrb_core::{keypair::Keypair, claim::Claim};
+    use sha2::{Digest, Sha256};
 
-    use block::{header::BlockHeader, Block, ConvergenceBlock};
-    use bulldag::{graph::BullDag, vertex::Vertex};
-    use primitives::{PublicKey, Signature};
-    use reward::reward::Reward;
-    use ritelinked::{LinkedHashMap, LinkedHashSet};
-    use secp256k1::{
-        hashes::{sha256 as s256, Hash},
-        Message,
-    };
-    use sha256::digest;
-    use utils::{create_payload, hash_data};
-    use vrrb_core::txn::Txn;
-
-    use super::test_helpers::create_txns;
-    use crate::test_helpers::{
-        build_proposal_block,
-        create_claim,
-        create_keypair,
-        create_miner,
-        mine_convergence_block,
-        mine_convergence_block_epoch_change,
-        mine_genesis,
-    };
+    use crate::{test_helpers::{mine_genesis, create_miner, create_miner_from_keypair, create_keypair, create_and_sign_message}, MinerConfig};
 
     #[test]
-    fn test_create_genesis_block() {
-        let genesis = mine_genesis();
-        assert!(genesis.is_some());
+    fn test_create_miner() {
+        let kp = Keypair::random();
+        let address = Address::new(kp.miner_kp.1.clone());
+        let claim = Claim::new(kp.miner_kp.1.to_string().clone(), address.to_string().clone());
+        let miner = create_miner_from_keypair(&kp);
+
+        assert_eq!(miner.claim, claim);
     }
 
     #[test]
-    fn test_create_proposal_block() {
-        let genesis = mine_genesis().unwrap();
-        let proposal = build_proposal_block(&genesis.hash, 30, 10, 0, 0).unwrap();
+    fn test_get_miner_address() {
+        let kp = Keypair::random();
+        let address = Address::new(kp.miner_kp.1.clone());
+        let miner = create_miner_from_keypair(&kp);
 
-        let payload = create_payload!(
-            proposal.round,
-            proposal.epoch,
-            proposal.txns,
-            proposal.claims,
-            proposal.from
-        );
+        assert_eq!(miner.address(), address);
+    } 
 
-        let h_pk = proposal.from.public_key;
-        let h_pk = PublicKey::from_str(&h_pk).unwrap();
-        let sig = proposal.signature;
-        let sig = Signature::from_str(&sig).unwrap();
-        let verify = sig.verify(&payload, &h_pk);
+    #[test]
+    fn test_get_miner_publickey() {
+        let kp = Keypair::random();
+        let address = Address::new(kp.miner_kp.1.clone());
+        let miner = create_miner_from_keypair(&kp);
 
-        assert!(verify.is_ok())
+        assert_eq!(miner.public_key(), kp.miner_kp.1);
     }
 
     #[test]
-    fn test_create_proposal_block_over_size_limit() {
-        let genesis = mine_genesis().unwrap();
-        let proposal = build_proposal_block(&genesis.hash, 2000, 10, 0, 0);
-
-        assert!(proposal.is_err());
-    }
-
-    #[test]
-    fn test_create_convergence_block_no_conflicts() {
-        let genesis = mine_genesis();
-        if let Some(gblock) = genesis {
-            let ref_hash = gblock.hash.clone();
-            let round = gblock.header.round.clone() + 1;
-            let epoch = gblock.header.epoch.clone();
-
-            let prop1 = build_proposal_block(&ref_hash, 30, 10, round, epoch)
-                .unwrap()
-                .clone();
-
-            let prop2 = build_proposal_block(&ref_hash, 40, 5, round, epoch)
-                .unwrap()
-                .clone();
-
-            let proposals = vec![prop1.clone(), prop2.clone()];
-
-            let mut chain: BullDag<Block, String> = BullDag::new();
-
-            let gvtx = Vertex::new(
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-                gblock.hash.clone(),
-            );
-
-            let p1vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop1.clone(),
-                },
-                prop1.hash.clone(),
-            );
-
-            let p2vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop2.clone(),
-                },
-                prop2.hash.clone(),
-            );
-
-            let edges = vec![(&gvtx, &p1vtx), (&gvtx, &p2vtx)];
-
-            chain.extend_from_edges(edges);
-
-            let c_block =
-                mine_convergence_block(&proposals, &chain, Block::Genesis { block: gblock });
-
-            if let Some(cb) = c_block {
-                let sig = cb.header.miner_signature;
-                let sig = Signature::from_str(&sig).unwrap();
-
-                let payload = create_payload!(
-                    cb.header.ref_hashes,
-                    cb.header.round,
-                    cb.header.epoch,
-                    cb.header.block_seed,
-                    cb.header.next_block_seed,
-                    cb.header.block_height,
-                    cb.header.timestamp,
-                    cb.header.txn_hash,
-                    cb.header.miner_claim,
-                    cb.header.claim_list_hash,
-                    cb.header.block_reward,
-                    cb.header.next_block_reward
-                );
-
-                let mpk = cb.header.miner_claim.public_key;
-                let mpk = PublicKey::from_str(&mpk).unwrap();
-
-                let verify = sig.verify(&payload, &mpk);
-
-                assert!(verify.is_ok())
-            }
-        } else {
-            panic!("A ConvergenceBlock should be produced")
-        }
-    }
-
-    #[test]
-    fn test_resolve_conflicts_curr_round() {
-        // Create a large transaction map
-        let genesis = mine_genesis();
-        if let Some(gblock) = genesis {
-            let ref_hash = gblock.hash.clone();
-            let round = gblock.header.round + 1;
-            let epoch = gblock.header.epoch;
-
-            let mut prop1 = build_proposal_block(&ref_hash, 30, 10, round, epoch)
-                .unwrap()
-                .clone();
-
-            let mut prop2 = build_proposal_block(&ref_hash, 40, 5, round, epoch)
-                .unwrap()
-                .clone();
-
-            let txns: HashMap<String, Txn> = create_txns(5).collect();
-            prop1.txns.extend(txns.clone());
-            prop2.txns.extend(txns.clone());
-
-            let proposals = vec![prop1.clone(), prop2.clone()];
-
-            let mut chain: BullDag<Block, String> = BullDag::new();
-
-            let gvtx = Vertex::new(
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-                gblock.hash.clone(),
-            );
-
-            let p1vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop1.clone(),
-                },
-                prop1.hash.clone(),
-            );
-
-            let p2vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop2.clone(),
-                },
-                prop2.hash.clone(),
-            );
-
-            let edges = vec![(&gvtx, &p1vtx), (&gvtx, &p2vtx)];
-
-            chain.extend_from_edges(edges);
-
-            let c_block =
-                mine_convergence_block(&proposals, &chain, Block::Genesis { block: gblock });
-
-            if let Some(cb) = c_block {
-                let sig = cb.header.miner_signature;
-                let sig = Signature::from_str(&sig).unwrap();
-
-                let payload = create_payload!(
-                    cb.header.ref_hashes,
-                    cb.header.round,
-                    cb.header.epoch,
-                    cb.header.block_seed,
-                    cb.header.next_block_seed,
-                    cb.header.block_height,
-                    cb.header.timestamp,
-                    cb.header.txn_hash,
-                    cb.header.miner_claim,
-                    cb.header.claim_list_hash,
-                    cb.header.block_reward,
-                    cb.header.next_block_reward
-                );
-
-                let mpk = cb.header.miner_claim.public_key;
-                let mpk = PublicKey::from_str(&mpk).unwrap();
-
-                let verify = sig.verify(&payload, &mpk);
-
-                assert!(verify.is_ok());
-
-                let total_w_duplicates = { prop1.txns.keys().len() + prop2.txns.keys().len() };
-
-                assert!(total_w_duplicates > cb.txns.len());
-
-                // Get the winner of the PoC election between proposer 1 and 2
-                let mut proposer_ps = vec![
-                    (
-                        prop1.hash,
-                        prop1.from.get_pointer(cb.header.block_seed as u128),
-                    ),
-                    (
-                        prop2.hash,
-                        prop2.from.get_pointer(cb.header.block_seed as u128),
-                    ),
-                ];
-
-                // The first will be the winner
-                proposer_ps.sort_unstable_by(|(_, a_pointer), (_, b_pointer)| {
-                    match (a_pointer, b_pointer) {
-                        (Some(x), Some(y)) => x.cmp(y),
-                        (None, Some(_)) => std::cmp::Ordering::Greater,
-                        (Some(_), None) => std::cmp::Ordering::Less,
-                        (None, None) => std::cmp::Ordering::Equal,
-                    }
-                });
-                let winner = proposer_ps[0].0.clone();
-                let mut resolved_conflicts = cb.txns.clone();
-                resolved_conflicts.retain(|_, set| {
-                    let conflicts = txns.keys().cloned().collect();
-                    let intersection: LinkedHashSet<&String> =
-                        set.intersection(&conflicts).collect();
-                    intersection.len() > 0
-                });
-
-                let key: Vec<String> = resolved_conflicts.keys().cloned().collect();
-                assert!(key.len() == 1);
-                assert_eq!(key[0], winner);
-            }
-        } else {
-            panic!("A ConvergenceBlock should be produced")
-        }
-    }
-
-    #[test]
-    fn test_resolve_conflicts_prev_rounds() {
-        let genesis = mine_genesis();
-        if let Some(gblock) = genesis {
-            let ref_hash = gblock.hash.clone();
-            let round = gblock.header.round.clone() + 1;
-            let epoch = gblock.header.epoch.clone();
-
-            let mut prop1 = build_proposal_block(&ref_hash, 30, 10, round, epoch)
-                .unwrap()
-                .clone();
-
-            let mut prop2 = build_proposal_block(&ref_hash, 40, 5, round, epoch)
-                .unwrap()
-                .clone();
-
-            let txns: HashMap<String, Txn> = create_txns(5).collect();
-            prop1.txns.extend(txns.clone());
-
-            let proposals = vec![prop1.clone(), prop2.clone()];
-
-            let mut chain: BullDag<Block, String> = BullDag::new();
-
-            let gvtx = Vertex::new(
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-                gblock.hash.clone(),
-            );
-
-            let p1vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop1.clone(),
-                },
-                prop1.hash.clone(),
-            );
-
-            let p2vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop2.clone(),
-                },
-                prop2.hash.clone(),
-            );
-
-            let edges = vec![(&gvtx, &p1vtx), (&gvtx, &p2vtx)];
-
-            chain.extend_from_edges(edges);
-
-            let c_block_1 = mine_convergence_block(
-                &proposals,
-                &chain,
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-            );
-
-            let cb1 = c_block_1.unwrap();
-
-            let cb1vtx = Vertex::new(Block::Convergence { block: cb1.clone() }, cb1.hash.clone());
-
-            let edges = vec![(&p1vtx, &cb1vtx), (&p2vtx, &cb1vtx)];
-
-            chain.extend_from_edges(edges);
-
-            let mut prop3 = build_proposal_block(&ref_hash, 20, 10, round, epoch)
-                .unwrap()
-                .clone();
-
-            prop3.txns.extend(txns.clone());
-
-            let c_block_2 = mine_convergence_block(
-                &vec![prop3.clone()],
-                &chain,
-                Block::Genesis {
-                    block: gblock.clone(),
-                },
-            );
-
-            let cb2 = {
-                let cb = c_block_2.unwrap();
-                let sig = cb.header.miner_signature.clone();
-                let sig = Signature::from_str(&sig).unwrap();
-
-                let payload = create_payload!(
-                    cb.header.ref_hashes,
-                    cb.header.round,
-                    cb.header.epoch,
-                    cb.header.block_seed,
-                    cb.header.next_block_seed,
-                    cb.header.block_height,
-                    cb.header.timestamp,
-                    cb.header.txn_hash,
-                    cb.header.miner_claim,
-                    cb.header.claim_list_hash,
-                    cb.header.block_reward,
-                    cb.header.next_block_reward
-                );
-
-                let mpk = cb.header.miner_claim.public_key.clone();
-                let mpk = PublicKey::from_str(&mpk).unwrap();
-
-                let verify = sig.verify(&payload, &mpk);
-
-                assert!(verify.is_ok());
-
-                let total_w_duplicates = { prop3.txns.keys().len() };
-
-                assert!(total_w_duplicates > cb.txns.len());
-
-                cb
-            };
-
-            let p3vtx = Vertex::new(
-                Block::Proposal {
-                    block: prop3.clone(),
-                },
-                prop3.hash.clone(),
-            );
-
-            let cb2vtx = Vertex::new(Block::Convergence { block: cb2.clone() }, cb2.hash.clone());
-
-            let edges = vec![(&gvtx, &p3vtx), (&p3vtx, &cb2vtx)];
-
-            chain.extend_from_edges(edges);
-        }
-    }
-
-    #[test]
-    fn test_epoch_change() {
-        let (msk1, mpk1) = create_keypair();
-
+    fn test_read_miner_dag_copy() {
         let miner = create_miner();
-        let addr = miner.address();
-        let nonce = 1;
+        let read_guard = miner.dag.read();
 
-        let ref_hashes = vec!["abcdef".to_string()];
-        let epoch = 0;
-        let round = 29_999_998;
-        let block_seed = 34_989_333;
-        let next_block_seed = 839_999_843;
-        let block_height = 29_999_998;
-        let timestamp = chrono::Utc::now().timestamp();
-        let txn_hash = "abcdef01234567890".to_string();
-        let miner_claim = miner.generate_claim();
-        let claim_list_hash = "01234567890abcdef".to_string();
-        let mut block_reward = Reward::default();
-        block_reward.current_block = block_height;
-        let next_block_reward = block_reward.clone();
-
-        let payload = create_payload!(
-            ref_hashes,
-            round,
-            epoch,
-            block_seed,
-            next_block_seed,
-            block_height,
-            timestamp,
-            txn_hash,
-            miner_claim,
-            claim_list_hash,
-            block_reward,
-            next_block_reward
-        );
-
-        let miner_signature = miner.sign_message(payload).to_string();
-
-        let header = BlockHeader {
-            ref_hashes,
-            round,
-            epoch,
-            block_seed,
-            next_block_seed,
-            block_height,
-            timestamp,
-            txn_hash,
-            miner_claim,
-            claim_list_hash,
-            block_reward,
-            next_block_reward,
-            miner_signature,
-        };
-
-        let txns = LinkedHashMap::new();
-        let claims = LinkedHashMap::new();
-        let block_hash = hash_data!(
-            header.ref_hashes,
-            header.round,
-            header.epoch,
-            header.block_seed,
-            header.next_block_seed,
-            header.block_height,
-            header.timestamp,
-            header.txn_hash,
-            header.miner_claim,
-            header.claim_list_hash,
-            header.block_reward,
-            header.next_block_reward,
-            header.miner_signature
-        );
-
-        let cb1 = ConvergenceBlock {
-            header,
-            txns,
-            claims,
-            hash: block_hash,
-            certificate: None,
-        };
-
-        let mut chain: BullDag<Block, String> = BullDag::new();
-
-        let prop1 = build_proposal_block(&cb1.hash.clone(), 5, 5, 30_000_000, 0)
-            .unwrap()
-            .clone();
-
-        let cb1vtx = Vertex::new(Block::Convergence { block: cb1.clone() }, cb1.hash.clone());
-
-        let p1vtx = Vertex::new(
-            Block::Proposal {
-                block: prop1.clone(),
-            },
-            prop1.hash.clone(),
-        );
-
-        let edges = vec![(&cb1vtx, &p1vtx)];
-
-        chain.extend_from_edges(edges);
-
-        let cb2 = mine_convergence_block_epoch_change(
-            &vec![prop1.clone()],
-            &chain,
-            &Block::Convergence { block: cb1.clone() },
-            0,
-        )
-        .unwrap();
-
-        assert_eq!(cb2.header.next_block_reward.epoch, 1);
-        assert_eq!(cb2.header.next_block_reward.next_epoch_block, 60_000_000);
+        assert!(read_guard.is_ok());
     }
 
     #[test]
-    fn test_utility_adjustment() {
-        let (msk1, mpk1) = create_keypair();
+    fn test_sign_valid_message() {
+        let (msg, kp, sig) = create_and_sign_message();
+        let mut miner = create_miner_from_keypair(&kp);
+        let from_miner = miner.sign_message(msg.clone());
 
-        let miner = create_miner();
-        let addr = miner.address();
-
-        let ref_hashes = vec!["abcdef".to_string()];
-        let epoch = 0;
-        let round = 29_999_998;
-        let block_seed = 34_989_333;
-        let next_block_seed = 839_999_843;
-        let block_height = 29_999_998;
-        let timestamp = chrono::Utc::now().timestamp();
-        let txn_hash = "abcdef01234567890".to_string();
-
-        let miner_claim = create_claim(&mpk1, &addr.to_string(), 1);
-
-        let claim_list_hash = "01234567890abcdef".to_string();
-
-        let mut block_reward = Reward::default();
-        block_reward.current_block = block_height;
-        let next_block_reward = block_reward.clone();
-
-        let payload = create_payload!(
-            ref_hashes,
-            round,
-            epoch,
-            block_seed,
-            next_block_seed,
-            block_height,
-            timestamp,
-            txn_hash,
-            miner_claim,
-            claim_list_hash,
-            block_reward,
-            next_block_reward
-        );
-
-        let miner_signature = msk1.sign_ecdsa(payload).to_string();
-
-        let header = BlockHeader {
-            ref_hashes,
-            round,
-            epoch,
-            block_seed,
-            next_block_seed,
-            block_height,
-            timestamp,
-            txn_hash,
-            miner_claim,
-            claim_list_hash,
-            block_reward,
-            next_block_reward,
-            miner_signature,
-        };
-
-        let txns = LinkedHashMap::new();
-        let claims = LinkedHashMap::new();
-        let block_hash = hash_data!(
-            header.ref_hashes,
-            header.round,
-            header.epoch,
-            header.block_seed,
-            header.next_block_seed,
-            header.block_height,
-            header.timestamp,
-            header.txn_hash,
-            header.miner_claim,
-            header.claim_list_hash,
-            header.block_reward,
-            header.next_block_reward,
-            header.miner_signature
-        );
-
-        let cb1 = ConvergenceBlock {
-            header,
-            txns,
-            claims,
-            hash: block_hash,
-            certificate: None,
-        };
-
-        let mut chain: BullDag<Block, String> = BullDag::new();
-
-        let prop1 = build_proposal_block(&cb1.hash.clone(), 5, 5, 30_000_000, 0)
-            .unwrap()
-            .clone();
-        let cb1vtx = Vertex::new(Block::Convergence { block: cb1.clone() }, cb1.hash.clone());
-
-        let p1vtx = Vertex::new(
-            Block::Proposal {
-                block: prop1.clone(),
-            },
-            prop1.hash.clone(),
-        );
-
-        let edges = vec![(&cb1vtx, &p1vtx)];
-
-        chain.extend_from_edges(edges);
-
-        let cb2 = mine_convergence_block_epoch_change(
-            &vec![prop1.clone()],
-            &chain,
-            &Block::Convergence { block: cb1.clone() },
-            (4 * 30_000_000) as i128,
-        )
-        .unwrap();
-
-        assert_eq!(cb2.header.next_block_reward.amount, 24);
+        assert_eq!(from_miner, sig);
+            
+        let valid = sig.verify(&msg, &kp.miner_kp.1);
+        assert!(valid.is_ok());
     }
+
+    #[test]
+    fn test_generate_timestamp() {
+        let miner = create_miner();
+        let timestamp = miner.get_timestamp();
+        
+        assert_eq!(timestamp, timestamp as u128);
+    }
+
+    #[test]
+    fn test_mine_valid_convergence_block_empty_proposals() {}
+
+    #[test]
+    fn test_mine_valid_convergence_block_from_proposals_w_no_conflicts() {
+        let genesis = mine_genesis();
+    }
+
+    #[test]
+    fn test_mine_valid_convergence_block_from_proposals_conflicts_curr_round() {
+        let genesis = mine_genesis();
+    }
+
+    #[test]
+    fn test_mine_valid_convergence_block_from_proposals_conflicts_prev_rounds() {
+        let genesis = mine_genesis();
+    }
+
+    #[test]
+    fn test_miner_handles_epoch_change() {}
+
+    #[test]
+    fn test_miner_handles_utility_adjustment_upon_epoch_change() {}
 }
 
 pub(crate) mod test_helpers {
-    use std::mem;
+    #![allow(unused, deprecated, deprecated_in_future)]
+    use std::sync::{Arc, RwLock};
 
     use block::{
         invalid::InvalidBlockErrorReason,
         Block,
-        ConvergenceBlock,
         GenesisBlock,
         ProposalBlock,
         TxnList,
-        EPOCH_BLOCK,
     };
     use bulldag::graph::BullDag;
-    use primitives::{Address, PublicKey, SecretKey};
+    use primitives::{Address, PublicKey, SecretKey, Signature};
     use secp256k1::Message;
-    use sha256::digest;
-    use utils::hash_data;
+    use sha2::{Digest, Sha256};
     use vrrb_core::{
         claim::Claim,
         helpers::size_of_txn_list,
-        keypair::KeyPair,
-        txn::{NewTxnArgs, Token, Txn},
+        keypair::Keypair,
+        txn::{NewTxnArgs, Txn, TransactionDigest, generate_txn_digest_vec},
     };
 
-    use crate::{MineArgs, Miner, MinerConfig};
+    use crate::{Miner, MinerConfig, result::MinerError};
+
+    /// Move this into primitives and call it simply `BlockDag`
+    pub type MinerDag = Arc<RwLock<BullDag<Block, String>>>;
 
     pub(crate) fn create_miner() -> Miner {
         let (secret_key, public_key) = create_keypair();
-
-        let address = create_address(&public_key).to_string();
+        let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
 
         let config = MinerConfig {
             secret_key,
             public_key,
-            address,
+            dag,
+        };
+
+        Miner::new(config)
+    }
+
+    pub(crate) fn create_miner_from_keypair(kp: &Keypair) -> Miner {
+        let (secret_key, public_key) = kp.miner_kp;
+        let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
+        
+        let config = MinerConfig {
+            secret_key,
+            public_key,
+            dag
         };
 
         Miner::new(config)
     }
 
     pub(crate) fn create_keypair() -> (SecretKey, PublicKey) {
-        let kp = KeyPair::random();
+        let kp = Keypair::random();
         kp.miner_kp
     }
 
@@ -686,31 +173,44 @@ pub(crate) mod test_helpers {
         Claim::new(pk.to_string(), addr.to_string())
     }
 
+    pub(crate) fn create_and_sign_message() -> (Message, Keypair, Signature) {
+        let kp = Keypair::random();
+        let message = b"Test Message";
+        let msg = {
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(message);
+            let message = hasher.finalize();
+            Message::from_slice(&message[..]).unwrap()
+        };
+
+        let sig = kp.miner_kp.0.sign_ecdsa(msg);
+
+        return (msg, kp, sig)
+
+    }
+
     pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
-        let (sk, pk) = create_keypair();
-        let addr = create_address(&pk);
         let miner = create_miner();
 
         let claim = miner.generate_claim();
 
         let claim_list = {
-            vec![(claim.hash.clone(), claim.clone())]
+            vec![(claim.public_key.clone(), claim.clone())]
                 .iter()
                 .cloned()
                 .collect()
         };
 
-        miner.mine_genesis_block(claim_list, 1)
+        miner.mine_genesis_block(claim_list)
     }
 
-    pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (String, Txn)> {
+    pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
         (0..n)
             .map(|n| {
                 let (sk, pk) = create_keypair();
                 let raddr = "0x192abcdef01234567890".to_string();
                 let saddr = create_address(&pk);
                 let amount = (n.pow(2)) as u128;
-                let nonce = 1u128;
                 let token = None;
 
                 let txn_args = NewTxnArgs {
@@ -731,9 +231,19 @@ pub(crate) mod test_helpers {
 
                 txn.sign(&sk);
 
-                let txn_hash = hash_data!(&txn);
+                let txn_digest_vec = generate_txn_digest_vec(
+                    txn.timestamp, 
+                    txn.sender_address.clone(), 
+                    txn.sender_public_key.clone(), 
+                    txn.receiver_address.clone(), 
+                    txn.token.clone(), 
+                    txn.amount, 
+                    txn.nonce
+                ); 
 
-                (txn_hash, txn)
+                let digest = TransactionDigest::from(txn_digest_vec);
+
+                (digest, txn)
             })
             .into_iter()
     }
@@ -743,8 +253,8 @@ pub(crate) mod test_helpers {
             .map(|_| {
                 let (_, pk) = create_keypair();
                 let addr = create_address(&pk);
-                let claim = create_claim(&pk, &addr.to_string(), 1);
-                (claim.hash.clone(), claim)
+                let claim = create_claim(&pk, &addr.to_string());
+                (claim.public_key.clone(), claim)
             })
             .into_iter()
     }
@@ -756,18 +266,14 @@ pub(crate) mod test_helpers {
         round: u128,
         epoch: u128,
     ) -> Result<ProposalBlock, InvalidBlockErrorReason> {
-        let (sk, pk) = create_keypair();
         let txns: TxnList = create_txns(n_tx).collect();
 
-        let nonce = 1;
-
         let claims = create_claims(n_claims).collect();
-        let hclaim = create_claim(&pk, &create_address(&pk).to_string(), 1);
 
         let miner = create_miner();
 
         let prop_block =
-            miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims, nonce);
+            miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims);
 
         let total_txns_size = size_of_txn_list(&txns);
 
@@ -778,130 +284,15 @@ pub(crate) mod test_helpers {
         return prop_block;
     }
 
-    pub(crate) fn mine_convergence_block(
-        proposals: &Vec<ProposalBlock>,
-        chain: &BullDag<Block, String>,
-        last_block: Block,
-    ) -> Option<ConvergenceBlock> {
-        let (msk, mpk) = create_keypair();
-        let maddr = create_address(&mpk).to_string();
-        let miner_claim = create_claim(&mpk, &maddr, 1);
-        let txns = create_txns(30).collect();
-        let claims = create_claims(5).collect();
-        let claim_list_hash = Some(hash_data!(claims));
-
-        let miner = create_miner();
-        let maddr = miner.address();
-
-        let mut reward = {
-            match last_block {
-                Block::Convergence { ref block } => block.header.next_block_reward.clone(),
-                Block::Genesis { ref block } => block.header.next_block_reward.clone(),
-                _ => return None,
-            }
-        };
-
-        let epoch = {
-            match last_block {
-                Block::Convergence { ref block } => {
-                    if block.header.block_height % EPOCH_BLOCK as u128 == 0 {
-                        block.header.epoch + 1
-                    } else {
-                        block.header.epoch
-                    }
-                },
-                Block::Genesis { ref block } => 0,
-                _ => return None,
-            }
-        };
-
-        let round = {
-            match last_block {
-                Block::Convergence { ref block } => block.header.round + 1,
-                Block::Genesis { .. } => 1,
-                _ => return None,
-            }
-        };
-
-        let mine_args = MineArgs {
-            claim: miner_claim,
-            last_block: last_block.clone(),
-            txns,
-            claims,
-            claim_list_hash,
-            reward: &mut reward,
-            abandoned_claim: None,
-            secret_key: msk,
-            epoch,
-            round,
-            next_epoch_adjustment: 0,
-        };
-
-        let miner = create_miner();
-        miner.mine_convergence_block(mine_args, proposals, chain)
-        // ConvergenceBlock::mine(mine_args, proposals, chain)
+    pub(crate) fn mine_convergence_block() -> Result<Block, MinerError> {
+        let mut miner = create_miner();
+        miner.try_mine()
     }
 
     pub(crate) fn mine_convergence_block_epoch_change(
-        proposals: &Vec<ProposalBlock>,
-        chain: &BullDag<Block, String>,
-        last_block: &Block,
-        next_epoch_adjustment: i128,
-    ) -> Option<ConvergenceBlock> {
-        let (msk, mpk) = create_keypair();
-        let maddr = create_address(&mpk).to_string();
-        let miner_claim = create_claim(&mpk, &maddr, 1);
-
-        let txns = create_txns(30).collect();
-        let claims = create_claims(5).collect();
-        let claim_list_hash = Some(hash_data!(claims));
-
-        let mut reward = {
-            match last_block {
-                Block::Convergence { ref block } => block.header.next_block_reward.clone(),
-                Block::Genesis { ref block } => block.header.next_block_reward.clone(),
-                _ => return None,
-            }
-        };
-
-        let epoch = {
-            match last_block {
-                Block::Convergence { ref block } => {
-                    if block.header.block_height % EPOCH_BLOCK as u128 == 0 {
-                        block.header.epoch + 1
-                    } else {
-                        block.header.epoch
-                    }
-                },
-                Block::Genesis { ref block } => 0,
-                _ => return None,
-            }
-        };
-
-        let round = {
-            match last_block {
-                Block::Convergence { ref block } => block.header.round + 1,
-                Block::Genesis { .. } => 1,
-                _ => return None,
-            }
-        };
-
-        let mine_args = MineArgs {
-            claim: miner_claim,
-            last_block: last_block.clone(),
-            txns,
-            claims,
-            claim_list_hash,
-            reward: &mut reward,
-            abandoned_claim: None,
-            secret_key: msk,
-            epoch,
-            round,
-            next_epoch_adjustment,
-        };
-
-        let miner = create_miner();
-
-        miner.mine_convergence_block(mine_args, proposals, chain)
+    ) -> Result<Block, MinerError> {
+        let mut miner = create_miner();
+        //TODO: Add Mock Convergence Block with round height of 29.999999mm
+        miner.try_mine()
     }
 }

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -86,10 +86,10 @@ pub struct Miner {
     secret_key: MinerSk,
     public_key: MinerPk,
     address: Address,
-    claim: Claim,
-    dag: Arc<RwLock<BullDag<Block, String>>>,
-    last_block: Option<ConvergenceBlock>,
-    status: MinerStatus,
+    pub claim: Claim,
+    pub dag: Arc<RwLock<BullDag<Block, String>>>,
+    pub last_block: Option<ConvergenceBlock>,
+    pub status: MinerStatus,
 }
 
 impl Miner {
@@ -281,7 +281,7 @@ impl Miner {
         Some(genesis)
     }
 
-    fn consolidate_txns(
+    pub(crate) fn consolidate_txns(
         &self, 
         proposals: &Vec<ProposalBlock>
     ) -> ConsolidatedTxns {
@@ -297,7 +297,7 @@ impl Miner {
         }).collect()
     }
 
-    fn consolidate_claims(
+    pub(crate) fn consolidate_claims(
         &self,
         proposals: &Vec<ProposalBlock>
     ) -> ConsolidatedClaims {
@@ -314,13 +314,13 @@ impl Miner {
         }).collect()
     }
 
-    fn get_ref_hashes(&self, proposals: &Vec<ProposalBlock>) -> &Vec<RefHash> {
+    pub(crate) fn get_ref_hashes(&self, proposals: &Vec<ProposalBlock>) -> &Vec<RefHash> {
         proposals.iter().map(|b| {
             b.hash.clone()
         }).collect()
     }
 
-    fn get_txn_hash(&self, txns: &ConsolidatedTxns) -> String {
+    pub(crate) fn get_txn_hash(&self, txns: &ConsolidatedTxns) -> String {
         let mut txn_hasher = Sha256::new();
 
         let txns_hash = {
@@ -333,7 +333,7 @@ impl Miner {
         format!("{:x}", txn_hash)
     }
 
-    fn get_claim_hash(&self, claims: &ConsolidatedClaims) -> String {
+    pub(crate) fn get_claim_hash(&self, claims: &ConsolidatedClaims) -> String {
 
         let mut claim_hasher = Sha256::new();
 
@@ -347,7 +347,7 @@ impl Miner {
         format!("{:x}", claims_hash)
     }
 
-    fn build_header(&self, ref_hashes: Vec<RefHash>, txns_hash: String, claims_hash: String) -> Option<BlockHeader> {
+    pub(crate) fn build_header(&self, ref_hashes: Vec<RefHash>, txns_hash: String, claims_hash: String) -> Option<BlockHeader> {
 
         BlockHeader::new(
             self.last_block.clone(),
@@ -360,7 +360,7 @@ impl Miner {
         )
     }
 
-    fn hash_block(&self, header: &BlockHeader) -> String {
+    pub(crate) fn hash_block(&self, header: &BlockHeader) -> String {
         let block_hash = hash_data!(
             header.ref_hashes,
             header.round,
@@ -380,345 +380,3 @@ impl Miner {
     }
 }
 
-impl BlockBuilder for Miner {
-    type BlockType = ConvergenceBlock;
-    type RefType = ProposalBlock;
-
-    fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i28) {
-        self.last_block = Some(new_block);
-        self.next_epoch_adjustment = adjustment;
-    }
-
-    fn build(&self) -> Option<Self::BlockType> {
-        let proposals = self.get_references();
-        if let Some(proposals) = proposals {
-
-            let resolved = self.resolve(&proposals);
-            let txns = self.consolidate_txns(&proposals);
-            let claims = self.consolidate_claims(&proposals);
-            let ref_hashes = self.get_ref_hashes(&proposals);
-            let txn_hash = self.get_txn_hash(&txns);
-            let claim_hash = self.get_claim_hash(&claims);
-            let header = self.build_header(ref_hashes, txns_hash, claims_hash)?;
-            let hash = self.hash_block(&header);
-
-            Some(ConvergenceBlock { 
-                header,
-                txns,
-                claims,
-                hash,
-                certificate: None,
-            })
-        } else {
-            return None
-        }
-    }
-
-
-    fn get_references(&self) -> Option<Vec<Self::RefType>> {
-        let idx = self.last_block.hash;
-        if let Ok(bulldag) = self.dag.read() {
-            if let Some(vtx) = bulldag.get_vertex(idx) {
-                let p_ids = vtx.get_references();
-                let mut proposals = Vec::new();
-                p_ids.iter().for_each(|idx| {
-                    if let Some(vtx) = bulldag.get_vertex(idx) {
-                        match vtx.get_data() {
-                            Block::Proposal { ref block } => {
-                                proposals.push(vtx);
-                            },
-                            _ => {}
-                        }
-                }});
-                return proposals
-            }
-            return None
-        }
-    }
-}
-
-impl Resolver for Miner {
-    type ProposalInner = ProposalBlock;
-    type Identified = HashMap<TransactionDigest, Conflict>;
-    type SourceInner = ConvergenceBlock;
-    type BallotInfo = (Claim, RefHash);
-    
-    /// Identifies conflicts between blocks eligible for inclusion in the 
-    /// current round ConvergenceBlock.
-    /// It accomplishes this by iterating through all the blocks and 
-    /// adding a Conflict struct to a HashMap. The conflict struct 
-    /// contains a HashSet with every node that proposed a txn with 
-    /// a given transaction digest. It then filters the HashMap to 
-    /// only keep Conflicts with more than 1 proposer.
-    fn identify<I: IntoIterator<Item=Self::ProposalInner>>(
-        &self, proposals: &I
-    ) -> &Self::Identified {
-        let mut conflicts: ConflictList = HashMap::new();
-        proposals.iter().for_each(|block| {
-            let mut txn_iter = block.txns.iter();
-            let mut proposer = HashSet::new();
-
-            proposer.insert((block.from.clone(), block.hash.clone()));
-
-            while let Some((id, _)) = txn_iter.next() {
-                let conflict = Conflict {
-                    txn_id: id.to_string(),
-                    proposers: proposer.clone(),
-                    winner: None,
-                };
-
-                conflicts
-                    .entry(id.to_string())
-                    .and_modify(|e| {
-                        e.proposers.insert((block.from.clone(), block.hash.clone()));
-                    })
-                    .or_insert(conflict);
-            }
-        });
-
-        conflicts.retain(|_, conflict| conflict.proposers.len() > 1);
-        &conflicts
-    }
-
-    /// Splits proposal blocks by current round and previous rounds 
-    /// and then attempts to resolve any conflicts between earlier 
-    /// round proposal blocks (that were not appended to DAG) and 
-    /// earlier round (from which it was originally proposed).
-    /// This is to handle blocks that don't get discovered in time to be 
-    /// included in the convergence block from the round which they were 
-    /// originally proposed in. 
-    ///
-    /// After this, the method identifies conflicts, creates an election 
-    /// results map (`BTreeMap`), elects and appends winners to the conflict.
-    /// It then resolves all conflicts in the current round blocks, by removing 
-    /// the txns associated with the block proposed by the losing party in the 
-    /// conflict resolution protocol.
-    fn resolve<I>(&self, proposals: &I) -> &I 
-    where 
-        I: IntoIterator<Item=Self::ProposalInner>
-    {
-        let (curr, prev) = self.split_proposals_by_round(proposals);
-        let prev_resolved = self.resolve_earlier(&prev);
-        let mut conflicts = self.identify(&curr);
-
-        let proposers = self.get_proposers(&curr); 
-
-        // Construct a BTreeMap of all election results
-        let mut election_results = self.get_election_results(proposers); 
-        let mut curr_resolved = curr.clone();
-        curr_resolved.extend(prev_resolved);
-
-        // Iterate, mutably through all the conflicts identified
-        self.append_winner(&mut conflicts, &mut election_results);
-        self.resolve_current(&mut curr_resolved, &conflicts);
-        &curr_resolved.clone()
-    }
-
-    /// Resolves Conflicts between a block that is eligible in this current 
-    /// round, i.e. is not already appended to the DAG, but was proposed earlier 
-    /// i.e. references a ConvergenceBlock that is not equal to miner.last_block,
-    /// and blocks in previous rounds.
-    fn resolve_earlier<I: IntoIterator<Item=Self::ProposalInner>>(
-        &self, 
-        proposals: &I
-    ) -> &I {
-
-        let prev_blocks: Vec<ConvergenceBlock> = {
-            let nested: Vec<Vec<ConvergenceBlock>> = proposals
-                .iter()
-                .map(|prop_block| self.get_sources(prop_block))
-                .collect();
-
-            nested.into_iter().flatten().collect()
-        };
-
-        let mut proposals = proposals.clone();
-
-        // Flatten consolidated transactions from all previous blocks
-        let removals: LinkedHashSet<&TxnId> = {
-            // Get nested sets of all previous blocks
-            let sets: Vec<LinkedHashSet<&TxnId>> = prev_blocks
-                .iter()
-                .map(|block| {
-                    let block_set: Vec<&LinkedHashSet<TxnId>> = {
-                        block
-                            .txns
-                            .iter()
-                            .map(|(_, txn_id_set)| txn_id_set)
-                            .collect()
-                    };
-                    block_set.into_iter().flatten().collect()
-                })
-                .collect();
-
-            // Flatten the nested sets
-            sets.into_iter().flatten().collect()
-        };
-
-        proposals.retain(|block| block.round != round);
-
-        let resolved: Vec<ProposalBlock> = proposals
-            .iter_mut()
-            .map(|block| {
-                let mut resolved_block = block.clone();
-
-                resolved_block.txns.retain(|id, _| !&removals.contains(id));
-
-                resolved_block
-            })
-            .collect();
-
-        resolved
-    }
-    
-    /// Get every convergence block between the proposal block passed to this 
-    /// method, and the convergence block that this proposal blocks references, 
-    /// i.e. this proposal blocks source, and all other blocks in between 
-    /// before this current block being mined. 
-    fn get_sources<I>(&self, proposal: &Self::ProposalInner) -> &I 
-    where 
-        I: IntoIterator<Item = Self::SourceInner>
-    {
-        // TODO: Handle the case where the reference block is the genesis block
-        let source = proposal.ref_block.clone();
-        if let Ok(bulldag) = self.dag.read() {
-
-            let source_vtx: Option<&Vertex<Block, String>> = bulldag.get_vertex(source);
-
-            // Get every block between current proposal and proposals source;
-            // if the source exists
-            let source_refs: Vec<String> = match source_vtx {
-                Some(vtx) => bulldag.trace(&vtx, Direction::Reference),
-                None => {
-                    vec![]
-                },
-            };
-
-            // Get all the vertices corresponding to the references to the
-            // proposal blocks source. This will include other proposal blocks
-            // between the ProposalBlock's source and the current round.
-            // Will need to filter to only retain the convergence blocks
-            let ref_vertices: Vec<Option<&Vertex<Block, String>>> = {
-                source_refs
-                    .iter()
-                    .map(|idx| chain.get_vertex(idx.to_string())).collect()
-            };
-
-            // Initialize a stack to save ConvergenceBlock vertices to
-            // This will where all the ConvergenceBlocks between the
-            // Source of ProposalBlock and the current round will be stored
-            // and returned to check for conflicts.
-            let mut stack = vec![];
-
-            // Iterate through the ref_vertices vector
-            // Check whether the ref_vertex is Some or None
-            // If it is Some, get the data from the Vertex and
-            // match the Block variant
-            // If the block variant is a convergence block add it to the stack
-            // otherwise ignore it
-            ref_vertices.iter().for_each(|opt| {
-                if let Some(vtx) = opt {
-                    match vtx.get_data() {
-                        Block::Convergence { block } => stack.push(block),
-                        _ => {},
-                    }
-                }
-            });
-
-            return &stack;
-        }
-
-        return &vec![]
-    }
-
-    /// Splits proposal blocks into two different proposal blocks
-    /// proposal blocks which has a source convergence block that is 
-    /// equal to miner.last_block, and proposal blocks with earlier 
-    /// round source convergence blocks. 
-    fn split_proposals_by_round<I>(&self, proposals: &I) -> (I, I) 
-    where 
-        I: IntoIterator<Item = Self::ProposalInner>
-    {
-        let (mut curr, mut prev) = (Vec::new(), Vec::new());
-        for block in proposals {
-            if block.is_current_round(round) {
-                curr.push(block.clone());
-            } else {
-                prev.push(block.clone());
-            }
-        }
-        (curr.clone(), prev.clone())
-    } 
-
-    fn get_proposers<I>(&self, proposals: &I) -> Vec<Self::BallotInfo> 
-    where 
-        I: IntoIterator<Item = Self::ProposalInner>
-    {
-        proposals.iter()
-            .map(|block| (block.from.clone(), block.hash.clone()))
-            .collect()
-    }
-
-    fn append_winner(
-        &self, 
-        conflicts: &mut Self::Identified, 
-        election_results: &mut BTreeMap<U256, Self::BallotInfo>
-    ) {
-        conflicts.iter_mut().for_each(|(_, conflict)| {
-            election_results.retain(|(election_results, (claim, ref_hash))| {
-                conflict
-                    .proposers
-                    .contains(&(claim.clone(), ref_hash.clone()))
-            });
-
-            // select the first pointer sum and extract the proposal block
-            // hash from the pointer sum
-            let winner = {
-
-                let mut first: Option<U256, Self::BallotInfo> = election_results.pop_first();
-                while let None = first {
-                    first = local_pointers.pop_first();
-                }
-
-                first
-            };
-            // save it as the conflict winner
-            if let Some((res, (claim, ref_hash))) = winner {
-                conflict.winner = Some(ref_hash);
-            }
-        });
-    }
-
-    fn resolve_current<I>(&self, current: &mut I, conflicts: Self::Identified) 
-    where
-        I: IntoIterator<Item = Self::ProposalInner>
-    {
-        current.iter_mut().for_each(|block| {
-            // Clone conflicts into a mutable variable
-            let mut local_conflicts = conflicts.clone();
-
-            // retain only the conflicts that relate to current proposal block
-            local_conflicts.retain(|id, _| block.txns.contains_key(id));
-
-            // convert filtered conflicts into an iterator
-            let mut conflict_iter = local_conflicts.iter();
-
-            // initialize a hashset to save transactions that current block
-            // proposer lost conflict resolution.
-            let mut removals = HashSet::new();
-
-            // loop through all the conflicts related to current block
-            // and check if the winner is the current block hash
-            while let Some((id, conflict)) = conflict_iter.next() {
-                if Some(block.hash.clone()) != conflict.winner {
-                    // if it does insert into removals, otherwise ignore
-                    removals.insert(id.to_string());
-                }
-            }
-
-            // remove transactions for which current block lost conflict
-            // resolution from the current block
-            block.txns.retain(|id, _| !removals.contains(id));
-        });
-    }
-}

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -5,7 +5,7 @@
 //FEATURE TAG(S): Block Structure, VRF for Next Block Seed, Rewards
 use std::{
     cmp::Ordering,
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, BTreeMap},
     mem,
 };
 
@@ -43,8 +43,10 @@ use utils::{create_payload, hash_data};
 use vrrb_core::{
     claim::Claim,
     keypair::{MinerPk, MinerSk},
-    txn::Txn,
+    txn::{Txn, TransactionDigest},
 };
+use sha2::{Digest, Sha256};
+use ethereum_types::U256;
 
 use crate::result::MinerError;
 
@@ -68,8 +70,7 @@ const GENESIS_ALLOWED_MINERS: [&str; 2] = [
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MinerStatus {
     Mining,
-    Waiting,
-    Processing,
+    Waiting
 }
 
 #[derive(Debug)]
@@ -84,31 +85,27 @@ pub struct Miner {
     secret_key: MinerSk,
     public_key: MinerPk,
     address: Address,
-}
-
-pub struct MineArgs<'a> {
-    pub claim: Claim,
-    pub last_block: Block,
-    pub txns: LinkedHashMap<String, Txn>,
-    pub claims: LinkedHashMap<String, Claim>,
-    pub claim_list_hash: Option<String>,
-    #[deprecated(
-        note = "will be removed, unnecessary as last block needed to mine and contains next block reward"
-    )]
-    pub reward: &'a mut Reward,
-    pub abandoned_claim: Option<Claim>,
-    pub secret_key: SecretKey,
-    pub epoch: Epoch,
-    pub round: u128,
-    pub next_epoch_adjustment: i128,
+    claim: Claim,
+    last_block: Option<ConvergenceBlock>,
+    status: MinerStatus,
 }
 
 impl Miner {
     pub fn new(config: MinerConfig) -> Self {
+        let public_key = config.public_key.clone();
+        let address = Address::new(config.public_key.clone());
+        let claim = Claim::new(
+            config.public_key,
+            address 
+        );
+
         Miner {
             secret_key: config.secret_key,
             public_key: config.public_key,
             address: Address::new(config.public_key.clone()),
+            claim,
+            last_block: None,
+            status: MinerStatus::Waiting,
         }
     }
 
@@ -137,79 +134,66 @@ impl Miner {
         todo!()
     }
 
+    pub fn get_dag(&self) -> Event {
+        return Event::GetDag
+    }
+
+    pub fn check_claim(&self, winner: U256) -> bool {
+        winner == self.claim.hash
+    }
+
     pub fn mine_convergence_block(
-        &self,
-        args: MineArgs,
-        proposals: &Vec<ProposalBlock>,
+        &mut self,
         chain: &BullDag<Block, String>,
+        next_epoch_adjustment: i128,
     ) -> Option<ConvergenceBlock> {
         // identify and resolve all the conflicting txns between proposal blocks
+        self.miner_status = MinerStatus::Mining;
+        
+        let proposals = &self.get_proposal_blocks(chain, &self.last_block);
         let resolved_txns = {
-            match args.last_block {
-                Block::Convergence { ref block } => self.resolve_conflicts(
-                    &proposals,
-                    block.header.next_block_seed.into(),
-                    args.round.clone(),
-                    chain,
-                ),
-                Block::Genesis { ref block } => self.resolve_conflicts(
-                    &proposals,
-                    block.header.next_block_seed.into(),
-                    args.round.clone(),
-                    chain,
-                ),
-                _ => return None,
+            if let Some(last_block) = self.last_block {
+                self.get_resolved_txns(
+                    proposals, 
+                    &last_block, 
+                    &last_block.header.round, 
+                    chain
+                )            
+            } else {
+                return None 
             }
         };
 
-        // Consolidate transactions after resolving conflicts.
-        let txns: ConsolidatedTxns = resolved_txns
-            .iter()
-            .map(|block| {
-                let txn_list = block.txns.iter().map(|(id, _)| id.clone()).collect();
+        let txns: ConsolidatedTxns = self.consolidate_txns(&resolved_txns);
+        let claims: ConsolidatedClaims = self.consolidate_claims(&proposals);
+        let last_block = self.last_block.clone();
+        let claim = self.claim.clone();
+        let secret_key = self.secret_key.clone();
 
-                (block.hash.clone(), txn_list)
-            })
-            .collect();
+        let ref_hashes = proposals.iter().map(|b| {
+            b.hash.clone()
+        }).collect();
 
-        //TODO: resolve claim conflicts. This is less important because it
-        //cannot lead to double spend
-        let claims: ConsolidatedClaims = proposals
-            .iter()
-            .map(|block| {
-                let claim_hashes: LinkedHashSet<ClaimHash> = block
-                    .claims
-                    .iter()
-                    .map(|(claim_hash, _)| claim_hash.clone())
-                    .collect();
+        let mut txn_hasher = Sha256::new();
+        let mut claim_hasher = Sha256::new();
 
-                (block.hash.clone(), claim_hashes)
-            })
-            .collect();
+        let txns_hash = {
+            if let Ok(serialized_txns) = serde_json::to_string(&txn) {
+                txn_hasher.update(serialized_txns.as_bytes());
+            } 
+            txn_hasher.finalize()
+        };
 
-        // Get the convergence block from the last round
-        let last_block = args.last_block;
+        let claims_hash = {
+            if let Ok(serialized_claims) = serde_json::to_string(&txn) {
+                claim_hasher.update(serialized_claims.as_bytes());
+            }
+            claim_hasher.finalize(); 
+        };
 
-        // Get the miner claim
-        let claim = args.claim;
+        let txn_hash_string = format!("{:x}", txn_hash);
+        let claims_hash_string = format!("{:x}", claims_hash);
 
-        // Get the miner secret key
-        let secret_key = args.secret_key;
-
-        // TODO: Calculate the rolling utility and the rolling
-        // next epoch adjustment
-        let adjustment_next_epoch = args.next_epoch_adjustment;
-
-        // Get all the proposal block hashes
-        let ref_hashes = proposals.iter().map(|b| b.hash.clone()).collect();
-
-        // Hash the conflict resolved transactions
-        let txn_hash = hash_data!(txns);
-
-        // Hash the claims
-        let claim_list_hash = hash_data!(claims);
-
-        // Get the block header for the current block
         let header = BlockHeader::new(
             last_block.clone(),
             ref_hashes,
@@ -217,10 +201,9 @@ impl Miner {
             secret_key,
             txn_hash,
             claim_list_hash,
-            adjustment_next_epoch,
+            next_epoch_adjustment,
         )?;
 
-        // Hash all the header data to get the blockhash
         let block_hash = hash_data!(
             header.ref_hashes,
             header.round,
@@ -236,7 +219,8 @@ impl Miner {
             header.miner_signature
         );
 
-        // Return the ConvergenceBlock
+        self.miner_status = MinerStatus::Waiting;
+
         Some(ConvergenceBlock {
             header,
             txns,
@@ -246,6 +230,7 @@ impl Miner {
         })
     }
 
+    #[deprecated(note = "Building proposal blocks will be done in Harvester")]
     pub fn mine_proposal_block(
         &self,
         ref_block: RefHash,
@@ -255,6 +240,7 @@ impl Miner {
         claims: ClaimList,
         from: Claim,
     ) -> ProposalBlock {
+
         let payload = create_payload!(round, epoch, txns, claims, from);
 
         let signature = self.secret_key.sign_ecdsa(payload).to_string();
@@ -273,6 +259,7 @@ impl Miner {
         }
     }
 
+    #[deprecated(note = "Building proposal blocks will be done in Harvester")]
     pub fn build_proposal_block(
         &self,
         ref_block: RefHash,
@@ -280,8 +267,6 @@ impl Miner {
         epoch: Epoch,
         txns: TxnList,
         claims: ClaimList,
-        // from: Claim,
-        // secret_key: SecretKeyBytes,
     ) -> Result<ProposalBlock, InvalidBlockErrorReason> {
         let from = self.generate_claim();
         let payload = create_payload!(round, epoch, txns, claims, from);
@@ -307,6 +292,7 @@ impl Miner {
             signature,
         })
     }
+
 
     pub fn mine_genesis_block(&self, claim_list: ClaimList) -> Option<GenesisBlock> {
         let claim_list_hash = hash_data!(claim_list);
@@ -370,12 +356,45 @@ impl Miner {
         chrono::Utc::now().timestamp() as u128
     }
 
+    fn get_proposal_blocks(
+        &self, 
+        bulldag: &BullDag<Block, String>, 
+        last_block: ConvergenceBlock
+    ) -> Option<Vec<ProposalBlock>> {
+        let idx = self.last_block.hash;
+        if let Some(vtx) = bulldag.get_vertex(idx) {
+            let p_ids = vtx.get_references();
+            let mut proposals = Vec::new();
+            p_ids.iter().for_each(|idx| {
+                if let Some(vtx) = bulldag.get_vertex(idx) {
+                    match vtx.get_data() {
+                        Block::Proposal { ref block } => {
+                            proposals.push(vtx);
+                        },
+                        _ => { 
+                            /*Should throw an error here as 
+                             this shouldn't happen, so we 
+                             should change return type to 
+                             Result<Vec<ProposalBlock>>
+                             so that we can propagate 
+                             the error.
+                            */
+                        }
+                    }
+            }});
+
+            return proposals
+        }
+
+        return None
+    }
+
     // Check that conflicts with previous convergence block are removed
     // and there is no winner in current round.
     fn resolve_conflicts(
         &self,
         proposals: &Vec<ProposalBlock>,
-        seed: u128,
+        seed: u64,
         round: u128,
         chain: &BullDag<Block, String>,
     ) -> Vec<ProposalBlock> {
@@ -394,36 +413,27 @@ impl Miner {
         };
 
         // Next get all the prev_round conflicts resolved
-        let prev_resolved = self.resolve_conflicts_prev_rounds(round, &prev, chain);
+        let prev_resolved = self.resolve_conflicts_prev_rounds(
+            round, &prev, chain
+        );
 
         // Identify all conflicts
         let mut conflicts = self.identify_conflicts(&curr);
 
-        // create a vector of proposers with the claim and the proposal block
-        // hash.
         let proposers: Vec<(Claim, RefHash)> = curr
             .iter()
             .map(|block| (block.from.clone(), block.hash.clone()))
             .collect();
 
-        // calculate the pointer sums for all propsers and save into a vector
-        // of thruples with the claim, ref_hash and pointer sum
-        let mut pointer_sums: Vec<(Claim, RefHash, Option<u128>)> = {
-            proposers
+        // Construct a BTreeMap of all election results
+        let mut pointer_sums: BTreeMap<U256, (Claim, RefHash)> = proposers
                 .iter()
                 .map(|(claim, ref_hash)| {
-                    (claim.clone(), ref_hash.to_string(), claim.get_pointer(seed))
+                    (claim.get_election_result(seed),
+                     (claim.clone(), 
+                     ref_hash.to_string()))
                 })
-                .collect()
-        };
-
-        // Sort all the pointer sums
-        pointer_sums.sort_by(|a, b| match (a.2, b.2) {
-            (Some(x), Some(y)) => x.cmp(&y),
-            (None, Some(_)) => Ordering::Greater,
-            (Some(_), None) => Ordering::Less,
-            (None, None) => Ordering::Equal,
-        });
+                .collect();
 
         // Iterate, mutably through all the conflicts identified
         conflicts.iter_mut().for_each(|(_, conflict)| {
@@ -431,7 +441,7 @@ impl Miner {
             let mut local_pointers = pointer_sums.clone();
 
             // retain only the pointer sum related to the current conflict
-            local_pointers.retain(|(claim, ref_hash, _)| {
+            local_pointers.retain(|(election_results, (claim, ref_hash))| {
                 conflict
                     .proposers
                     .contains(&(claim.clone(), ref_hash.clone()))
@@ -439,10 +449,20 @@ impl Miner {
 
             // select the first pointer sum and extract the proposal block
             // hash from the pointer sum
-            let winner = local_pointers[0].1.clone();
+            let winner = {
 
+                let mut first: Option<U256,(Claim, RefHash)> = local_pointers.pop_first();
+
+                while let None = first {
+                    first = local_pointers.pop_first();
+                }
+
+                first
+            };
             // save it as the conflict winner
-            conflict.winner = Some(winner);
+            if let Some((res, (claim, ref_hash))) = winner {
+                conflict.winner = Some(ref_hash);
+            }
         });
 
         let mut curr_resolved = curr.clone();
@@ -615,5 +635,65 @@ impl Miner {
         });
 
         return stack;
+    }
+
+    fn get_resolved_txns(
+        &self,
+        proposals: &Vec<ProposalBlock>,
+        last_block: &Block,
+        round: &u128,
+        chain: &BullDag<Block, String>,
+    ) -> Vec<ProposalBlock> {
+        match last_block {
+            Block::Convergence { ref block } => {
+                self.resolve_conflicts(
+                    proposals, 
+                    &block.header.next_block_seed, 
+                    round, 
+                    chain
+                )
+            },
+            Block::Genesis { ref block } => {
+                self.resolve_conflicts(
+                    proposals,
+                    &block.head.next_block_seed,
+                    round,
+                    chain
+                )
+            },
+            _ => return None,
+        }
+    }
+
+    fn consolidate_txns(
+        &self, 
+        proposals: &Vec<ProposalBlock>
+    ) -> ConsolidatedTxns {
+
+        propsals.iter()
+            .map(|block| {
+                let txn_list = block.txns.iter()
+                    .map(|(id, _)| { 
+                        id.clone()
+                    }).collect();
+
+            (block.hash.clone(), txn_list)
+        }).collect()
+    }
+
+    fn consolidate_claims(
+        proposals: &Vec<ProposalBlock>
+    ) -> ConsolidatedClaims {
+
+        proposals.iter()
+            .map(|block| {
+                let claim_hashes: LinkedHashSet<ClaimHash> = block
+                    .claims
+                    .iter()
+                    .map(|(claim_hash, _)| claim_hash.clone())
+                    .collect();
+
+            (block.hash.clone(), claim_hashes)
+        }).collect()
     }
 }

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -120,11 +120,10 @@ impl Miner {
         self.public_key.clone()
     }
 
-    pub fn generate_claim(&self, nonce: u128) -> Claim {
+    pub fn generate_claim(&self) -> Claim {
         Claim::new(
             self.public_key().to_string(),
             self.address().to_string(),
-            nonce,
         )
     }
 
@@ -281,11 +280,10 @@ impl Miner {
         epoch: Epoch,
         txns: TxnList,
         claims: ClaimList,
-        nonce: u128,
         // from: Claim,
         // secret_key: SecretKeyBytes,
     ) -> Result<ProposalBlock, InvalidBlockErrorReason> {
-        let from = self.generate_claim(nonce);
+        let from = self.generate_claim();
         let payload = create_payload!(round, epoch, txns, claims, from);
         let signature = self.secret_key.sign_ecdsa(payload).to_string();
         let hash = hash_data!(round, epoch, txns, claims, from, signature);
@@ -310,13 +308,13 @@ impl Miner {
         })
     }
 
-    pub fn mine_genesis_block(&self, claim_list: ClaimList, nonce: u128) -> Option<GenesisBlock> {
+    pub fn mine_genesis_block(&self, claim_list: ClaimList) -> Option<GenesisBlock> {
         let claim_list_hash = hash_data!(claim_list);
         let seed = 0;
         let round = 0;
         let epoch = 0;
 
-        let claim = self.generate_claim(nonce);
+        let claim = self.generate_claim();
 
         let header = BlockHeader::genesis(
             seed,

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -42,7 +42,6 @@ impl<'a> BlockBuilder for Miner<'a> {
                 certificate: None,
             })
         } else {
-            println!("Couldn't find references");
             return None
         }
     }
@@ -56,7 +55,6 @@ impl<'a> BlockBuilder for Miner<'a> {
     /// been referenced. We need to add this functionality so that 
     /// blocks don't get "orphaned"
     fn get_references(&self) -> Option<Vec<Self::RefType>> {
-        println!("Getting last block");
         let last_block = self.last_block.clone();
         if let Some(last_block) = last_block {
             let idx = last_block.get_hash();
@@ -81,7 +79,6 @@ impl<'a> BlockBuilder for Miner<'a> {
                 return None 
         }
     }
-    println!("Couldn't find last block");
     None
     }
 }

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -1,13 +1,15 @@
 use crate::{block_builder::BlockBuilder, Miner, conflict_resolver::Resolver};
-use block::{Block, ConvergenceBlock, ProposalBlock, ConflictList, Conflict, RefHash};
+use block::{Block, ConvergenceBlock, ProposalBlock, ConflictList, Conflict, RefHash, InnerBlock, header::BlockHeader};
+use reward::reward::Reward;
 use std::collections::{BTreeMap, HashSet, HashMap};
 use bulldag::vertex::{Direction, Vertex};
 use ethereum_types::U256;
 use ritelinked::LinkedHashSet;
 use vrrb_core::{claim::Claim, txn::TransactionDigest};
+use std::sync::Arc;
 
 
-impl<'a> BlockBuilder for Miner<'a> {
+impl BlockBuilder for Miner {
     type BlockType = ConvergenceBlock;
     type RefType = ProposalBlock;
 
@@ -16,7 +18,12 @@ impl<'a> BlockBuilder for Miner<'a> {
     /// We should make sure that the new `ConvergenceBlock` is actually
     /// pulled from the `miner.dag` instance instead of just passing it 
     // into this method. 
-    fn update(&mut self, adjustment: &i128) {
+    fn update(
+        &mut self, 
+        last_block: Option<Arc<dyn InnerBlock<Header = BlockHeader, RewardType = Reward>>>, 
+        adjustment: &i128
+    ) {
+        self.last_block = last_block;
         self.next_epoch_adjustment = *adjustment;
     }
 
@@ -24,7 +31,6 @@ impl<'a> BlockBuilder for Miner<'a> {
     fn build(&self) -> Option<Self::BlockType> {
         let proposals = self.get_references();
         if let Some(proposals) = proposals {
-
             let resolved = self.resolve(&proposals, self.get_round(), self.get_seed());
             let txns = self.consolidate_txns(&resolved);
             let claims = self.consolidate_claims(&resolved);
@@ -34,7 +40,7 @@ impl<'a> BlockBuilder for Miner<'a> {
             let header = self.build_header(ref_hashes.clone(), txns_hash, claims_hash)?;
             let hash = self.hash_block(&header);
 
-            Some(ConvergenceBlock { 
+            return Some(ConvergenceBlock { 
                 header,
                 txns,
                 claims,
@@ -56,98 +62,26 @@ impl<'a> BlockBuilder for Miner<'a> {
     /// blocks don't get "orphaned"
     fn get_references(&self) -> Option<Vec<Self::RefType>> {
         if let Ok(bulldag) = self.dag.read() {
-            if let Some(vtx) = self.get_last_block_vertex(None) {
-                let p_ids = vtx.get_references();
-                let mut proposals = Vec::new();
-                p_ids.iter().for_each(|idx| {
-                if let Some(vtx) = bulldag.get_vertex(idx.to_string()) {
+            
+            let leaf_ids = bulldag.get_leaves();
+            let mut proposals = Vec::new();
+            
+            leaf_ids.iter().for_each(|leaf| {
+                if let Some(vtx) = bulldag.get_vertex(leaf.clone()) {
                     match vtx.get_data() {
-                        Block::Proposal { ref block } => {
+                        Block::Proposal { block } => {
                             proposals.push(block.clone());
                         },
                         _ => {}
                     }
-                }});
-                
-                let orphans = self.get_orphaned_references(
-                    vtx.get_index(), 
-                    0, 
-                    5
-                );
-                proposals.extend(orphans);
-                return Some(proposals)
-            } 
-        }
+                }
+            });
+
+            return Some(proposals)
+
+        } 
 
         return None
-    }
-
-    /// Gets all the orphaned ProposalBlocks from the past n rounds.
-    fn get_orphaned_references(
-        &self, 
-        idx: RefHash, 
-        current_round: usize, 
-        n_rounds: usize
-    ) -> Vec<Self::RefType> {
-
-        let source_cbs = self.get_n_rounds_convergence(idx, current_round, n_rounds);
-        let mut orphaned = vec![];
-
-        source_cbs.iter().for_each(|ref_hash| {
-            if let Ok(guard) = self.dag.read() {
-                if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
-                    let references = vtx.get_references();
-                    for ref_hash in references {
-                        if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
-                            if let Block::Proposal { block } = vtx.get_data() { 
-                                if vtx.get_references().len() == 0 {
-                                    orphaned.push(block.clone());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        });
-
-        orphaned
-    }
-
-    /// Gets the ConvegenceBlock from the past n rounds.
-    fn get_n_rounds_convergence(&self, idx: RefHash, current_round: usize, n_rounds: usize) -> HashSet<RefHash> {
-        if current_round > n_rounds {
-            return HashSet::new() 
-        }
-
-        let mut source_cbs = HashSet::new();
-        
-        if let Ok(guard) = self.dag.read() {
-            if let Some(vtx) = guard.get_vertex(idx) {
-                if let Block::Convergence { .. } = vtx.get_data() {
-                    let sources = vtx.get_sources();
-                    sources.iter().for_each(|ref_hash| {
-                        if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
-                            if let Block::Proposal { .. } = vtx.get_data() {
-                                let sources = vtx.get_sources();
-                                for source in sources {
-                                    source_cbs.insert(source.to_string());
-                                }
-                            }
-                        }
-                    });
-
-                    source_cbs.iter().for_each(|ref_hash| {
-                        source_cbs.extend(
-                            self.get_n_rounds_convergence(
-                                ref_hash.clone().to_string(), current_round + 1, n_rounds
-                            )
-                        )
-                    });
-                }
-            }
-        }
-        
-        return source_cbs 
     }
 
     /// Gets the vertex from the last Convergence (or Genesis) block.
@@ -173,7 +107,7 @@ impl<'a> BlockBuilder for Miner<'a> {
     }
 }
 
-impl<'a> Resolver for Miner<'a> {
+impl Resolver for Miner {
     type Proposal = ProposalBlock;
     type Identified = HashMap<TransactionDigest, Conflict>;
     type Source = ConvergenceBlock;
@@ -235,16 +169,14 @@ impl<'a> Resolver for Miner<'a> {
         round: u128, 
         seed: u64
     ) -> Vec<Self::Proposal> {
-        let (curr, prev) = self.split_proposals_by_round(proposals);
+        let (mut curr, prev) = self.split_proposals_by_round(proposals);
         let prev_resolved = self.resolve_earlier(&prev, round);
+        curr.extend(prev_resolved.clone());
         let mut conflicts = self.identify(&curr);
-
         let proposers = self.get_proposers(&curr); 
-
         // Construct a BTreeMap of all election results
         let mut election_results = self.get_election_results(&proposers, seed); 
         let mut curr_resolved = curr.clone();
-        curr_resolved.extend(prev_resolved.clone());
 
         // Iterate, mutably through all the conflicts identified
         self.append_winner(&mut conflicts, &mut election_results);
@@ -327,7 +259,9 @@ impl<'a> Resolver for Miner<'a> {
             // Get every block between current proposal and proposals source;
             // if the source exists
             let source_refs: Vec<String> = match source_vtx {
-                Some(vtx) => bulldag.trace(&vtx, Direction::Reference),
+                Some(vtx) => {
+                    bulldag.trace(&vtx, Direction::Reference)
+                },
                 None => {
                     vec![]
                 },

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -318,7 +318,7 @@ impl Resolver for Miner {
     ) -> BTreeMap<U256, Self::BallotInfo> {
         
         proposers.iter().map(|(claim, ref_hash)| {
-            (claim.get_election_result(seed), (claim.clone(), ref_hash.clone()))
+            (claim.get_election_result(seed).0, (claim.clone(), ref_hash.clone()))
         }).collect() 
     }
 

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -1,0 +1,346 @@
+use crate::{block_builder::BlockBuilder, Miner, conflict_resolver::Resolver};
+use block::{ConvergenceBlock, ProposalBlock};
+
+
+impl BlockBuilder for Miner {
+    type BlockType = ConvergenceBlock;
+    type RefType = ProposalBlock;
+
+    fn update(&mut self, new_block: &ConvergenceBlock, adjustment: &i128) {
+        self.last_block = Some(new_block);
+        self.next_epoch_adjustment = adjustment;
+    }
+
+    fn build(&self) -> Option<Self::BlockType> {
+        let proposals = self.get_references();
+        if let Some(proposals) = proposals {
+
+            let resolved = self.resolve(&proposals);
+            let txns = self.consolidate_txns(&proposals);
+            let claims = self.consolidate_claims(&proposals);
+            let ref_hashes = self.get_ref_hashes(&proposals);
+            let txn_hash = self.get_txn_hash(&txns);
+            let claim_hash = self.get_claim_hash(&claims);
+            let header = self.build_header(ref_hashes, txns_hash, claims_hash)?;
+            let hash = self.hash_block(&header);
+
+            Some(ConvergenceBlock { 
+                header,
+                txns,
+                claims,
+                hash,
+                certificate: None,
+            })
+        } else {
+            return None
+        }
+    }
+
+
+    fn get_references(&self) -> Option<Vec<Self::RefType>> {
+        let idx = self.last_block.hash;
+        if let Ok(bulldag) = self.dag.read() {
+            if let Some(vtx) = bulldag.get_vertex(idx) {
+                let p_ids = vtx.get_references();
+                let mut proposals = Vec::new();
+                p_ids.iter().for_each(|idx| {
+                    if let Some(vtx) = bulldag.get_vertex(idx) {
+                        match vtx.get_data() {
+                            Block::Proposal { ref block } => {
+                                proposals.push(vtx);
+                            },
+                            _ => {}
+                        }
+                }});
+                return proposals
+            }
+            return None
+        }
+    }
+}
+
+impl Resolver for Miner {
+    type ProposalInner = ProposalBlock;
+    type Identified = HashMap<TransactionDigest, Conflict>;
+    type SourceInner = ConvergenceBlock;
+    type BallotInfo = (Claim, RefHash);
+    
+    /// Identifies conflicts between blocks eligible for inclusion in the 
+    /// current round ConvergenceBlock.
+    /// It accomplishes this by iterating through all the blocks and 
+    /// adding a Conflict struct to a HashMap. The conflict struct 
+    /// contains a HashSet with every node that proposed a txn with 
+    /// a given transaction digest. It then filters the HashMap to 
+    /// only keep Conflicts with more than 1 proposer.
+    fn identify<I: IntoIterator<Item=Self::ProposalInner>>(
+        &self, proposals: &I
+    ) -> &Self::Identified {
+        let mut conflicts: ConflictList = HashMap::new();
+        proposals.iter().for_each(|block| {
+            let mut txn_iter = block.txns.iter();
+            let mut proposer = HashSet::new();
+
+            proposer.insert((block.from.clone(), block.hash.clone()));
+
+            while let Some((id, _)) = txn_iter.next() {
+                let conflict = Conflict {
+                    txn_id: id.to_string(),
+                    proposers: proposer.clone(),
+                    winner: None,
+                };
+
+                conflicts
+                    .entry(id.to_string())
+                    .and_modify(|e| {
+                        e.proposers.insert((block.from.clone(), block.hash.clone()));
+                    })
+                    .or_insert(conflict);
+            }
+        });
+
+        conflicts.retain(|_, conflict| conflict.proposers.len() > 1);
+        &conflicts
+    }
+
+    /// Splits proposal blocks by current round and previous rounds 
+    /// and then attempts to resolve any conflicts between earlier 
+    /// round proposal blocks (that were not appended to DAG) and 
+    /// earlier round (from which it was originally proposed).
+    /// This is to handle blocks that don't get discovered in time to be 
+    /// included in the convergence block from the round which they were 
+    /// originally proposed in. 
+    ///
+    /// After this, the method identifies conflicts, creates an election 
+    /// results map (`BTreeMap`), elects and appends winners to the conflict.
+    /// It then resolves all conflicts in the current round blocks, by removing 
+    /// the txns associated with the block proposed by the losing party in the 
+    /// conflict resolution protocol.
+    fn resolve<I>(&self, proposals: &I) -> &I 
+    where 
+        I: IntoIterator<Item=Self::ProposalInner>
+    {
+        let (curr, prev) = self.split_proposals_by_round(proposals);
+        let prev_resolved = self.resolve_earlier(&prev);
+        let mut conflicts = self.identify(&curr);
+
+        let proposers = self.get_proposers(&curr); 
+
+        // Construct a BTreeMap of all election results
+        let mut election_results = self.get_election_results(proposers); 
+        let mut curr_resolved = curr.clone();
+        curr_resolved.extend(prev_resolved);
+
+        // Iterate, mutably through all the conflicts identified
+        self.append_winner(&mut conflicts, &mut election_results);
+        self.resolve_current(&mut curr_resolved, &conflicts);
+        &curr_resolved.clone()
+    }
+
+    /// Resolves Conflicts between a block that is eligible in this current 
+    /// round, i.e. is not already appended to the DAG, but was proposed earlier 
+    /// i.e. references a ConvergenceBlock that is not equal to miner.last_block,
+    /// and blocks in previous rounds.
+    fn resolve_earlier<I: IntoIterator<Item=Self::ProposalInner>>(
+        &self, 
+        proposals: &I
+    ) -> &I {
+
+        let prev_blocks: Vec<ConvergenceBlock> = {
+            let nested: Vec<Vec<ConvergenceBlock>> = proposals
+                .iter()
+                .map(|prop_block| self.get_sources(prop_block))
+                .collect();
+
+            nested.into_iter().flatten().collect()
+        };
+
+        let mut proposals = proposals.clone();
+
+        // Flatten consolidated transactions from all previous blocks
+        let removals: LinkedHashSet<&TxnId> = {
+            // Get nested sets of all previous blocks
+            let sets: Vec<LinkedHashSet<&TxnId>> = prev_blocks
+                .iter()
+                .map(|block| {
+                    let block_set: Vec<&LinkedHashSet<TxnId>> = {
+                        block
+                            .txns
+                            .iter()
+                            .map(|(_, txn_id_set)| txn_id_set)
+                            .collect()
+                    };
+                    block_set.into_iter().flatten().collect()
+                })
+                .collect();
+
+            // Flatten the nested sets
+            sets.into_iter().flatten().collect()
+        };
+
+        proposals.retain(|block| block.round != round);
+
+        let resolved: Vec<ProposalBlock> = proposals
+            .iter_mut()
+            .map(|block| {
+                let mut resolved_block = block.clone();
+
+                resolved_block.txns.retain(|id, _| !&removals.contains(id));
+
+                resolved_block
+            })
+            .collect();
+
+        resolved
+    }
+    
+    /// Get every convergence block between the proposal block passed to this 
+    /// method, and the convergence block that this proposal blocks references, 
+    /// i.e. this proposal blocks source, and all other blocks in between 
+    /// before this current block being mined. 
+    fn get_sources<I>(&self, proposal: &Self::ProposalInner) -> &I 
+    where 
+        I: IntoIterator<Item = Self::SourceInner>
+    {
+        // TODO: Handle the case where the reference block is the genesis block
+        let source = proposal.ref_block.clone();
+        if let Ok(bulldag) = self.dag.read() {
+
+            let source_vtx: Option<&Vertex<Block, String>> = bulldag.get_vertex(source);
+
+            // Get every block between current proposal and proposals source;
+            // if the source exists
+            let source_refs: Vec<String> = match source_vtx {
+                Some(vtx) => bulldag.trace(&vtx, Direction::Reference),
+                None => {
+                    vec![]
+                },
+            };
+
+            // Get all the vertices corresponding to the references to the
+            // proposal blocks source. This will include other proposal blocks
+            // between the ProposalBlock's source and the current round.
+            // Will need to filter to only retain the convergence blocks
+            let ref_vertices: Vec<Option<&Vertex<Block, String>>> = {
+                source_refs
+                    .iter()
+                    .map(|idx| chain.get_vertex(idx.to_string())).collect()
+            };
+
+            // Initialize a stack to save ConvergenceBlock vertices to
+            // This will where all the ConvergenceBlocks between the
+            // Source of ProposalBlock and the current round will be stored
+            // and returned to check for conflicts.
+            let mut stack = vec![];
+
+            // Iterate through the ref_vertices vector
+            // Check whether the ref_vertex is Some or None
+            // If it is Some, get the data from the Vertex and
+            // match the Block variant
+            // If the block variant is a convergence block add it to the stack
+            // otherwise ignore it
+            ref_vertices.iter().for_each(|opt| {
+                if let Some(vtx) = opt {
+                    match vtx.get_data() {
+                        Block::Convergence { block } => stack.push(block),
+                        _ => {},
+                    }
+                }
+            });
+
+            return &stack;
+        }
+
+        return &vec![]
+    }
+
+    /// Splits proposal blocks into two different proposal blocks
+    /// proposal blocks which has a source convergence block that is 
+    /// equal to miner.last_block, and proposal blocks with earlier 
+    /// round source convergence blocks. 
+    fn split_proposals_by_round<I>(&self, proposals: &I) -> (I, I) 
+    where 
+        I: IntoIterator<Item = Self::ProposalInner>
+    {
+        let (mut curr, mut prev) = (Vec::new(), Vec::new());
+        for block in proposals {
+            if block.is_current_round(round) {
+                curr.push(block.clone());
+            } else {
+                prev.push(block.clone());
+            }
+        }
+        (curr.clone(), prev.clone())
+    } 
+
+    fn get_proposers<I>(&self, proposals: &I) -> Vec<Self::BallotInfo> 
+    where 
+        I: IntoIterator<Item = Self::ProposalInner>
+    {
+        proposals.iter()
+            .map(|block| (block.from.clone(), block.hash.clone()))
+            .collect()
+    }
+
+    fn append_winner(
+        &self, 
+        conflicts: &mut Self::Identified, 
+        election_results: &mut BTreeMap<U256, Self::BallotInfo>
+    ) {
+        conflicts.iter_mut().for_each(|(_, conflict)| {
+            election_results.retain(|(election_results, (claim, ref_hash))| {
+                conflict
+                    .proposers
+                    .contains(&(claim.clone(), ref_hash.clone()))
+            });
+
+            // select the first pointer sum and extract the proposal block
+            // hash from the pointer sum
+            let winner = {
+
+                let mut first: Option<U256, Self::BallotInfo> = election_results.pop_first();
+                while let None = first {
+                    first = local_pointers.pop_first();
+                }
+
+                first
+            };
+            // save it as the conflict winner
+            if let Some((res, (claim, ref_hash))) = winner {
+                conflict.winner = Some(ref_hash);
+            }
+        });
+    }
+
+    fn resolve_current<I>(&self, current: &mut I, conflicts: Self::Identified) 
+    where
+        I: IntoIterator<Item = Self::ProposalInner>
+    {
+        current.iter_mut().for_each(|block| {
+            // Clone conflicts into a mutable variable
+            let mut local_conflicts = conflicts.clone();
+
+            // retain only the conflicts that relate to current proposal block
+            local_conflicts.retain(|id, _| block.txns.contains_key(id));
+
+            // convert filtered conflicts into an iterator
+            let mut conflict_iter = local_conflicts.iter();
+
+            // initialize a hashset to save transactions that current block
+            // proposer lost conflict resolution.
+            let mut removals = HashSet::new();
+
+            // loop through all the conflicts related to current block
+            // and check if the winner is the current block hash
+            while let Some((id, conflict)) = conflict_iter.next() {
+                if Some(block.hash.clone()) != conflict.winner {
+                    // if it does insert into removals, otherwise ignore
+                    removals.insert(id.to_string());
+                }
+            }
+
+            // remove transactions for which current block lost conflict
+            // resolution from the current block
+            block.txns.retain(|id, _| !removals.contains(id));
+        });
+    }
+}

--- a/crates/miner/src/miner_impl.rs
+++ b/crates/miner/src/miner_impl.rs
@@ -55,31 +55,121 @@ impl<'a> BlockBuilder for Miner<'a> {
     /// been referenced. We need to add this functionality so that 
     /// blocks don't get "orphaned"
     fn get_references(&self) -> Option<Vec<Self::RefType>> {
-        let last_block = self.last_block.clone();
-        if let Some(last_block) = last_block {
-            let idx = last_block.get_hash();
+        if let Ok(bulldag) = self.dag.read() {
+            if let Some(vtx) = self.get_last_block_vertex(None) {
+                let p_ids = vtx.get_references();
+                let mut proposals = Vec::new();
+                p_ids.iter().for_each(|idx| {
+                if let Some(vtx) = bulldag.get_vertex(idx.to_string()) {
+                    match vtx.get_data() {
+                        Block::Proposal { ref block } => {
+                            proposals.push(block.clone());
+                        },
+                        _ => {}
+                    }
+                }});
+                
+                let orphans = self.get_orphaned_references(
+                    vtx.get_index(), 
+                    0, 
+                    5
+                );
+                proposals.extend(orphans);
+                return Some(proposals)
+            } 
+        }
+
+        return None
+    }
+
+    /// Gets all the orphaned ProposalBlocks from the past n rounds.
+    fn get_orphaned_references(
+        &self, 
+        idx: RefHash, 
+        current_round: usize, 
+        n_rounds: usize
+    ) -> Vec<Self::RefType> {
+
+        let source_cbs = self.get_n_rounds_convergence(idx, current_round, n_rounds);
+        let mut orphaned = vec![];
+
+        source_cbs.iter().for_each(|ref_hash| {
+            if let Ok(guard) = self.dag.read() {
+                if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
+                    let references = vtx.get_references();
+                    for ref_hash in references {
+                        if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
+                            if let Block::Proposal { block } = vtx.get_data() { 
+                                if vtx.get_references().len() == 0 {
+                                    orphaned.push(block.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        orphaned
+    }
+
+    /// Gets the ConvegenceBlock from the past n rounds.
+    fn get_n_rounds_convergence(&self, idx: RefHash, current_round: usize, n_rounds: usize) -> HashSet<RefHash> {
+        if current_round > n_rounds {
+            return HashSet::new() 
+        }
+
+        let mut source_cbs = HashSet::new();
+        
+        if let Ok(guard) = self.dag.read() {
+            if let Some(vtx) = guard.get_vertex(idx) {
+                if let Block::Convergence { .. } = vtx.get_data() {
+                    let sources = vtx.get_sources();
+                    sources.iter().for_each(|ref_hash| {
+                        if let Some(vtx) = guard.get_vertex(ref_hash.clone().to_string()) {
+                            if let Block::Proposal { .. } = vtx.get_data() {
+                                let sources = vtx.get_sources();
+                                for source in sources {
+                                    source_cbs.insert(source.to_string());
+                                }
+                            }
+                        }
+                    });
+
+                    source_cbs.iter().for_each(|ref_hash| {
+                        source_cbs.extend(
+                            self.get_n_rounds_convergence(
+                                ref_hash.clone().to_string(), current_round + 1, n_rounds
+                            )
+                        )
+                    });
+                }
+            }
+        }
+        
+        return source_cbs 
+    }
+
+    /// Gets the vertex from the last Convergence (or Genesis) block.
+    fn get_last_block_vertex(&self, idx: Option<RefHash>) -> Option<Vertex<Block, String>> {
+        if let Some(idx) = idx {
             if let Ok(bulldag) = self.dag.read() {
                 if let Some(vtx) = bulldag.get_vertex(idx) {
-                    let p_ids = vtx.get_references();
-                    let mut proposals = Vec::new();
-                    p_ids.iter().for_each(|idx| {
-                        if let Some(vtx) = bulldag.get_vertex(idx.to_string()) {
-                            match vtx.get_data() {
-                                Block::Proposal { ref block } => {
-                                    proposals.push(block.clone());
-                                },
-                                _ => {}
-                            }
-                    }});
-                    return Some(proposals)
-                } else {
-                    return None
+                    return Some(vtx.clone())
                 }
-            } else {
-                return None 
+            }
+        } else {
+            let last_block = self.last_block.clone();
+            if let Some(last_block) = last_block {
+                let idx = last_block.get_hash();
+                if let Ok(bulldag) = self.dag.read() {
+                    if let Some(vtx) = bulldag.get_vertex(idx) {
+                        return Some(vtx.clone())
+                    }
+                }
+            }
         }
-    }
-    None
+        None
     }
 }
 

--- a/crates/miner/src/miner_v1.rs
+++ b/crates/miner/src/miner_v1.rs
@@ -266,17 +266,17 @@ impl Miner {
 
     /// Increases the nonce and calculates the new hash for all claims
     /// This only occurs in the event that no claims return valid pointer sums.
-    pub fn nonce_up(&mut self) {
-        self.claim.nonce_up();
-        let mut new_claim_map = LinkedHashMap::new();
-        self.claim_map.clone().iter().for_each(|(pk, claim)| {
-            let mut new_claim = claim.clone();
-            new_claim.nonce_up();
-            new_claim_map.insert(pk.clone(), new_claim.clone());
-        });
-
-        self.claim_map = new_claim_map;
-    }
+//    pub fn nonce_up(&mut self) {
+//        self.claim.nonce_up();
+//        let mut new_claim_map = LinkedHashMap::new();
+//        self.claim_map.clone().iter().for_each(|(pk, claim)| {
+//            let mut new_claim = claim.clone();
+//            new_claim.nonce_up();
+//            new_claim_map.insert(pk.clone(), new_claim.clone());
+//        });
+//
+//        self.claim_map = new_claim_map;
+//    }
 
     /// Checks if the transaction has been confirmed
     //TODO: Either eliminate and replace, each miner should retain only

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -1,0 +1,515 @@
+#![cfg(test)]
+use std::sync::{Arc, RwLock};
+
+use block::{
+    invalid::InvalidBlockErrorReason,
+    Block,
+    GenesisBlock,
+    ProposalBlock,
+    TxnList, ConvergenceBlock, InnerBlock,
+};
+use bulldag::{graph::BullDag, vertex::Vertex};
+use primitives::{Address, PublicKey, SecretKey, Signature};
+use ritelinked::LinkedHashMap;
+use secp256k1::Message;
+use sha2::{Digest, Sha256};
+use vrrb_core::{
+    claim::Claim,
+    helpers::size_of_txn_list,
+    keypair::Keypair,
+    txn::{NewTxnArgs, Txn, TransactionDigest, generate_txn_digest_vec},
+};
+
+use crate::{Miner, MinerConfig, result::MinerError};
+
+/// Move this into primitives and call it simply `BlockDag`
+pub type MinerDag = Arc<RwLock<BullDag<Block, String>>>;
+
+/// Helper function to create a random Miner.
+pub(crate) fn create_miner() -> Miner<'static> {
+    let (secret_key, public_key) = create_keypair();
+    let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
+
+    let config = MinerConfig {
+        secret_key,
+        public_key,
+        dag,
+    };
+
+    Miner::new(config)
+}
+
+/// Helper function to create a miner from a `Keypair`
+pub(crate) fn create_miner_from_keypair(kp: &Keypair) -> Miner<'static> {
+    let (secret_key, public_key) = kp.miner_kp;
+    let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
+    
+    let config = MinerConfig {
+        secret_key,
+        public_key,
+        dag
+    };
+
+    Miner::new(config)
+}
+
+pub(crate) fn create_miner_from_keypair_return_dag(kp: &Keypair) -> (Miner<'static>, MinerDag) {
+    let miner = create_miner_from_keypair(kp);
+    (miner.clone(), miner.dag.clone())
+}
+
+pub(crate) fn create_miner_from_keypair_and_dag(kp: &Keypair, dag: MinerDag) -> Miner<'static> {
+    let mut miner = create_miner_from_keypair(kp);
+    miner.dag = dag;
+    miner
+}
+
+/// Helper function to create a `MinerKeypair` which is 
+/// simply `(SecretKey, PublicKey)`
+pub(crate) fn create_keypair() -> (SecretKey, PublicKey) {
+    let kp = Keypair::random();
+    kp.miner_kp
+}
+
+/// Helper function to create an address from a `&PublicKey`
+pub(crate) fn create_address(pubkey: &PublicKey) -> Address {
+    Address::new(pubkey.clone())
+}
+
+/// Helper function to create a claim from a `&PublicKey` and 
+/// `&Address`
+pub(crate) fn create_claim(pk: &PublicKey, addr: &Address) -> Claim {
+    Claim::new(pk.to_string(), addr.to_string())
+}
+
+/// Helper function to create a random message and signature 
+/// returning `(Message, Keypair, Signature)`
+pub(crate) fn create_and_sign_message() -> (Message, Keypair, Signature) {
+    let kp = Keypair::random();
+    let message = b"Test Message";
+    let msg = {
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(message);
+        let message = hasher.finalize();
+        Message::from_slice(&message[..]).unwrap()
+    };
+
+    let sig = kp.miner_kp.0.sign_ecdsa(msg);
+
+    return (msg, kp, sig)
+
+}
+
+/// Helper function to mine a `GenesisBlock` and 
+/// return an `Option<GenesisBlock>`
+/// This is currently using a deprecated method 
+/// `miner.mine_genesis_block` will be removed soon 
+/// and replaced by a different method.
+pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
+    let miner = create_miner();
+
+    let claim = miner.generate_claim();
+
+    let claim_list = {
+        vec![(claim.public_key.clone(), claim.clone())]
+            .iter()
+            .cloned()
+            .collect()
+    };
+
+    miner.mine_genesis_block(claim_list)
+}
+
+/// Helper function to create `n` number of `Txn` and 
+/// return an `Iterator` of `(TransactionDigest, Txn)`
+/// to be collected by the caller.
+pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
+    (0..n)
+        .map(|n| {
+            let (sk, pk) = create_keypair();
+            let raddr = "0x192abcdef01234567890".to_string();
+            let saddr = create_address(&pk);
+            let amount = (n.pow(2)) as u128;
+            let token = None;
+
+            let txn_args = NewTxnArgs {
+                timestamp: 0,
+                sender_address: saddr.to_string(),
+                sender_public_key: pk.clone(),
+                receiver_address: raddr,
+                token,
+                amount,
+                signature: sk.sign_ecdsa(Message::from_hashed_data::<
+                    secp256k1::hashes::sha256::Hash,
+                >(b"vrrb")),
+                validators: None,
+                nonce: n.clone() as u128,
+            };
+
+            let mut txn = Txn::new(txn_args);
+
+            txn.sign(&sk);
+
+            let txn_digest_vec = generate_txn_digest_vec(
+                txn.timestamp, 
+                txn.sender_address.clone(), 
+                txn.sender_public_key.clone(), 
+                txn.receiver_address.clone(), 
+                txn.token.clone(), 
+                txn.amount, 
+                txn.nonce
+            ); 
+
+            let digest = TransactionDigest::from(txn_digest_vec);
+
+            (digest, txn)
+        })
+        .into_iter()
+}
+
+/// Helper function to create `n` number of `Claim`s and 
+/// return an `Iterator` of `(String, Claim)` to be collected 
+/// by the caller
+pub(crate) fn create_claims(n: usize) -> impl Iterator<Item = (String, Claim)> {
+    (0..n)
+        .map(|_| {
+            let (_, pk) = create_keypair();
+            let addr = create_address(&pk);
+            let claim = create_claim(&pk, &addr);
+            (claim.public_key.clone(), claim)
+        })
+        .into_iter()
+}
+
+/// A helper function to build a `ProposalBlock`. This function has been 
+/// deprecated and replaced by the `build_single_proposal_block` function
+#[deprecated(note = "use `build_single_proposal_block` function instead")]
+pub(crate) fn build_proposal_block(
+    ref_hash: &String,
+    n_tx: usize,
+    n_claims: usize,
+    round: u128,
+    epoch: u128,
+) -> Result<ProposalBlock, InvalidBlockErrorReason> {
+    let txns: TxnList = create_txns(n_tx).collect();
+
+    let claims = create_claims(n_claims).collect();
+
+    let miner = create_miner();
+
+    let prop_block =
+        miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims);
+
+    let total_txns_size = size_of_txn_list(&txns);
+
+    if total_txns_size > 2000 {
+        return Err(InvalidBlockErrorReason::InvalidBlockSize);
+    }
+
+    return prop_block;
+}
+
+/// A helper function to attempt to mine a `ConvergenceBlock`
+/// with a random `miner`
+pub(crate) fn mine_convergence_block() -> Result<Block, MinerError> {
+    let mut miner = create_miner();
+    miner.try_mine()
+}
+
+/// A helper function to attempt to mine a `ConvergenceBlock`
+/// that signals a change in `Epoch` i.e. a block 
+/// with a `round % Epoch == 0`
+pub(crate) fn mine_convergence_block_epoch_change(
+) -> Result<Block, MinerError> {
+    let mut miner = create_miner();
+    //TODO: Add Mock Convergence Block with round height of 29.999999mm
+    miner.try_mine()
+}
+
+/// A helper function that creates a `Miner` and returns both the 
+/// `Miner` and the `MinerDag`
+pub(crate) fn create_miner_return_dag() -> (Miner<'static>, MinerDag) {
+    let mut miner = create_miner();
+    let dag = miner.dag.clone();
+
+    (miner, dag)
+}
+
+/// A helper function that creates a random `Miner` and provides 
+/// an existing `MinerDag` to replace the default one in the 
+/// `Miner`. Returns both the `Miner` and the `MinerDag`
+pub(crate) fn create_miner_from_dag(dag: &MinerDag) -> (Miner<'static>, MinerDag) {
+    let mut miner = create_miner();
+    miner.dag = dag.clone(); 
+
+    (miner, dag.clone())
+}
+
+/// A helper function to build a single `ProposalBlock` and return it.
+pub(crate) fn build_single_proposal_block(
+    last_block_hash: String,
+    n_txns: usize, 
+    n_claims: usize,
+    round: u128,
+    epoch: u128,
+    from: Claim,
+    sk: SecretKey,
+) -> ProposalBlock {
+    let txns = create_txns(n_txns).collect();
+    let claims = create_claims(n_claims).collect();
+    ProposalBlock::build(
+        last_block_hash,
+        round,
+        epoch,
+        txns,
+        claims,
+        from,
+        sk 
+    )
+}
+
+/// A helper function to build `n` number of porposal blocks 
+/// from random `Claim`s and return a `Vec<ProposalBlock>` 
+pub(crate) fn build_multiple_proposal_blocks_single_round(
+    n_blocks: usize,
+    last_block_hash: String,
+    n_txns: usize,
+    n_claims: usize,
+    round: u128,
+    epoch: u128,
+) -> Vec<ProposalBlock> {
+    
+    (0..n_blocks).into_iter().map(|n| {
+
+        let keypair = Keypair::random();
+        let address = Address::new(keypair.miner_kp.1.clone());
+        let claim = Claim::new(keypair.miner_kp.1.clone().to_string(), address.to_string());
+        let prop = build_single_proposal_block(
+            last_block_hash.clone(), 
+            n_txns, 
+            n_claims, 
+            round, 
+            epoch, 
+            claim, 
+            keypair.miner_kp.0.clone()
+        );
+        prop
+    }).collect()
+}
+
+/// A recursive helper function that takes in a mutable 
+/// `MinerDag` and some information regarding the number 
+/// of rounds, number of blocks (`ProposalBlock`) per round 
+/// The current round (as a mutable reference), and the epoch,
+/// as well as the `last_block_hash` which is either 
+/// the hash of the `GenesisBlock` or a hash of the most recent 
+/// `ConvergenceBlock`
+///
+/// The function checks whether the current `round` that it is 
+/// building is less than the number of rounds (`n_rounds`) the 
+/// caller is asking for. 
+///
+/// If so, then it stops, otherwise it proceeds with the following logic:
+///     
+///     Check if the DAG has a GenesisBlock.
+///
+///         If so: 
+///             Mine a ConvergenceBlock and append it to the MinerDag 
+///             referencing the previous round ProposalBlocks
+///
+///             Add 1 to the round
+///
+///             Build ProposalBlocks that reference the new ConvergenceBlock. 
+///
+///             Append the new ProposalBlocks to the DAG referencing 
+///             the most recent ConvergenceBlock.
+///
+///             Recursively calls itself passing in the most recent 
+///             ConvergenceBlock hash as the `last_block_hash` and the 
+///             updated round, as well as the rest of the information.
+///
+///        Otherwise:
+///             Add a genesis block, and a single, random, empty ProposalBlock 
+///             to the DAG as the root vertex and first leaf the two make
+///             up the first edge.
+///
+///             Add 1 to the round
+///
+///             Recursively calls itself passing in the GenesisBlock hash 
+///             as the last_block_hash and the updated round as the 
+///             round, as well as all the other data.
+pub(crate) fn build_multiple_rounds(
+    dag: &mut MinerDag,
+    last_block_hash: String, 
+    n_blocks: usize, 
+    n_txns: usize,
+    n_claims: usize,
+    n_rounds: usize,
+    round: &mut usize,
+    epoch: usize,
+) {
+    if n_rounds > round.clone() {
+        if dag_has_genesis(&mut dag.clone()) {
+            if let Some(hash) = mine_next_convergence_block(&mut dag.clone()) {
+                *round += 1usize;
+                let proposals = build_multiple_proposal_blocks_single_round(
+                    n_blocks, hash.clone(), n_txns, n_claims, round.clone() as u128, epoch as u128
+                );
+                append_proposal_blocks_to_dag(&mut dag.clone(), proposals);
+                build_multiple_rounds(
+                    &mut dag.clone(), hash, n_blocks, n_txns,
+                    n_claims, n_rounds, round, epoch,
+                );
+            };
+            
+        } else {
+            if let Some(hash) = add_genesis_to_dag(&mut dag.clone()) {
+                *round += 1usize;
+                build_multiple_rounds(
+                    &mut dag.clone(), hash, n_blocks, n_txns, 
+                    n_claims, n_rounds, round, epoch
+                );
+            }
+        }
+    }
+}
+
+/// Checks whether the DAG already has a root vertex
+/// returns true if so, false if not
+pub(crate) fn dag_has_genesis(dag: &mut MinerDag) -> bool {
+    dag.read().unwrap().len() > 0
+}
+
+/// build and adds a `GenesisBlock` to the `MinerDag` 
+/// returns the `Some(hash)` if successful otherwise returns None
+pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
+    let mut prop_vertices = Vec::new();
+    let genesis = mine_genesis();
+    let keypair = Keypair::random();
+    let miner = create_miner_from_keypair(&keypair);
+
+    if let Some(genesis) = genesis {
+        let gblock = Block::Genesis { block: genesis.clone() };
+        let gvtx: Vertex<Block, String> = gblock.into();
+        let prop1 = ProposalBlock::build(
+            genesis.hash.clone(),
+            0,
+            0,
+            LinkedHashMap::new(),
+            LinkedHashMap::new(),
+            miner.claim.clone(),
+            keypair.miner_kp.0.clone()
+        );
+        let pblock = Block::Proposal { block: prop1.clone() };
+        let pvtx: Vertex<Block, String> = pblock.into(); 
+        prop_vertices.push(pvtx.clone());
+        if let Ok(mut guard) = dag.write() {
+            let edge = (&gvtx, &pvtx);
+            guard.add_edge(edge);
+            return Some(genesis.get_hash().clone())
+        }
+    }
+    None
+}
+
+/// Mines the next `ConvergenceBlock` in the `MinerDag`
+/// Returns `Some(hash)` if successful otherwise returns `None`
+pub(crate) fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> {
+    let keypair = Keypair::random();
+    let mut miner = create_miner_from_keypair(&keypair);
+    miner.dag = dag.clone();
+    if let Ok(cblock) = miner.try_mine() {
+        if let Block::Convergence { ref block } = cblock.clone() {
+            let cvtx: Vertex<Block, String> = cblock.into();
+            let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![]; 
+            if let Ok(guard) = dag.read() {
+                block.clone().get_ref_hashes().iter().for_each(|t| {
+                    if let Some(pvtx) = guard.get_vertex(t.clone()) {
+                        edges.push((pvtx.clone(), cvtx.clone()));
+                    }
+                });
+            }
+
+            if let Ok(mut guard) = dag.write() {
+                let edges = edges.iter().map(|(source, reference)| {
+                    (source, reference)
+                }).collect();
+                guard.extend_from_edges(edges);
+                return Some(block.get_hash())
+            }
+        }
+    }
+
+    None
+}
+
+/// Appends `ProposalBlock`s to the `MinerDag`
+pub(crate) fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
+    let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
+    for block in proposals.iter() {
+        let ref_hash = block.ref_block.clone();
+        if let Ok(guard) = dag.read() {
+            if let Some(cvtx) = guard.get_vertex(ref_hash) {
+                let pblock = Block::Proposal { block: block.clone() };
+                let pvtx: Vertex<Block, String> = pblock.into();
+                let edge = (cvtx.clone(), pvtx.clone());
+                edges.push(edge);
+            }
+        }
+    }
+
+    let edges: Vec<(&Vertex<Block, String>, &Vertex<Block, String>)> = edges.iter().map(|(source, reference)| {
+        (source, reference)
+    }).collect();
+
+    if let Ok(mut guard) = dag.write() {
+        guard.extend_from_edges(edges);
+    }
+}
+
+/// Builds 2 `ProposalBlock`s which contain 5 of the same `Txn`s 
+/// this is used to test conflict resolution mechanism of the `Miner`
+pub(crate) fn build_conflicting_proposal_blocks(
+    last_block_hash: String,
+    round: u128,
+    epoch: u128,
+) -> (ProposalBlock, ProposalBlock) {
+    let txns: LinkedHashMap<TransactionDigest, Txn> = create_txns(5).collect();
+    let prop1 = build_single_proposal_block_from_txns(
+        last_block_hash.clone(), txns.clone(), round, epoch
+    );  
+
+    let prop2 = build_single_proposal_block_from_txns(
+        last_block_hash, txns, round, epoch
+    );
+
+    (prop1, prop2)
+
+}
+
+/// Builds a single `ProposalBlock` and extends the `TxnList` of the 
+/// `ProposalBlock` with transactions provided in the function call.
+pub(crate) fn build_single_proposal_block_from_txns(
+    last_block_hash: String, 
+    txns: impl IntoIterator<Item = (TransactionDigest, Txn)>,
+    round: u128,
+    epoch: u128,
+) -> ProposalBlock {
+    
+    let kp = Keypair::random();
+    let miner = create_miner_from_keypair(&kp);
+    let mut prop = build_single_proposal_block(
+        last_block_hash, 
+        5, 
+        4, 
+        round, 
+        epoch, 
+        miner.claim, 
+        kp.miner_kp.0
+    );
+
+    prop.txns.extend(txns);
+
+    prop
+
+}

--- a/crates/network/src/network.rs
+++ b/crates/network/src/network.rs
@@ -382,7 +382,6 @@ impl BroadcastEngine {
         self.endpoint.0.local_addr()
     }
 
-    #[telemetry::instrument(name = "get_address_for_packet_shards")]
     fn get_address_for_packet_shards(
         &self,
         packet_index: usize,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -60,6 +60,7 @@ dashmap ={workspace=true}
 timer = {workspace=true}
 laminar = {workspace=true}
 ethereum-types = { workspace = true }
+quorum={workspace=true}
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -59,6 +59,7 @@ lazy_static = {workspace=true}
 dashmap ={workspace=true}
 timer = {workspace=true}
 laminar = {workspace=true}
+ethereum-types = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -9,6 +9,7 @@ pub mod services;
 pub mod test_utils;
 
 use events::{DirectedEvent, Event};
+
 pub use node_type::*;
 pub use result::*;
 pub use runtime::*;
@@ -17,7 +18,7 @@ pub use services::*;
 
 pub use crate::node::*;
 
-pub(crate) type EventBroadcastSender = tokio::sync::mpsc::UnboundedSender<Event>;
+pub(crate) type EventBroadcastSender = tokio::sync::mpsc::UnboundedSender<DirectedEvent>;
 pub(crate) type EventBroadcastReceiver = tokio::sync::broadcast::Receiver<Event>;
 
 /// The maximum size in kilobytes of transactions that can be in the mempool at

--- a/crates/node/src/result.rs
+++ b/crates/node/src/result.rs
@@ -1,8 +1,6 @@
 use std::net::AddrParseError;
 
-use events::DirectedEvent;
 use network::{config::BroadcastError, types::config::BroadCastError};
-use theater::TheaterError;
 use thiserror::Error;
 use tokio::sync::{
     broadcast::error::RecvError,
@@ -30,16 +28,7 @@ pub enum NodeError {
     TryRecv(#[from] TryRecvError),
 
     #[error("{0}")]
-    MpscSend(#[from] SendError<DirectedEvent>),
-
-    #[error("{0}")]
-    Theater(#[from] theater::TheaterError),
-
-    #[error("{0}")]
     Event(#[from] events::Error),
-
-    #[error("{0}")]
-    BroadcastRecv(#[from] RecvError),
 
     #[error("{0}")]
     Core(#[from] vrrb_core::Error),

--- a/crates/node/src/runtime/broadcast_module.rs
+++ b/crates/node/src/runtime/broadcast_module.rs
@@ -1,21 +1,31 @@
-use std::{net::SocketAddr, time::Duration};
+use std::{collections::HashSet, net::SocketAddr, result::Result as StdResult, time::Duration};
 
 use async_trait::async_trait;
+use block::Block;
 use bytes::Bytes;
 use events::{DirectedEvent, Event};
-use network::network::BroadcastEngine;
+use network::{
+    message::{Message, MessageBody},
+    network::BroadcastEngine,
+};
 use primitives::{NodeType, PeerId};
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::{error, instrument};
 use theater::{ActorLabel, ActorState, Handler};
-use tokio::sync::mpsc::unbounded_channel;
+use tokio::{
+    sync::{
+        broadcast::{
+            error::{RecvError, TryRecvError},
+            Receiver,
+        },
+        mpsc::{channel, Receiver as MpscReceiver, Sender},
+    },
+    task::JoinHandle,
+    time::timeout,
+};
 use uuid::Uuid;
 
-use crate::{
-    broadcast_controller::{self, BroadcastEngineController, BroadcastEngineControllerConfig},
-    NodeError,
-    Result,
-};
+use crate::{NodeError, Result, RuntimeModuleState};
 
 pub struct BroadcastModuleConfig {
     pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
@@ -33,16 +43,23 @@ pub struct BroadcastModule {
     status: ActorState,
     events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
     vrrbdb_read_handle: VrrbDbReadHandle,
-    engine_controller_handle: tokio::task::JoinHandle<()>,
-    engine_controller_tx: tokio::sync::mpsc::UnboundedSender<Event>,
-    broadcast_engine_local_addr: SocketAddr,
+    broadcast_engine: BroadcastEngine,
+    status: ActorState,
 }
 
-/// Useful alias to represent get_incomming_connections' return type
-type BytesTrifecta = (Bytes, Bytes, Bytes);
+const PACKET_TIMEOUT_DURATION: u64 = 10;
+
+trait Timeout: Sized {
+    fn timeout(self) -> tokio::time::Timeout<Self>;
+}
+
+impl<F: std::future::Future> Timeout for F {
+    fn timeout(self) -> tokio::time::Timeout<Self> {
+        tokio::time::timeout(Duration::from_secs(PACKET_TIMEOUT_DURATION), self)
+    }
+}
 
 const PACKET_TIMEOUT_DURATION: u64 = 10;
-const EMPTY_BYTES_TRIFECTA: BytesTrifecta = (Bytes::new(), Bytes::new(), Bytes::new());
 
 trait Timeout: Sized {
     fn timeout(self) -> tokio::time::Timeout<Self>;
@@ -62,43 +79,61 @@ impl BroadcastModule {
                 NodeError::Other(format!("unable to setup broadcast engine: {:?}", err))
             })?;
 
-        let broadcast_engine_local_addr = broadcast_engine.local_addr();
-
-        let events_tx = config.events_tx.clone();
-
-        let (engine_controller_tx, engine_controller_rx) = unbounded_channel();
-
-        let engine_controller_handle = tokio::spawn(async move {
-            let events_tx = events_tx;
-
-            let mut broadcast_engine = broadcast_engine;
-
-            let mut broadcast_controller =
-                BroadcastEngineController::new(BroadcastEngineControllerConfig {
-                    engine: broadcast_engine,
-                    events_tx,
-                })
-                .listen(engine_controller_rx)
-                .await;
-        });
-
         Ok(Self {
             id: Uuid::new_v4(),
             events_tx: config.events_tx,
             status: ActorState::Stopped,
             vrrbdb_read_handle: config.vrrbdb_read_handle,
-            broadcast_engine_local_addr,
-            engine_controller_tx,
-            engine_controller_handle,
+            broadcast_engine,
         })
     }
 
     pub fn local_addr(&self) -> SocketAddr {
-        self.broadcast_engine_local_addr
+        self.broadcast_engine.local_addr()
     }
 
     pub fn name(&self) -> String {
         "BroadcastModule".to_string()
+    }
+
+    pub async fn process_received_msg(&mut self) {
+        loop {
+            if let Some((_, mut incoming)) = self
+                .broadcast_engine
+                .get_incomming_connections()
+                .next()
+                .await
+            {
+                if let Ok(message_result) = incoming.next().timeout().await {
+                    if let Ok(msg_option) = message_result {
+                        if let Some(message) = msg_option {
+                            let msg = Message::from_bytes(&message.2);
+                            match msg.data {
+                                MessageBody::InvalidBlock { .. } => {},
+                                MessageBody::Disconnect { .. } => {},
+                                MessageBody::StateComponents { .. } => {},
+                                MessageBody::Genesis { .. } => {},
+                                MessageBody::Child { .. } => {},
+                                MessageBody::Parent { .. } => {},
+                                MessageBody::Ledger { .. } => {},
+                                MessageBody::NetworkState { .. } => {},
+                                MessageBody::ClaimAbandoned { .. } => {},
+                                MessageBody::ResetPeerConnection { .. } => {},
+                                MessageBody::RemovePeer { .. } => {},
+                                MessageBody::AddPeer { .. } => {},
+                                MessageBody::DKGPartCommitment {
+                                    part_commitment,
+                                    sender_id,
+                                } => {},
+                                MessageBody::DKGPartAcknowledgement { .. } => {},
+                                MessageBody::Vote { .. } => {},
+                                MessageBody::Empty => {},
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -126,14 +161,96 @@ impl Handler<Event> for BroadcastModule {
 
     #[instrument]
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
-        if let Err(err) = self.engine_controller_tx.send(event.clone()) {
-            error!("unable to send event to broadcast controller: {:?}", err);
+        match event {
+            Event::PartMessage(sender_id, part_commitment) => {
+                let status = self
+                    .broadcast_engine
+                    .quic_broadcast(Message::new(MessageBody::DKGPartCommitment {
+                        sender_id,
+                        part_commitment,
+                    }))
+                    .await;
+                match status {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!(
+                            "Error occured while broadcasting ack commitment to peers :{:?}",
+                            e
+                        );
+                    },
+                }
+            },
+            Event::SendAck(curr_node_id, sender_id, ack) => {
+                let status = self
+                    .broadcast_engine
+                    .quic_broadcast(Message::new(MessageBody::DKGPartAcknowledgement {
+                        curr_node_id,
+                        sender_id,
+                        ack,
+                    }))
+                    .await;
+                match status {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!(
+                            "Error occured while broadcasting Part commitment to peers :{:?}",
+                            e
+                        );
+                    },
+                }
+            },
+            Event::SyncPeers(peers) => {
+                let mut quic_addresses = vec![];
+                let mut raptor_peer_list = vec![];
+                for peer in peers.iter() {
+                    if let Ok(addr) = peer.address.parse::<SocketAddr>() {
+                        quic_addresses.push(addr);
+                        let mut raptor_addr = addr.clone();
+                        raptor_addr.set_port(peer.raptor_udp_port);
+                        raptor_peer_list.push(raptor_addr);
+                    }
+                }
+                self.broadcast_engine.add_raptor_peers(raptor_peer_list);
+                self.broadcast_engine.add_peer_connection(quic_addresses);
+            },
+            Event::Vote(vote, quorum_type, farmer_quorum_threshold) => {
+                let status = self
+                    .broadcast_engine
+                    .quic_broadcast(Message::new(MessageBody::Vote {
+                        vote,
+                        quorum_type,
+                        farmer_quorum_threshold,
+                    }))
+                    .await;
+                match status {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!(
+                            "Error occured while broadcasting votes to harvesters :{:?}",
+                            e
+                        );
+                    },
+                }
+            },
+            /// Broadcasting the Convergence block to the peers.
+            Event::BlockConfirmed(block) => {
+                let status = self
+                    .broadcast_engine
+                    .unreliable_broadcast(
+                        block,
+                        RAPTOR_ERASURE_COUNT,
+                        self.broadcast_engine.raptor_udp_port,
+                    )
+                    .await;
+                match status {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!("Error occured while broadcasting blocks to peers :{:?}", e);
+                    },
+                }
+            },
 
-            return Ok(ActorState::Stopped);
-        }
-
-        if matches!(event, Event::Stop) {
-            return Ok(ActorState::Stopped);
+            _ => {},
         }
 
         Ok(ActorState::Running)
@@ -143,13 +260,10 @@ impl Handler<Event> for BroadcastModule {
 #[cfg(test)]
 mod tests {
     use std::io::stdout;
-
-    use events::{Event, SyncPeerData};
+    use events::Event;
     use primitives::NodeType;
     use storage::vrrbdb::{VrrbDb, VrrbDbConfig};
-    use telemetry::TelemetrySubscriber;
-    use theater::{Actor, ActorImpl};
-    use tokio::{net::UdpSocket, sync::mpsc::unbounded_channel};
+    use tokio::sync::mpsc::unbounded_channel;
 
     use super::{BroadcastModule, BroadcastModuleConfig};
 

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -48,8 +48,8 @@ pub struct DkgModuleConfig {
 pub struct DkgModule {
     pub dkg_engine: DkgEngine,
     pub quorum_type: Option<QuorumType>,
-    pub rendzevous_local_addr: SocketAddr,
-    pub rendzevous_server_addr: SocketAddr,
+    pub rendezvous_local_addr: SocketAddr,
+    pub rendezvous_server_addr: SocketAddr,
     pub quic_port: u16,
     pub socket: Socket,
     status: ActorState,
@@ -64,8 +64,8 @@ impl DkgModule {
         node_type: NodeType,
         secret_key: hbbft::crypto::SecretKey,
         config: DkgModuleConfig,
-        rendzevous_local_addr: SocketAddr,
-        rendzevous_server_addr: SocketAddr,
+        rendezvous_local_addr: SocketAddr,
+        rendezvous_server_addr: SocketAddr,
         quic_port: u16,
         broadcast_events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
     ) -> Result<DkgModule> {
@@ -79,7 +79,7 @@ impl DkgModule {
             },
         );
         let socket_result = Socket::bind_with_config(
-            rendzevous_local_addr,
+            rendezvous_local_addr,
             Config {
                 blocking_mode: false,
                 idle_connection_timeout: Duration::from_secs(5),
@@ -101,8 +101,8 @@ impl DkgModule {
             Ok(socket) => Ok(Self {
                 dkg_engine: engine,
                 quorum_type: config.quorum_type,
-                rendzevous_local_addr,
-                rendzevous_server_addr,
+                rendezvous_local_addr,
+                rendezvous_server_addr,
                 quic_port,
                 socket,
                 status: ActorState::Stopped,
@@ -146,8 +146,8 @@ impl DkgModule {
         Self {
             dkg_engine,
             quorum_type: Some(QuorumType::Farmer),
-            rendzevous_local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
-            rendzevous_server_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
+            rendezvous_local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
+            rendezvous_server_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
             quic_port: 9090,
             socket,
             status: ActorState::Stopped,
@@ -161,14 +161,14 @@ impl DkgModule {
         String::from("DKG module")
     }
 
-    pub fn process_rendzevous_response(&self) {
+    pub fn process_rendezvous_response(&self) {
         let receiver = self.socket.get_event_receiver();
         let sender = self.socket.get_packet_sender();
         loop {
             if let Ok(event) = receiver.recv() {
                 match event {
                     SocketEvent::Packet(packet) => {
-                        if packet.addr() == self.rendzevous_server_addr {
+                        if packet.addr() == self.rendezvous_server_addr {
                             if let Ok(payload_response) =
                                 bincode::deserialize::<Data>(packet.payload())
                             {
@@ -253,7 +253,7 @@ impl DkgModule {
                                         harvester_public_key.to_bytes().to_vec(),
                                     ))){
                                 let _ = sender.send(Packet::reliable_ordered(
-                                    self.rendzevous_server_addr,
+                                    self.rendezvous_server_addr,
                                     data,
                                     None,
                                 ));
@@ -270,7 +270,7 @@ impl DkgModule {
                                             quorum_key.public_key().to_bytes().to_vec(),
                                         ))){
                                                    let _ = sender.send(Packet::reliable_ordered(
-                                        self.rendzevous_server_addr,
+                                        self.rendezvous_server_addr,
                                         data,
                                         None,
                                     ));
@@ -302,8 +302,8 @@ impl DkgModule {
                                                 signature,
                                                 msg_bytes,
                                                 SyncPeerData {
-                                                    address: self.rendzevous_local_addr.to_string(),
-                                                    raptor_udp_port: self.rendzevous_local_addr.port(),
+                                                    address: self.rendezvous_local_addr.to_string(),
+                                                    raptor_udp_port: self.rendezvous_local_addr.port(),
                                                     quic_port: self.quic_port,
                                                     node_type: self.dkg_engine.node_type,
                                                 },
@@ -311,7 +311,7 @@ impl DkgModule {
                                         ));
                                         if let Ok(payload) = payload_result {
                                             let _ = sender.send(Packet::reliable_ordered(
-                                                self.rendzevous_server_addr,
+                                                self.rendezvous_server_addr,
                                                 payload,
                                                 None,
                                             ));

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -190,7 +190,7 @@ impl DkgModule {
                                         RendezvousResponse::Peers(peers) => {
                                             let _ = self
                                                 .broadcast_events_tx
-                                                .send(Event::SyncPeers(peers));
+                                                .send((Topic::Network, Event::SyncPeers(peers)));
                                         },
                                         RendezvousResponse::NamespaceRegistered => {
                                             info!("Namespace Registered");
@@ -302,7 +302,7 @@ impl DkgModule {
                                                 signature,
                                                 msg_bytes,
                                                 SyncPeerData {
-                                                    address: self.rendzevous_local_addr,
+                                                    address: self.rendzevous_local_addr.to_string(),
                                                     raptor_udp_port: self.rendzevous_local_addr.port(),
                                                     quic_port: self.quic_port,
                                                     node_type: self.dkg_engine.node_type,
@@ -329,6 +329,37 @@ impl DkgModule {
             }
         }
     }
+}
+
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Data {
+    Request(RendezvousRequest),
+    Response(RendezvousResponse),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RendezvousRequest {
+    Ping,
+    Peers(Vec<u8>),
+    Namespace(NodeTypeBytes, QuorumPublicKey),
+    RegisterPeer(
+        QuorumPublicKey,
+        NodeTypeBytes,
+        PKShareBytes,
+        RawSignature,
+        PayloadBytes,
+        SyncPeerData,
+    ),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RendezvousResponse {
+    Pong,
+    RequestPeers(QuorumPublicKey),
+    Peers(Vec<SyncPeerData>),
+    PeerRegistered,
+    NamespaceRegistered,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -361,6 +392,8 @@ pub enum RendezvousResponse {
     NamespaceRegistered,
 }
 
+
+>>>>>>> d47861a (Feat change claimpointers to xor (#205))
 #[async_trait]
 impl Handler<Event> for DkgModule {
     fn id(&self) -> ActorId {

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -1,0 +1,356 @@
+use std::{collections::{HashMap, BTreeMap}, error::Error};
+use block::{
+    header::BlockHeader, 
+    ConflictList, 
+    RefHash, 
+    Conflict, 
+    ResolvedConflicts
+};
+use events::{ConflictBytes, DirectedEvent, Topic};
+use telemetry::info;
+use async_trait::async_trait;
+use primitives::NodeId;
+use storage::vrrbdb::VrrbDbReadHandle;
+use theater::{ActorId, ActorState, ActorLabel, Handler};
+use vrrb_core::{claim::Claim, event_router::{DirectedEvent, Event}};
+use serde::{Serialize, Deserialize};
+use std::fmt::Debug;
+use tokio::{task::JoinHandle, sync::mpsc::UnboundedSender};
+use ethereum_types::U256;
+
+pub type Seed = u64;
+
+pub trait ElectionType: Clone + Debug {}
+pub trait ElectionOutcome: Clone + Debug {}
+
+pub type MinerElectionResult = Vec<ElectionResult>;
+pub type QuorumElectionResult = HashMap<u8, Vec<ElectionResult>>;
+pub type ConflictResolutionResult = HashMap<String, ElectionResult>;
+
+#[derive(Clone, Debug)]
+pub struct MinerElection;
+
+#[derive(Clone, Debug)]
+pub struct QuorumElection;
+
+#[derive(Clone, Debug)]
+pub struct ConflictResolution;
+
+pub struct ElectionModuleConfig {
+    pub db_read_handle: VrrbDbReadHandle,
+    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+    pub local_claim: Claim,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ElectionResult {
+    pub claim_pointer: u128,
+    pub claim_hash: String,
+    pub node_id: NodeId,
+}
+
+#[derive(Clone, Debug)]
+pub struct ElectionModule<E, T> 
+where 
+    E: ElectionType,
+    T: ElectionOutcome,
+{
+    election_type: E,
+    status: ActorState,
+    id: ActorId,
+    label: ActorLabel,
+    pub db_read_handle: VrrbDbReadHandle,
+    pub local_claim: Claim,
+    pub outcome: Option<T>,
+    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>, 
+}
+
+impl ElectionModule<MinerElection, MinerElectionResult> {
+    pub fn new(
+        config: ElectionModuleConfig
+    ) -> ElectionModule<MinerElection, MinerElectionResult> 
+    {
+        ElectionModule {
+            election_type: MinerElection,
+            status: ActorState::Stopped,
+            id: uuid::Uuid::new_v4().to_string(),
+            label: String::from("State module"),
+            db_read_handle: config.db_read_handle,
+            local_claim: config.local_claim,
+            outcome: None,
+            events_tx: config.events_tx
+        }
+    }
+
+    pub fn name(&self) -> ActorLabel {
+        String::from("Miner Election Module") 
+    }
+}
+
+impl ElectionModule<QuorumElection, QuorumElectionResult> {
+    pub fn new(
+        config: ElectionModuleConfig
+    ) -> ElectionModule<QuorumElection, QuorumElectionResult> {
+        ElectionModule { 
+            election_type: QuorumElection, 
+            status: ActorState::Stopped, 
+            id: uuid::Uuid::new_v4().to_string(), 
+            label: String::from("State module"), 
+            db_read_handle: config.db_read_handle, 
+            local_claim: config.local_claim, 
+            outcome: None, 
+            events_tx: config.events_tx 
+        } 
+    }
+
+    pub fn name(&self) -> ActorLabel {
+        String::from("Quorum Election Module") 
+    }
+}
+
+impl ElectionModule<ConflictResolution, ConflictResolutionResult> {
+    pub fn new(
+        config: ElectionModuleConfig 
+    ) -> ElectionModule<ConflictResolution, ConflictResolutionResult> {
+        ElectionModule { 
+            election_type: ConflictResolution, 
+            status: ActorState::Stopped, 
+            id: uuid::Uuid::new_v4().to_string(), 
+            label: String::from("State module"), 
+            db_read_handle: config.db_read_handle, 
+            local_claim: config.local_claim, 
+            outcome: None, 
+            events_tx: config.events_tx 
+        } 
+
+    }
+
+    pub fn name(&self) -> ActorLabel {
+        String::from("Conflict Resultion Election Module") 
+    }
+}
+
+
+impl ElectionType for MinerElection {}
+impl ElectionType for QuorumElection {}
+impl ElectionType for ConflictResolution {}
+
+impl ElectionOutcome for MinerElectionResult {}
+impl ElectionOutcome for QuorumElectionResult {}
+impl ElectionOutcome for ConflictResolutionResult {}
+
+#[async_trait]
+impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
+    fn id(&self) -> ActorId {
+        self.id.clone()
+    }
+
+    fn label(&self) -> ActorLabel {
+        self.name()
+    }
+
+    fn status(&self) -> ActorState {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, actor_status: ActorState) {
+        self.status = actor_status;
+    }
+
+    fn on_stop(&self) {
+        info!(
+            "{}-{} received stop signal. Stopping",
+            self.name(),
+            self.label()
+        );
+    }
+
+    async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
+        match event {
+            Event::MinerElection(header_bytes) => {
+                let header_result: Result<BlockHeader> = serde_json::from_slice(
+                    &header_bytes
+                );
+                if let Ok(header) = header_result {
+                    let claims = self.db_read_handle.claim_store_values();
+                    let mut election_results: BTreeMap<U256, String> = elect_miner(
+                        claims, header.block_seed
+                    );
+                    
+                    let winner = get_winner(&mut election_results); 
+
+                    let directed_event = (Topic::Consensus, Event::ElectedMiner(winner));
+                    let _ = self.events_tx.send(directed_event);
+                }
+            }
+            _ => {},
+        }
+
+        Ok(ActorState::Running)
+    }
+}
+
+#[async_trait]
+impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
+
+    fn id(&self) -> ActorId {
+        self.id.clone()
+    }
+
+    fn label(&self) -> ActorLabel {
+        self.name()
+    }
+
+    fn status(&self) -> ActorState {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, actor_status: ActorState) {
+        self.status = actor_status;
+    }
+
+    fn on_stop(&self) {
+        info!(
+            "{}-{} received stop signal. Stopping",
+            self.name(),
+            self.label()
+        );
+    }
+
+    async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
+        match event {
+            //TODO: Implement
+            _ => {},
+        }
+
+        Ok(ActorState::Running)
+    }
+}
+
+#[async_trait]
+impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionResult> {
+
+    fn id(&self) -> ActorId {
+        self.id.clone()
+    }
+
+    fn label(&self) -> ActorLabel {
+        self.name()
+    }
+
+    fn status(&self) -> ActorState {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, actor_status: ActorState) {
+        self.status = actor_status;
+    }
+
+    fn on_stop(&self) {
+        info!(
+            "{}-{} received stop signal. Stopping",
+            self.name(),
+            self.label()
+        );
+    }
+
+    async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
+        match event {
+            Event::ConflictResolution(ConflictBytes, HeaderBytes) => {
+                let cl_res: Result<ConflictList> = serde_json::from_slice(
+                    &ConflictBytes
+                );
+
+                let header_res: Result<BlockHeader> = serde_json::from_slice(
+                    &HeaderBytes
+                );
+                
+                if let Ok(conflicts) = cl_res {
+                    if let Ok(header) = header_res {
+                        let handles: ResolvedConflicts = 
+                            conflicts.iter()
+                                .map(|(txnid, conflict)| {
+                                    let inner_header = header.clone();
+                                    let events_tx = self.events_tx.clone();
+                                    let mut inner_conflict: Conflict = conflict.clone();
+                                    tokio::spawn(async move {
+                                        resolve_conflict(
+                                            &mut inner_conflict, 
+                                            inner_header.clone(),
+                                            events_tx,
+                                        ).await;
+                                    }
+                                );
+                            }
+                        ).collect();
+                    }
+                }
+            }
+            _ => {},
+        }
+
+        Ok(ActorState::Running)
+    }
+}
+
+fn elect_miner(
+    claims: HashMap<NodeId, Claim>,
+    block_seed: u64 
+) -> BTreeMap<U256, NodeId> {
+
+    claims.iter()
+        .filter(|(_, claim)| claim.eligible)
+        .map(|(nodeid, claim)| single_miner_results(claim, nodeid, block_seed)
+    ).collect()
+}
+
+fn single_miner_results(
+    claim: Claim,
+    node_id: NodeId,
+    block_seed: u64,
+) -> (U256, NodeId) {
+    (claim.get_election_result(block_seed), node_id)
+}
+
+fn get_winner(
+    results: &mut BTreeMap<U256, NodeId>
+) -> (U256, NodeId) {
+
+    let mut first: Option<(U256, NodeId)> = election_results.pop_first();
+    while let None = first {
+        first = election_results.pop_first();
+    }
+
+    return first
+}
+
+async fn resolve_conflict(
+    conflict: &mut Conflict, 
+    header: BlockHeader,
+    events_tx: UnboundedSender<DirectedEvent>
+) {
+
+    let propopsers = conflict.proposers.clone();
+    let resoultion_results: BTreeMap<U256, String> = proposers.iter()
+        .map(|(claim, refhash)| {
+            (claim.get_election_results(
+            inner_header.block_seed.clone() 
+            ), refhash.clone());
+        }
+    ).collect(); 
+
+    let winner = {
+
+        let mut first: Option<(U256, NodeId)> = resolution_results.pop_first();
+
+        while let None = first {
+            first = resolution_results.pop_first();
+        }
+
+        return first
+    };
+
+    conflict.winner = Some(winner.1);
+    let directed_event = (Topic::Consensus, Event::ConflictResolved(conflict));
+    let _ = events_tx.send(directed_event);
+}

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -1,22 +1,28 @@
-use std::{collections::{HashMap, BTreeMap}, error::Error};
-use block::{
-    header::BlockHeader, 
-    ConflictList, 
-    RefHash, 
-    Conflict, 
-    ResolvedConflicts
+use std::{
+    collections::{hash_map::DefaultHasher, BTreeMap, HashMap},
+    error::Error,
+    fmt::Debug,
+    hash::{Hash, Hasher},
 };
-use events::{ConflictBytes, DirectedEvent, Topic};
-use telemetry::info;
+
 use async_trait::async_trait;
-use primitives::NodeId;
-use storage::vrrbdb::VrrbDbReadHandle;
-use theater::{ActorId, ActorState, ActorLabel, Handler};
-use vrrb_core::{claim::Claim, event_router::{DirectedEvent, Event}};
-use serde::{Serialize, Deserialize};
-use std::fmt::Debug;
-use tokio::{task::JoinHandle, sync::mpsc::UnboundedSender};
+use block::{header::BlockHeader, Conflict, ConflictList, RefHash, ResolvedConflicts};
 use ethereum_types::U256;
+use events::{ConflictBytes, DirectedEvent, Event, Topic};
+use primitives::NodeId;
+use quorum::{election::Election, quorum::Quorum, Quorum};
+use serde::{Deserialize, Serialize};
+use sha256::digest;
+use storage::vrrbdb::VrrbDbReadHandle;
+use telemetry::info;
+use theater::{ActorId, ActorLabel, ActorState, Handler};
+use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
+use vrrb_core::{
+    claim::Claim,
+    event_router::{DirectedEvent, Event},
+};
+
+use crate::NodeError;
 
 pub type Seed = u64;
 
@@ -50,8 +56,8 @@ pub struct ElectionResult {
 }
 
 #[derive(Clone, Debug)]
-pub struct ElectionModule<E, T> 
-where 
+pub struct ElectionModule<E, T>
+where
     E: ElectionType,
     T: ElectionOutcome,
 {
@@ -62,71 +68,67 @@ where
     pub db_read_handle: VrrbDbReadHandle,
     pub local_claim: Claim,
     pub outcome: Option<T>,
-    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>, 
+    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
 }
 
 impl ElectionModule<MinerElection, MinerElectionResult> {
-    pub fn new(
-        config: ElectionModuleConfig
-    ) -> ElectionModule<MinerElection, MinerElectionResult> 
-    {
+    pub fn new(config: ElectionModuleConfig) -> ElectionModule<MinerElection, MinerElectionResult> {
         ElectionModule {
             election_type: MinerElection,
             status: ActorState::Stopped,
             id: uuid::Uuid::new_v4().to_string(),
-            label: String::from("State module"),
+            label: String::from("Election module"),
             db_read_handle: config.db_read_handle,
             local_claim: config.local_claim,
             outcome: None,
-            events_tx: config.events_tx
+            events_tx: config.events_tx,
         }
     }
 
     pub fn name(&self) -> ActorLabel {
-        String::from("Miner Election Module") 
+        String::from("Miner Election Module")
     }
 }
 
 impl ElectionModule<QuorumElection, QuorumElectionResult> {
     pub fn new(
-        config: ElectionModuleConfig
+        config: ElectionModuleConfig,
     ) -> ElectionModule<QuorumElection, QuorumElectionResult> {
-        ElectionModule { 
-            election_type: QuorumElection, 
-            status: ActorState::Stopped, 
-            id: uuid::Uuid::new_v4().to_string(), 
-            label: String::from("State module"), 
-            db_read_handle: config.db_read_handle, 
-            local_claim: config.local_claim, 
-            outcome: None, 
-            events_tx: config.events_tx 
-        } 
+        ElectionModule {
+            election_type: QuorumElection,
+            status: ActorState::Stopped,
+            id: uuid::Uuid::new_v4().to_string(),
+            label: String::from("Election module"),
+            db_read_handle: config.db_read_handle,
+            local_claim: config.local_claim,
+            outcome: None,
+            events_tx: config.events_tx,
+        }
     }
 
     pub fn name(&self) -> ActorLabel {
-        String::from("Quorum Election Module") 
+        String::from("Quorum Election Module")
     }
 }
 
 impl ElectionModule<ConflictResolution, ConflictResolutionResult> {
     pub fn new(
-        config: ElectionModuleConfig 
+        config: ElectionModuleConfig,
     ) -> ElectionModule<ConflictResolution, ConflictResolutionResult> {
-        ElectionModule { 
-            election_type: ConflictResolution, 
-            status: ActorState::Stopped, 
-            id: uuid::Uuid::new_v4().to_string(), 
-            label: String::from("State module"), 
-            db_read_handle: config.db_read_handle, 
-            local_claim: config.local_claim, 
-            outcome: None, 
-            events_tx: config.events_tx 
-        } 
-
+        ElectionModule {
+            election_type: ConflictResolution,
+            status: ActorState::Stopped,
+            id: uuid::Uuid::new_v4().to_string(),
+            label: String::from("Election module"),
+            db_read_handle: config.db_read_handle,
+            local_claim: config.local_claim,
+            outcome: None,
+            events_tx: config.events_tx,
+        }
     }
 
     pub fn name(&self) -> ActorLabel {
-        String::from("Conflict Resultion Election Module") 
+        String::from("Conflict Resultion Election Module")
     }
 }
 
@@ -168,21 +170,18 @@ impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
             Event::MinerElection(header_bytes) => {
-                let header_result: Result<BlockHeader> = serde_json::from_slice(
-                    &header_bytes
-                );
+                let header_result: Result<BlockHeader> = serde_json::from_slice(&header_bytes);
                 if let Ok(header) = header_result {
                     let claims = self.db_read_handle.claim_store_values();
-                    let mut election_results: BTreeMap<U256, String> = elect_miner(
-                        claims, header.block_seed
-                    );
-                    
-                    let winner = get_winner(&mut election_results); 
+                    let mut election_results: BTreeMap<U256, String> =
+                        elect_miner(claims, header.block_seed);
+
+                    let winner = get_winner(&mut election_results);
 
                     let directed_event = (Topic::Consensus, Event::ElectedMiner(winner));
                     let _ = self.events_tx.send(directed_event);
                 }
-            }
+            },
             _ => {},
         }
 
@@ -192,7 +191,6 @@ impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
 
 #[async_trait]
 impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
-
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -219,7 +217,31 @@ impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
 
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
-            //TODO: Implement
+            Event::QuorumElection(kp, last_block_height) => {
+                let claims = self.db_read_handle.claim_store_values();
+                let mut hasher = DefaultHasher::new();
+                kp.get_miner_public_key().hash(&mut hasher);
+                let pubkey_hash = hasher.finish();
+
+                let mut pub_key_bytes = pubkey_hash.to_string().as_bytes().to_vec();
+                pub_key_bytes.push(1u8);
+
+                let hash = digest(digest(&*pub_key_bytes).as_bytes());
+                let payload = (10, hash);
+
+                if let Ok(seed) = Quorum::generate_seed(payload, kp.clone()) {
+                    if let Ok(mut quorum) = Quorum::new(seed, last_block_height, kp.clone()) {
+                        if let Ok(elected_quorum) =
+                            quorum.run_election(claims.values().cloned().collect::<Vec<Claim>>())
+                        {
+                            let directed_event = Event::ElectedQuorum(elected_quorum.clone());
+                            let _ = self.events_tx.send(directed_event);
+                        }
+                    }
+                }
+
+            },
+
             _ => {},
         }
 
@@ -229,7 +251,6 @@ impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
 
 #[async_trait]
 impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionResult> {
-
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -257,35 +278,31 @@ impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionRes
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
             Event::ConflictResolution(ConflictBytes, HeaderBytes) => {
-                let cl_res: Result<ConflictList> = serde_json::from_slice(
-                    &ConflictBytes
-                );
+                let cl_res: Result<ConflictList> = serde_json::from_slice(&ConflictBytes);
 
-                let header_res: Result<BlockHeader> = serde_json::from_slice(
-                    &HeaderBytes
-                );
-                
+                let header_res: Result<BlockHeader> = serde_json::from_slice(&HeaderBytes);
+
                 if let Ok(conflicts) = cl_res {
                     if let Ok(header) = header_res {
-                        let handles: ResolvedConflicts = 
-                            conflicts.iter()
-                                .map(|(txnid, conflict)| {
-                                    let inner_header = header.clone();
-                                    let events_tx = self.events_tx.clone();
-                                    let mut inner_conflict: Conflict = conflict.clone();
-                                    tokio::spawn(async move {
-                                        resolve_conflict(
-                                            &mut inner_conflict, 
-                                            inner_header.clone(),
-                                            events_tx,
-                                        ).await;
-                                    }
-                                );
-                            }
-                        ).collect();
+                        let handles: ResolvedConflicts = conflicts
+                            .iter()
+                            .map(|(txnid, conflict)| {
+                                let inner_header = header.clone();
+                                let events_tx = self.events_tx.clone();
+                                let mut inner_conflict: Conflict = conflict.clone();
+                                tokio::spawn(async move {
+                                    resolve_conflict(
+                                        &mut inner_conflict,
+                                        inner_header.clone(),
+                                        events_tx,
+                                    )
+                                    .await;
+                                });
+                            })
+                            .collect();
                     }
                 }
-            }
+            },
             _ => {},
         }
 
@@ -293,61 +310,50 @@ impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionRes
     }
 }
 
-fn elect_miner(
-    claims: HashMap<NodeId, Claim>,
-    block_seed: u64 
-) -> BTreeMap<U256, NodeId> {
-
-    claims.iter()
+fn elect_miner(claims: HashMap<NodeId, Claim>, block_seed: u64) -> BTreeMap<U256, NodeId> {
+    claims
+        .iter()
         .filter(|(_, claim)| claim.eligible)
-        .map(|(nodeid, claim)| single_miner_results(claim, nodeid, block_seed)
-    ).collect()
+        .map(|(nodeid, claim)| single_miner_results(claim, nodeid, block_seed))
+        .collect()
 }
 
-fn single_miner_results(
-    claim: Claim,
-    node_id: NodeId,
-    block_seed: u64,
-) -> (U256, NodeId) {
+fn single_miner_results(claim: Claim, node_id: NodeId, block_seed: u64) -> (U256, NodeId) {
     (claim.get_election_result(block_seed), node_id)
 }
 
-fn get_winner(
-    results: &mut BTreeMap<U256, NodeId>
-) -> (U256, NodeId) {
-
+fn get_winner(results: &mut BTreeMap<U256, NodeId>) -> (U256, NodeId) {
     let mut first: Option<(U256, NodeId)> = election_results.pop_first();
     while let None = first {
         first = election_results.pop_first();
     }
 
-    return first
+    return first;
 }
 
 async fn resolve_conflict(
-    conflict: &mut Conflict, 
+    conflict: &mut Conflict,
     header: BlockHeader,
-    events_tx: UnboundedSender<DirectedEvent>
+    events_tx: UnboundedSender<DirectedEvent>,
 ) {
-
     let propopsers = conflict.proposers.clone();
-    let resoultion_results: BTreeMap<U256, String> = proposers.iter()
+    let resoultion_results: BTreeMap<U256, String> = proposers
+        .iter()
         .map(|(claim, refhash)| {
-            (claim.get_election_results(
-            inner_header.block_seed.clone() 
-            ), refhash.clone());
-        }
-    ).collect(); 
+            (
+                claim.get_election_results(inner_header.block_seed.clone()),
+                refhash.clone(),
+            );
+        })
+        .collect();
 
     let winner = {
-
         let mut first: Option<(U256, NodeId)> = resolution_results.pop_first();
 
         while let None = first {
             first = resolution_results.pop_first();
         }
-
-        return first
+        first
     };
 
     conflict.winner = Some(winner.1);

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -314,12 +314,12 @@ fn elect_miner(claims: HashMap<NodeId, Claim>, block_seed: u64) -> BTreeMap<U256
     claims
         .iter()
         .filter(|(_, claim)| claim.eligible)
-        .map(|(nodeid, claim)| single_miner_results(claim, nodeid, block_seed))
+        .map(|(_, claim)| single_miner_results(claim, block_seed))
         .collect()
 }
 
-fn single_miner_results(claim: Claim, node_id: NodeId, block_seed: u64) -> (U256, NodeId) {
-    (claim.get_election_result(block_seed), node_id)
+fn single_miner_results(claim: Claim, block_seed: u64) -> (U256, Claim) {
+    (claim.get_election_result(block_seed), claim)
 }
 
 fn get_winner(results: &mut BTreeMap<U256, NodeId>) -> (U256, NodeId) {

--- a/crates/node/src/runtime/farmer_harvester_module.rs
+++ b/crates/node/src/runtime/farmer_harvester_module.rs
@@ -162,10 +162,13 @@ impl FarmerHarvesterModule {
                 JobResult::Votes((votes, farmer_quorum_threshold)) => {
                     for vote_opt in votes.iter() {
                         if let Some(vote) = vote_opt {
-                            let _ = broadcast_events_tx.send(Event::Vote(
-                                vote.clone(),
-                                QuorumType::Harvester,
-                                farmer_quorum_threshold,
+                            let _ = broadcast_events_tx.send((
+                                Topic::Network,
+                                Event::Vote(
+                                    vote.clone(),
+                                    QuorumType::Harvester,
+                                    farmer_quorum_threshold,
+                                ),
                             ));
                         }
                     }

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -95,10 +95,9 @@ impl FarmerModule {
                 JobResult::Votes((votes, farmer)) => {
                     for vote_opt in votes.iter() {
                         if let Some(vote) = vote_opt {
-                            let _ = broadcast_events_tx.send(Event::Vote(
-                                vote.clone(),
-                                QuorumType::Harvester,
-                                farmer,
+                            let _ = broadcast_events_tx.send((
+                                Topic::Network,
+                                Event::Vote(vote.clone(), QuorumType::Harvester, farmer),
                             ));
                         }
                     }

--- a/crates/node/src/runtime/mempool_module.rs
+++ b/crates/node/src/runtime/mempool_module.rs
@@ -92,7 +92,7 @@ impl Handler<Event> for MempoolModule {
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 self.events_tx
-                    .send(Event::TxnAddedToMempool(txn_hash.clone()))
+                    .send((Topic::Consensus, Event::TxnAddedToMempool(txn_hash.clone())))
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 info!("Transaction {} sent to mempool", txn_hash);
@@ -104,9 +104,12 @@ impl Handler<Event> for MempoolModule {
                     self.cutoff_transaction = Some(txn_hash.clone());
 
                     self.events_tx
-                        .send(Event::MempoolSizeThesholdReached {
-                            cutoff_transaction: txn_hash,
-                        })
+                        .send((
+                            Topic::Consensus,
+                            Event::MempoolSizeThesholdReached {
+                                cutoff_transaction: txn_hash,
+                            },
+                        ))
                         .map_err(|err| TheaterError::Other(err.to_string()))?;
                 }
             },

--- a/crates/node/src/runtime/mining_module.rs
+++ b/crates/node/src/runtime/mining_module.rs
@@ -51,7 +51,10 @@ impl MiningModule {
         // TODO: drain mempool instead then commit changes
         handle
             .drain(..cutoff_idx)
-            .map(|(id, record)| record.txn)
+            .map(|(id, record)| {
+                dbg!(id);
+                record.txn
+            })
             .collect()
     }
 
@@ -97,12 +100,17 @@ impl Handler<Event> for MiningModule {
                 return Ok(ActorState::Stopped);
             },
             // Event::TxnAddedToMempool(txn_digest) => {
-            Event::TxnAddedToMempool(_) => {},
+            Event::TxnAddedToMempool(_) => {
+                // dbg!(txn_digest.to_string());
+            },
             Event::MempoolSizeThesholdReached { cutoff_transaction } => {
                 let handle = self.mempool_read_handle_factory.handle();
 
                 if let Some(idx) = handle.get_index_of(&cutoff_transaction) {
+                    dbg!(handle.len());
                     let transaction_snapshot = self.take_snapshot_until_cutoff(idx);
+                    dbg!(transaction_snapshot.len());
+                    dbg!(handle.len());
 
                     self.mark_snapshot_transactions(idx);
                 } else {
@@ -111,7 +119,12 @@ impl Handler<Event> for MiningModule {
                     );
                 }
             },
+            Event::MinerElection() => {
+                
+            },
+            Event::ResolvedConflict(conflict) => {
 
+            }
             Event::BlockConfirmed(_) => {
                 // do something
             },

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -25,12 +25,8 @@ use self::{
     mining_module::{MiningModule, MiningModuleConfig},
     state_module::StateModule, election_module::{ElectionModuleConfig, ElectionModule, QuorumElection, QuorumElectionResult, ConflictResolutionResult, ConflictResolution},
 };
-use crate::{
-    broadcast_controller::{BroadcastEngineController, BROADCAST_CONTROLLER_BUFFER_SIZE},
-    dkg_module::DkgModuleConfig,
-    NodeError,
-    Result,
-};
+use crate::{broadcast_controller::{BroadcastEngineController, BROADCAST_CONTROLLER_BUFFER_SIZE}, dkg_module::DkgModuleConfig, EventBroadcastSender, NodeError, Result};
+use crate::election_module::{MinerElection, MinerElectionResult};
 
 pub mod broadcast_module;
 pub mod credit_model_module;
@@ -394,10 +390,10 @@ fn setup_miner_election_module(
         ElectionModule::new(ElectionModuleConfig)
     };
 
-    let miner_election_module_actor = ActorImpl::new(module);
+    let mut miner_election_module_actor = ActorImpl::new(module);
     let miner_election_module_handle = tokio::spawn(async move {
         miner_election_module_actor
-            .start(&miner_election_events_rx)
+            .start(&mut miner_election_events_rx)
             .await 
             .map_err(|err| NodeError::Other(err.to_string()))
     });
@@ -422,10 +418,10 @@ fn setup_quorum_election_module(
         ElectionModule::new(ElectionModuleConfig)
     };
 
-    let quorum_election_module_actor = ActorImpl::new(module);
+    let mut quorum_election_module_actor = ActorImpl::new(module);
     let quorum_election_module_handle = tokio::spawn(async move {
         quorum_election_module_actor
-            .start(&quorum_election_events_rx)
+            .start(&mut quorum_election_events_rx)
             .await 
             .map_err(|err| NodeError::Other(err.to_string()))
     });
@@ -450,10 +446,10 @@ fn setup_conflict_resolution_module(
         ElectionModule::new(ElectionModuleConfig)
     };
 
-    let conflict_resolution_module_actor = ActorImpl::new(module);
+    let mut conflict_resolution_module_actor = ActorImpl::new(module);
     let conflict_resolution_module_handle = tokio::spawn(async move {
         conflict_resolution_module_actor
-            .start(&conflict_resolution_events_rx)
+            .start(&mut conflict_resolution_events_rx)
             .await 
             .map_err(|err| NodeError::Other(err.to_string()))
     });

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -351,8 +351,8 @@ fn setup_dkg_module(
             /* Need to be decided either will be preconfigured or decided
              * by Bootstrap Node */
         },
-        config.rendzevous_local_address,
-        config.rendzevous_local_address,
+        config.rendezvous_local_address,
+        config.rendezvous_local_address,
         config.udp_gossip_address.port(),
         events_tx,
     );

--- a/crates/node/src/services/broadcast_controller.rs
+++ b/crates/node/src/services/broadcast_controller.rs
@@ -2,12 +2,24 @@ use std::net::SocketAddr;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use events::{Event, Topic};
+use events::{DirectedEvent, Event};
 use network::{
     message::{Message, MessageBody},
     network::{BroadcastEngine, ConnectionIncoming},
 };
 use telemetry::{error, info, warn};
+use theater::{ActorLabel, ActorState, Handler};
+use tokio::{
+    sync::{
+        broadcast::{
+            error::{RecvError, TryRecvError},
+            Receiver,
+        },
+        mpsc::Sender,
+    },
+    task::JoinHandle,
+};
+use uuid::Uuid;
 
 use crate::{EventBroadcastSender, NodeError, Result};
 

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -22,8 +22,8 @@ pub fn create_mock_full_node_config() -> NodeConfig {
     let jsonrpc_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let udp_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let raptorq_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let rendzevous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let rendzevous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let rendezvous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let rendezvous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
 
     let main_bootstrap_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 10)), 0);
     let bootstrap_node_addresses = vec![main_bootstrap_addr];
@@ -44,8 +44,8 @@ pub fn create_mock_full_node_config() -> NodeConfig {
         .udp_gossip_address(udp_gossip_address)
         .jsonrpc_server_address(jsonrpc_server_address)
         .keypair(Keypair::random())
-        .rendzevous_local_address(rendzevous_local_address)
-        .rendzevous_server_address(rendzevous_server_address)
+        .rendezvous_local_address(rendezvous_local_address)
+        .rendezvous_server_address(rendezvous_server_address)
         .disable_networking(false)
         .build()
         .unwrap()

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -22,8 +22,8 @@ pub fn create_mock_full_node_config() -> NodeConfig {
     let jsonrpc_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let udp_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let raptorq_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let rendezvous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let rendezvous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let rendzevous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let rendzevous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
 
     let main_bootstrap_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 10)), 0);
     let bootstrap_node_addresses = vec![main_bootstrap_addr];
@@ -44,8 +44,8 @@ pub fn create_mock_full_node_config() -> NodeConfig {
         .udp_gossip_address(udp_gossip_address)
         .jsonrpc_server_address(jsonrpc_server_address)
         .keypair(Keypair::random())
-        .rendezvous_local_address(rendezvous_local_address)
-        .rendezvous_server_address(rendezvous_server_address)
+        .rendzevous_local_address(rendzevous_local_address)
+        .rendzevous_server_address(rendzevous_server_address)
         .disable_networking(false)
         .build()
         .unwrap()

--- a/crates/node/tests/state_sync.rs
+++ b/crates/node/tests/state_sync.rs
@@ -14,7 +14,6 @@ use vrrb_core::txn::NewTxnArgs;
 use vrrb_rpc::rpc::{api::RpcApiClient, client::create_client};
 
 #[tokio::test]
-#[ignore]
 async fn nodes_can_synchronize_state() {
     // NOTE: two instances of a config are required because the node will create a
     // data directory for the database which cannot be the same for both nodes

--- a/crates/primitives/src/base.rs
+++ b/crates/primitives/src/base.rs
@@ -52,3 +52,4 @@ pub type NodeTypeBytes = ByteVec;
 pub type QuorumPublicKey = ByteVec;
 pub type PKShareBytes = ByteVec;
 pub type PayloadBytes = ByteVec;
+pub type LastBlockHeight = u128;

--- a/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
+++ b/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use lr_trie::{InnerTrieWrapper, ReadHandleFactory};
+use patriecia::inner::InnerTrie;
+use primitives::NodeId;
+use sha2::Digest;
+use storage_utils::{Result, StorageError};
+use vrrb_core::claim::Claim;
+
+use crate::RocksDbAdapter;
+
+#[derive(Debug, Clone)]
+pub struct ClaimStoreReadHandle {
+    inner: InnerTrieWrapper<RocksDbAdapter>,
+}
+
+impl ClaimStoreReadHandle {
+    pub fn new(inner: InnerTrieWrapper<RocksDbAdapter>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns `Some(Claim)` if an account exist under given PublicKey.
+    /// Otherwise returns `None`.
+    pub fn get(&self, key: &NodeId) -> Result<Claim> {
+        self.inner
+            .get(key)
+            .map_err(|err| StorageError::Other(err.to_string()))
+    }
+
+    /// Get a batch of claims by providing Vec of PublicKeysHash
+    ///
+    /// Returns HashMap indexed by PublicKeys and containing either
+    /// Some(account) or None if account was not found.
+    pub fn batch_get(&self, keys: Vec<NodeId>) -> HashMap<NodeId, Option<Claim>> {
+        let mut claims = HashMap::new();
+
+        keys.iter().for_each(|key| {
+            let value = self.get(key).ok();
+            claims.insert(key.to_owned(), value);
+        });
+
+        claims
+    }
+
+    pub fn entries(&self) -> HashMap<NodeId, Claim> {
+        // TODO: revisit and refactor into inner wrapper
+        self.inner
+            .iter()
+            .filter_map(|(key, value)| {
+                if let Ok(key) = bincode::deserialize(&key) {
+                    if let Ok(value) = bincode::deserialize(&value) {
+                        return Some((key, value));
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
+    /// Returns a number of initialized claims in the database
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns the information about the ClaimDb being empty
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ClaimStoreReadHandleFactory {
+    inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>,
+}
+
+impl ClaimStoreReadHandleFactory {
+    pub fn new(inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>) -> Self {
+        Self { inner }
+    }
+
+    pub fn handle(&self) -> ClaimStoreReadHandle {
+        let handle = self
+            .inner
+            .handle()
+            .enter()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
+
+        let inner = InnerTrieWrapper::new(handle);
+
+        ClaimStoreReadHandle { inner }
+    }
+}

--- a/crates/storage/vrrbdb/src/claim_store/mod.rs
+++ b/crates/storage/vrrbdb/src/claim_store/mod.rs
@@ -1,0 +1,282 @@
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use lr_trie::{LeftRightTrie, H256};
+use primitives::{NodeId, NodeIdentifier};
+use sha2::Digest;
+use storage_utils::{Result, StorageError};
+use vrrb_core::claim::Claim;
+
+use crate::RocksDbAdapter;
+
+mod claim_store_rh;
+pub use claim_store_rh::*;
+
+pub type Claims = Vec<Claim>;
+pub type FailedClaimUpdates = Vec<(NodeId, Claims, Result<()>)>;
+
+#[derive(Debug, Clone)]
+pub struct ClaimStore {
+    trie: LeftRightTrie<'static, NodeId, Claim, RocksDbAdapter>,
+}
+
+impl Default for ClaimStore {
+    fn default() -> Self {
+        let db_path = storage_utils::get_node_data_dir()
+            .unwrap_or_default()
+            .join("db")
+            .join("claim");
+
+        let db_adapter = RocksDbAdapter::new(db_path, "claim").unwrap_or_default();
+
+        let trie = LeftRightTrie::new(Arc::new(db_adapter));
+
+        Self { trie }
+    }
+}
+
+impl ClaimStore {
+    /// Returns new, empty instance of ClaimDb
+
+    pub fn new(path: &PathBuf) -> Self {
+        let path = path.join("claim");
+        let db_adapter = RocksDbAdapter::new(path.to_owned(), "claim").unwrap_or_default();
+        let trie = LeftRightTrie::new(Arc::new(db_adapter));
+
+        Self { trie }
+    }
+
+    /// Returns new ReadHandle to the VrrDb data. As long as the returned value
+    /// lives, no write to the database will be committed.
+    pub fn read_handle(&self) -> ClaimStoreReadHandle {
+        let inner = self.trie.handle();
+        ClaimStoreReadHandle::new(inner)
+    }
+
+    /// Commits uncommitted changes to the underlying trie by calling
+    /// `publish()` Will wait for EACH ReadHandle to be consumed.
+    fn commit_changes(&mut self) {
+        self.trie.publish();
+    }
+
+    // Maybe initialize is better name for that?
+    fn insert_uncommited(&mut self, key: NodeIdentifier, claim: Claim) -> Result<()> {
+
+//        if claim.debits != 0 {
+//            return Err(StorageError::Other(
+//                "cannot insert claim with debit".to_string(),
+//            ));
+//        }
+//
+//        if claim.nonce != 0 {
+//            return Err(StorageError::Other(
+//                "cannot insert claim with nonce bigger than 0".to_string(),
+//            ));
+//        }
+
+        self.trie.insert_uncommitted(key, claim);
+
+        Ok(())
+    }
+
+    /// Inserts new claim into ClaimDb.
+    pub fn insert(&mut self, key: NodeId, claim: Claim) -> Result<()> {
+        self.insert_uncommited(key, claim)?;
+        self.commit_changes();
+        Ok(())
+    }
+
+    // Iterates over provided (PublicKey,DBRecord) pairs, inserting valid ones into
+    // the db Returns Option with vec of NOT inserted (PublicKey,DBRecord,e)
+    // pairs e being the error which prevented (PublicKey,DBRecord) from being
+    // inserted
+    fn batch_insert_uncommited(
+        &mut self,
+        inserts: Vec<(NodeId, Claim)>,
+    ) -> Option<Vec<(NodeId, Claim, StorageError)>> {
+        let mut failed_inserts: Vec<(NodeId, Claim, StorageError)> = vec![];
+
+        inserts.iter().for_each(|item| {
+            let (k, v) = item;
+            if let Err(e) = self.insert_uncommited(k.to_owned(), v.clone()) {
+                failed_inserts.push((k.to_owned(), v.clone(), e));
+            }
+        });
+
+        if failed_inserts.is_empty() {
+            None
+        } else {
+            Some(failed_inserts)
+        }
+    }
+
+    /// Inserts a batch of claims provided in a vector
+    ///
+    /// Returns None if all inserts were succesfully commited.
+    ///
+    /// Otherwise returns vector of (key, claim_to_be_inserted, error).
+    pub fn batch_insert(
+        &mut self,
+        inserts: Vec<(NodeId, Claim)>,
+    ) -> Option<Vec<(NodeId, Claim, StorageError)>> {
+        let failed_inserts = self.batch_insert_uncommited(inserts);
+        self.commit_changes();
+        failed_inserts
+    }
+
+    /// Retain returns new ClaimDb with which all Claims that fulfill `filter`
+    /// cloned to it.
+    pub fn retain<F>(&self, _filter: F) -> ClaimStore
+    where
+        F: FnMut(&Claim) -> bool,
+    {
+        todo!()
+        // let mut subdb = ClaimStore::new(self.);
+        //
+        // self.trie.entries().iter().for_each(|(key, value)| {
+        //     let claim = value.to_owned();
+        //     if filter(&claim) {
+        //         subdb.insert_uncommited(key.to_string(), claim);
+        //     }
+        // });
+        //
+        // subdb.trie.publish();
+        // subdb
+    }
+
+    /// Returns a number of initialized claims in the database
+    pub fn len(&self) -> usize {
+        self.trie.len()
+    }
+
+// TODO: We need to figure out what "updating" a claim means, if anything
+// for now I am leaving these methods out. There will only be inserts, 
+// however, updating a claim should include:
+// 1. Stake
+// 2. !Eligible
+//
+    /// Updates a given claim if it exists within the store
+//    fn update_uncommited(&mut self, key: NodeId, update: UpdateArgs) -> Result<()> {
+//        let mut claim = self
+//            .read_handle()
+//            .get(&key)
+//            .map_err(|err| StorageError::Other(err.to_string()))?;
+//
+//        claim
+//            .update(update)
+//            .map_err(|err| StorageError::Other(err.to_string()))?;
+//
+//        Ok(())
+//    }
+//
+//    /// Updates an Claim in the database under given PublicKey
+//    ///
+//    /// If succesful commits the change. Otherwise returns an error.
+//    pub fn update(&mut self, key: NodeId, update: UpdateArgs) -> Result<()> {
+//        self.update_uncommited(key, update)?;
+//        self.commit_changes();
+//        Ok(())
+//    }
+//
+//    // IDEA: Insted of grouping updates by key in advance, we'll just clear oplog
+//    // from given keys in case error hapens Cannot borrow oplog mutably though
+//    /// Updates claims with batch of updates provied in a `updates` vector.
+//    ///
+//    /// If there are multiple updates for single PublicKey, those are sorted by
+//    /// the `nonce` and applied in correct order.
+//    ///
+//    /// If at least one update for given claim fails, the whole batch for that
+//    /// `PublicKey` is abandoned.
+//    ///
+//    /// All failed batches are returned in vector, with all data - PublicKey for
+//    /// the claim for which the update failed, vector of all updates for that
+//    /// claim, and error that prevented the update.
+//    pub fn batch_update(
+//        &mut self,
+//        mut updates: Vec<(NodeId, UpdateArgs)>,
+//    ) -> Option<FailedClaimUpdates> {
+//        // Store and return all failures as (PublicKey, AllPushedUpdates, Error)
+//        // This way caller is provided with all info -> They know which claims were
+//        // not modified, have a list of all updates to try again And an error
+//        // thrown so that they can fix it
+//        let mut failed = FailedClaimUpdates::new();
+//
+//        // We sort updates by nonce (that's impl of Ord in ClaimField)
+//        // This way all provided updates are used in order (doesn't matter for different
+//        // claims, but important for multiple ops on single PubKey)
+//        updates.sort_by(|a, b| a.1.cmp(&b.1));
+//
+//        // We'll segregate the batch of updates by key (since it's possible that in
+//        // provided Vec there is a chance that not every PublicKey is unique)
+//        let mut update_batches = HashMap::<&NodeId, Vec<UpdateArgs>>::new();
+//
+//        updates.iter().for_each(|update| {
+//            if let Some(vec_of_updates) = update_batches.get_mut(&update.0) {
+//                vec_of_updates.push(update.1.clone());
+//            } else {
+//                update_batches.insert(&update.0, vec![update.1.clone()]);
+//            }
+//        });
+//
+//        // For each PublicKey we try to apply every ClaimFieldsUpdate on a copy of
+//        // current claim if event one fails, the whole batch is abandoned with
+//        // no changes on ClaimDb when that happens, the key, batch of updates and
+//        // error are pushed into result vec On success we update the claim at
+//        // given index (PublicKey) We don't need to commit the changes, since we
+//        // never go back to that key in this function, saving a lot of time (we
+//        // don't need to wait for all readers to finish)
+//        update_batches.drain().for_each(|(k, v)| {
+//            let mut fail: (bool, Result<()>) = (false, Ok(()));
+//            let mut final_claim = Claim::default();
+//
+//            let claim_result = self.read_handle().get(k);
+//
+//            match claim_result {
+//                Ok(mut claim) => {
+//                    for update in v.as_slice() {
+//                        let update_result = claim
+//                            .update(update.clone())
+//                            .map_err(|err| StorageError::Other(err.to_string()));
+//
+//                        if let Err(err) = update_result {
+//                            fail = (true, Err(err));
+//                            break;
+//                        }
+//                    }
+//                    final_claim = claim;
+//                },
+//                Err(err) => fail = (true, Err(err)),
+//            }
+//
+//            if fail.0 {
+//                failed.push((k.to_owned(), v, fail.1));
+//            } else {
+//                // TODO: implement an update method on underlying lr trie
+//                self.trie.insert(k.to_owned(), final_claim);
+//            };
+//        });
+//
+//        if failed.len() != updates.len() {
+//            self.commit_changes();
+//        };
+//
+//        if failed.is_empty() {
+//            return None;
+//        }
+//
+//        Some(failed)
+//    }
+
+    pub fn root_hash(&self) -> Option<H256> {
+        self.trie.root()
+    }
+
+    pub fn extend(&mut self, claims: Vec<(NodeId, Claim)>) {
+        self.trie.extend(claims)
+    }
+
+    pub fn factory(&self) -> ClaimStoreReadHandleFactory {
+        let inner = self.trie.factory();
+
+        ClaimStoreReadHandleFactory::new(inner)
+    }
+}

--- a/crates/storage/vrrbdb/src/lib.rs
+++ b/crates/storage/vrrbdb/src/lib.rs
@@ -1,3 +1,5 @@
+
+mod claim_store;
 mod event_store;
 pub mod result;
 mod rocksdb_adapter;
@@ -7,6 +9,7 @@ mod vrrbdb;
 mod vrrbdb_read_handle;
 mod vrrbdb_serialized_values;
 
+pub use claim_store::*;
 pub use event_store::*;
 pub use rocksdb_adapter::*;
 pub use state_store::*;

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -122,7 +122,7 @@ impl StateStore {
         failed_inserts
     }
 
-    /// Retain returns new StateDb with witch all Accounts that fulfill `filter`
+    /// Retain returns new StateDb with which all Accounts that fulfill `filter`
     /// cloned to it.
     pub fn retain<F>(&self, _filter: F) -> StateStore
     where

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -1,15 +1,17 @@
 use std::{collections::HashMap, fmt::Display, path::PathBuf};
 
 use lr_trie::H256;
-use primitives::Address;
+use primitives::{Address, NodeId};
 use serde_json::json;
 use storage_utils::{Result, StorageError};
 use vrrb_core::{
     account::{Account, UpdateArgs},
-    txn::Txn,
+    txn::Txn, claim::Claim,
 };
 
 use crate::{
+    ClaimStore,
+    ClaimStoreReadHandleFactory,
     StateStore,
     StateStoreReadHandleFactory,
     TransactionStore,
@@ -23,6 +25,15 @@ pub struct VrrbDbConfig {
     pub state_store_path: Option<String>,
     pub transaction_store_path: Option<String>,
     pub event_store_path: Option<String>,
+    pub claim_store_path: Option<String>, 
+}
+
+impl VrrbDbConfig {
+    pub fn with_path(&mut self, path: PathBuf) -> Self {
+        self.path = path;
+
+        self.clone()
+    }
 }
 
 impl VrrbDbConfig {
@@ -44,6 +55,7 @@ impl Default for VrrbDbConfig {
             state_store_path: None,
             transaction_store_path: None,
             event_store_path: None,
+            claim_store_path: None,
         }
     }
 }
@@ -52,27 +64,40 @@ impl Default for VrrbDbConfig {
 pub struct VrrbDb {
     state_store: StateStore,
     transaction_store: TransactionStore,
+    claim_store: ClaimStore,
 }
 
 impl VrrbDb {
     pub fn new(config: VrrbDbConfig) -> Self {
         let state_store = StateStore::new(&config.path);
         let transaction_store = TransactionStore::new(&config.path);
+        let claim_store = ClaimStore::new(&config.path);
 
         Self {
             state_store,
             transaction_store,
+            claim_store,
         }
     }
 
     pub fn read_handle(&self) -> VrrbDbReadHandle {
-        VrrbDbReadHandle::new(self.state_store.factory(), self.transaction_store_factory())
+        VrrbDbReadHandle::new(
+            self.state_store.factory(), 
+            self.transaction_store_factory(),
+            self.claim_store_factory(),
+            )
     }
 
-    pub fn new_with_stores(state_store: StateStore, transaction_store: TransactionStore) -> Self {
+    pub fn new_with_stores(
+        state_store: StateStore, 
+        transaction_store: TransactionStore,
+        claim_store: ClaimStore
+    ) -> Self {
+
         Self {
             state_store,
             transaction_store,
+            claim_store,
         }
     }
 
@@ -82,6 +107,10 @@ impl VrrbDb {
 
     pub fn transaction_store(&self) -> &TransactionStore {
         &self.transaction_store
+    }
+
+    pub fn claim_store(&self) -> &ClaimStore {
+        &self.claim_store 
     }
 
     /// Returns the current state store trie's root hash.
@@ -94,6 +123,12 @@ impl VrrbDb {
         self.transaction_store.root_hash()
     }
 
+    /// Returns the claim store trie's root hash.
+    pub fn claims_root_hash(&self) -> Option<H256> {
+        self.claim_store.root_hash() 
+    }
+
+
     /// Produces a reader factory that can be used to generate read handles into
     /// the state trie.
     pub fn state_store_factory(&self) -> StateStoreReadHandleFactory {
@@ -104,6 +139,12 @@ impl VrrbDb {
     /// the the transaction trie.
     pub fn transaction_store_factory(&self) -> TransactionStoreReadHandleFactory {
         self.transaction_store.factory()
+    }
+
+    /// Produces a reader factory that can be used to generate read_handles into 
+    /// the claim trie
+    pub fn claim_store_factory(&self) -> ClaimStoreReadHandleFactory {
+        self.claim_store.factory() 
     }
 
     /// Inserts an account to current state tree.
@@ -139,7 +180,7 @@ impl VrrbDb {
         self.transaction_store.insert(txn)
     }
 
-    /// Adds multiplpe accounts to current state tree. Does not check if
+    /// Adds multiplpe transactions to current state tree. Does not check if
     /// accounts involved in the transaction actually exist.
     pub fn extend_transactions_unchecked(&mut self, transactions: Vec<Txn>) {
         self.transaction_store.extend(transactions);
@@ -151,11 +192,32 @@ impl VrrbDb {
         self.transaction_store.insert(txn)
     }
 
-    /// Adds multiplpe accounts to current state tree. Does not check if
+    /// Adds multiplpe transactions to current transaction tree. Does not check if
     /// accounts involved in the transaction actually exist.
     pub fn extend_transactions(&mut self, transactions: Vec<Txn>) {
         self.transaction_store.extend(transactions);
     }
+
+    /// Inserts a confirmed claim to the current claim tree. 
+    pub fn insert_claim_unchecked(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
+        self.claim_store.insert(node_id, claim)
+    }
+
+    /// Adds multiple claims to the current claim tree.  
+    pub fn extend_claims_unchecked(&mut self, claims: Vec<(NodeId, Claim)>) {
+        self.claim_store.extend(claims)
+    }
+
+    /// Inserts a confirmed claim into the claim tree. 
+    pub fn insert_claim(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
+        self.claim_store.insert(node_id, claim) 
+    }
+    
+    /// Inserts multiple claims into the current claim trie
+    pub fn extend_claims(&mut self, claims: Vec<(NodeId, Claim)>) {
+        self.claim_store.extend(claims)
+    }
+
 }
 
 impl Clone for VrrbDb {
@@ -163,6 +225,7 @@ impl Clone for VrrbDb {
         Self {
             state_store: self.state_store.clone(),
             transaction_store: self.transaction_store.clone(),
+            claim_store: self.claim_store.clone(),
         }
     }
 }
@@ -177,6 +240,7 @@ impl Display for VrrbDb {
             .into_iter()
             .map(|(digest, txn)| (digest.to_string(), txn))
             .collect::<HashMap<String, Txn>>();
+        let claim_entries = self.claim_store_factory().handle().entries();
 
         let out = json!({
             "state": {
@@ -186,6 +250,10 @@ impl Display for VrrbDb {
             "transactions": {
                 "count": transaction_entries.len(),
                 "entries": transaction_entries,
+            },
+            "claims": {
+                "count": claim_entries.len(),
+                "entries": claim_entries,
             },
         });
 

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -1,27 +1,37 @@
 use std::collections::HashMap;
 
-use primitives::Address;
+use primitives::{Address, NodeId};
 use vrrb_core::{
     account::Account,
     txn::{TransactionDigest, Txn},
+    claim::Claim,
 };
 
-use crate::{StateStoreReadHandleFactory, TransactionStoreReadHandleFactory};
+use crate::{
+    StateStoreReadHandleFactory, 
+    TransactionStoreReadHandleFactory, 
+    ClaimStoreReadHandleFactory
+};
 
 #[derive(Debug, Clone)]
 pub struct VrrbDbReadHandle {
     state_store_handle_factory: StateStoreReadHandleFactory,
     transaction_store_handle_factory: TransactionStoreReadHandleFactory,
+    claim_store_handle_factory: ClaimStoreReadHandleFactory,
 }
 
 impl VrrbDbReadHandle {
+
     pub fn new(
         state_store_handle_factory: StateStoreReadHandleFactory,
         transaction_store_handle_factory: TransactionStoreReadHandleFactory,
+        claim_store_handle_factory: ClaimStoreReadHandleFactory,
     ) -> Self {
+
         Self {
             state_store_handle_factory,
             transaction_store_handle_factory,
+            claim_store_handle_factory,
         }
     }
 
@@ -34,4 +44,9 @@ impl VrrbDbReadHandle {
     pub fn transaction_store_values(&self) -> HashMap<TransactionDigest, Txn> {
         self.transaction_store_handle_factory.handle().entries()
     }
+
+    pub fn claim_store_values(&self) -> HashMap<NodeId, Claim> {
+        self.claim_store_handle_factory.handle().entries()
+    }
 }
+

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -1,7 +1,8 @@
-use primitives::{Address, SecretKey};
+use primitives::{Address, SecretKey, NodeId};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secp256k1::{Message, Secp256k1};
 use vrrb_core::{
+    claim::Claim,
     keypair::Keypair,
     txn::{NewTxnArgs, Txn},
 };
@@ -66,4 +67,14 @@ pub fn generate_random_valid_transaction() -> Txn {
         validators: None,
         nonce: 10,
     })
+}
+
+pub fn generate_random_claim() -> Claim {
+    let keypair = Keypair::random(); 
+
+    Claim::new(
+        keypair.miner_kp.1.clone().to_string(), 
+        Address::new(keypair.miner_kp.1).to_string(), 
+        0
+    ) 
 }

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -75,6 +75,5 @@ pub fn generate_random_claim() -> Claim {
     Claim::new(
         keypair.miner_kp.1.clone().to_string(), 
         Address::new(keypair.miner_kp.1).to_string(), 
-        0
     ) 
 }

--- a/crates/storage/vrrbdb/tests/test_claim_store.rs
+++ b/crates/storage/vrrbdb/tests/test_claim_store.rs
@@ -1,0 +1,54 @@
+
+use vrrbdb::{VrrbDb, VrrbDbConfig};
+
+mod common;
+use common::generate_random_claim;
+use serial_test::serial;
+
+
+#[test]
+#[serial]
+fn claims_can_be_added() {
+    let mut db = VrrbDb::new(VrrbDbConfig::default());
+
+    let claim1 = generate_random_claim();
+    let claim2 = generate_random_claim();
+    let claim3 = generate_random_claim();
+    let claim4 = generate_random_claim();
+    let claim5 = generate_random_claim();
+
+    db.insert_claim(
+        claim1.public_key.clone(),
+        claim1
+    )
+    .unwrap();
+
+    db.insert_claim(
+        claim2.public_key.clone(),
+        claim2
+    )
+    .unwrap();
+
+    let entries = db.claim_store_factory().handle().entries();
+
+    assert_eq!(entries.len(), 2);
+
+    db.extend_claims(vec![
+        (
+            claim3.public_key.clone(),
+            claim3
+        ),
+        (
+            claim4.public_key.clone(),
+            claim4
+        ),
+        (
+            claim5.public_key.clone(),
+            claim5
+        ),
+    ]);
+
+    let entries = db.claim_store_factory().handle().entries();
+
+    assert_eq!(entries.len(), 5);
+}

--- a/crates/storage/vrrbdb/tests/test_transaction_store.rs
+++ b/crates/storage/vrrbdb/tests/test_transaction_store.rs
@@ -29,6 +29,7 @@ fn transactions_can_be_added() {
         state_store_path: None,
         transaction_store_path: None,
         event_store_path: None,
+        claim_store_path: None,
     });
 
     let txn1 = generate_random_valid_transaction();

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-secp256k1 = { version = "0.25.0", features = ["rand", "bitcoin-hashes"] }
-sha256 = "1.0.2"
-chrono = "0.4.23"
+secp256k1 = { workspace = true }
+sha2 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/utils/src/payload.rs
+++ b/crates/utils/src/payload.rs
@@ -1,9 +1,3 @@
-#![allow(unused_imports)]
-use secp256k1::{
-    hashes::{sha256 as s256, Hash},
-    Message,
-};
-
 #[macro_export]
 macro_rules! create_payload {
     ($($x:expr),*) => {{

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -33,12 +33,11 @@ pub struct NodeConfig {
 
     /// This is the address that the node will use to connect to the rendzevous
     /// server.
-    pub rendezvous_local_address: SocketAddr,
+    pub rendzevous_local_address: SocketAddr,
 
     /// This is the address that the node will use to connect to the rendzevous
     /// server.
     pub rendezvous_server_address: SocketAddr,
-
     /// The type of the node, used for custom impl's based on the type the
     /// capabilities may vary.
     //TODO: Change this to a generic that takes anything that implements the NodeAuth trait.
@@ -133,8 +132,8 @@ impl Default for NodeConfig {
                 .join("db"),
             raptorq_gossip_address: ipv4_localhost_with_random_port,
             udp_gossip_address: ipv4_localhost_with_random_port,
-            rendezvous_local_address: ipv4_localhost_with_random_port,
-            rendezvous_server_address: ipv4_localhost_with_random_port,
+            rendzevous_local_address: ipv4_localhost_with_random_port,
+            rendzevous_server_address: ipv4_localhost_with_random_port,
             node_type: NodeType::Full,
             bootstrap_node_addresses: vec![],
             http_api_address: ipv4_localhost_with_random_port,

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -31,11 +31,11 @@ pub struct NodeConfig {
     /// Address the node listens for network events through udp2p
     pub udp_gossip_address: SocketAddr,
 
-    /// This is the address that the node will use to connect to the rendzevous
+    /// This is the address that the node will use to connect to the rendezvous
     /// server.
-    pub rendzevous_local_address: SocketAddr,
+    pub rendezvous_local_address: SocketAddr,
 
-    /// This is the address that the node will use to connect to the rendzevous
+    /// This is the address that the node will use to connect to the rendezvous
     /// server.
     pub rendezvous_server_address: SocketAddr,
     /// The type of the node, used for custom impl's based on the type the
@@ -132,8 +132,8 @@ impl Default for NodeConfig {
                 .join("db"),
             raptorq_gossip_address: ipv4_localhost_with_random_port,
             udp_gossip_address: ipv4_localhost_with_random_port,
-            rendzevous_local_address: ipv4_localhost_with_random_port,
-            rendzevous_server_address: ipv4_localhost_with_random_port,
+            rendezvous_local_address: ipv4_localhost_with_random_port,
+            rendezvous_server_address: ipv4_localhost_with_random_port,
             node_type: NodeType::Full,
             bootstrap_node_addresses: vec![],
             http_api_address: ipv4_localhost_with_random_port,

--- a/crates/vrrb_core/Cargo.toml
+++ b/crates/vrrb_core/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = { workspace = true }
 theater = { workspace = true }
 utils = { workspace = true }
 cuckoofilter = { workspace = true }
+ethereum-types = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -6,9 +6,8 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use sha2::{Sha256, Digest};
 use ethereum_types::U256;
-use sha256::digest;
 
-use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable, keypair::Keypair};
+use crate::{ownable::Ownable, verifiable::Verifiable, keypair::Keypair};
 
 /// A custom error type for invalid claims that are used/attempted to be used
 /// in the mining of a block.
@@ -51,6 +50,10 @@ impl Claim {
             // collects threshold of votes on its validity
             eligible: true,
         }
+    }
+
+    pub fn get_ballot_info(&self) -> (U256, Claim) {
+        (self.hash, self.clone())
     }
 
     /// Uses XOR of the ClaimHash as a U256 against a block seed of u64

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -161,12 +161,13 @@ impl Verifiable for Claim {
         true
     }
 
-    #[allow(unused_variables)]
     fn valid(
         &self,
         item: &Self::Item,
         dependancies: &Self::Dependencies,
     ) -> Result<bool, InvalidClaimError> {
+        let _ = item;
+        let _ = dependancies;
         Ok(true)
     }
 }

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -1,11 +1,13 @@
+use primitives::Address;
 use serde::{Deserialize, Serialize};
 /// a Module for creating, maintaining, and using a claim in the fair,
 /// computationally inexpensive, collission proof, fully decentralized, fully
 /// permissionless Proof of Claim Miner Election algorithm
 use serde_json;
-use sha256::digest;
+use sha2::{Sha256, Digest};
+use ethereum_types::U256;
 
-use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable};
+use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable, keypair::Keypair};
 
 /// A custom error type for invalid claims that are used/attempted to be used
 /// in the mining of a block.
@@ -22,7 +24,7 @@ pub struct InvalidClaimError {
 pub struct Claim {
     pub public_key: String,
     pub address: String,
-    pub hash: String,
+    pub hash: U256,
     pub nonce: u128,
     pub eligible: bool,
 }
@@ -33,19 +35,15 @@ impl Claim {
     pub fn new(public_key: String, address: String, claim_nonce: u128) -> Claim {
         // Calculate the number of times the pubkey should be hashed to generate the
         // claim hash
-        let iters = if let Some(n) = claim_nonce.checked_mul(10) {
-            n
-        } else {
-            claim_nonce
-        };
-
-        let mut hash = public_key.clone();
         // sequentially hash the public key the correct number of times
         // for the given nonce.
-        (0..iters).for_each(|_| {
-            hash = digest(hash.as_bytes());
+        let mut hasher = Sha256::new();
+        (0..claim_nonce).for_each(|_| {
+            hasher.update(public_key.clone());
         });
 
+        let result = hasher.finalize();
+        let hash = U256::from_big_endian(&result[..]);
         Claim {
             public_key,
             address,
@@ -55,16 +53,28 @@ impl Claim {
         }
     }
 
+    /// Uses XOR of the ClaimHash as a U256 against a block seed of u64
+    /// U256 is represented as a [u64; 4] so we XOR each of the 4
+    /// u64 values in the U256 against the block seed.
+    pub fn get_election_result(&self, block_seed: u64) -> U256 {
+        let mut xor_val = [0u64; 4];
+        self.hash.0.iter().enumerate().for_each(|(idx, x)| {
+           xor_val[idx] = x ^ block_seed; 
+        });
+
+        U256(xor_val)
+    }
+
     /// Calculates the claims pointer sum
     // TODO: Rename to `get_pointer_sum` to better represent the purpose of the
     // function. This can be made significantly faster (if necessary to scale
     // network) by concurrently calculating the index position of each matched
     // character, and summing the total at the end after every match position
     // has been discovered, or returning None if we can't match a character.
+    #[deprecated(note = "Please use get_election_result")]
     pub fn get_pointer(&self, block_seed: u128) -> Option<u128> {
+        
         // get the hexadecimal format of the block seed
-        // TODO: Make the block seed hexadecimal to begin with in the `Block` itself
-        // No reason for miners to have to do this conversion.
         let block_seed_hex = format!("{block_seed:x}");
         // Get the length of the hexadecimal representation of the block seed
         // for later use
@@ -73,10 +83,14 @@ impl Claim {
         let mut pointers = vec![];
         // iterate through (and enumerate for index position) the characters
         // of the block seed.
+        let mut hash_bytes = [0u8; 32];
+        self.hash.to_big_endian(&mut hash_bytes);
+        let hash_string = hex::encode(hash_bytes);
+
         block_seed_hex.chars().enumerate().for_each(|(idx, c)| {
             // Check if the character is in the claim hash, and save the index position into
             // a variable `n`.
-            let res = self.hash.find(c);
+            let res = hash_string.find(c);
             if let Some(n) = res {
                 // convert `n` to a u128 and calculate an integer overflow safe
                 // exponential of the `n` to the power of idx
@@ -182,5 +196,16 @@ impl Nonceable for Claim {
         });
 
         self.hash = hash;
+    }
+}
+
+
+impl From<Keypair> for Claim {
+    fn from(item: Keypair) -> Claim {
+        Claim::new(
+           item.miner_kp.1.to_string(),
+           Address::new(item.miner_kp.1).to_string(),
+           0
+        )
     }
 }

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -59,13 +59,13 @@ impl Claim {
     /// Uses XOR of the ClaimHash as a U256 against a block seed of u64
     /// U256 is represented as a [u64; 4] so we XOR each of the 4
     /// u64 values in the U256 against the block seed.
-    pub fn get_election_result(&self, block_seed: u64) -> U256 {
+    pub fn get_election_result(&self, block_seed: u64) -> (U256, Claim) {
         let mut xor_val = [0u64; 4];
         self.hash.0.iter().enumerate().for_each(|(idx, x)| {
            xor_val[idx] = x ^ block_seed; 
         });
 
-        U256(xor_val)
+        (U256(xor_val), self.clone())
     }
 
     /// Calculates the claims pointer sum

--- a/crates/vrrb_core/src/helpers.rs
+++ b/crates/vrrb_core/src/helpers.rs
@@ -5,7 +5,7 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use ritelinked::LinkedHashMap;
 use secp256k1::generate_keypair;
 
-use crate::{txn::Txn, Error};
+use crate::{txn::{Txn, TransactionDigest}, Error};
 
 pub fn gen_hex_encoded_string<T: AsRef<[u8]>>(data: T) -> String {
     hex::encode(data)
@@ -32,7 +32,7 @@ macro_rules! is_enum_variant {
     };
 }
 
-pub fn size_of_txn_list(txns: &LinkedHashMap<String, Txn>) -> usize {
+pub fn size_of_txn_list(txns: &LinkedHashMap<TransactionDigest, Txn>) -> usize {
     txns.iter()
         .map(|(_, set)| set)
         .map(|txn| std::mem::size_of_val(&txn))

--- a/crates/vrrb_core/src/ledger.rs
+++ b/crates/vrrb_core/src/ledger.rs
@@ -1,10 +1,10 @@
 use ritelinked::LinkedHashMap;
 use serde::{Deserialize, Serialize};
 
-use crate::{claim::Claim, nonceable::Nonceable, ownable::Ownable};
+use crate::{claim::Claim, ownable::Ownable};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Ledger<C: Clone + Ownable + Nonceable + Serialize> {
+pub struct Ledger<C: Clone + Ownable + Serialize> {
     pub credits: LinkedHashMap<String, u128>,
     pub debits: LinkedHashMap<String, u128>,
     pub claims: LinkedHashMap<String, C>,


### PR DESCRIPTION
This PR implements the ElectionModule struct,

- Provides Election Module struct with new method for 3 different configurations
- Provides ElectionModuleConfig struct to pass in data common to all 3 different configurations
- Provides unit structs to use as generic types in the ElectionModule struct fields, and a couple of marker traits that restrict the generic fields to the specific unit structs created.
- Implements of the Handler trait 
- This module will receive one type of event (Election) and will check the election_type and if the module in question is responsible for that election type will execute on the election or will ignore it.
- The module has a sender to send out ElectionResult event to a different module which will then conduce the required actions upon its reception.
- This module is simply responsible for running Proof of Claim elections and returning results to the module responsible for the result of a given election type

- This PR also contains a very significant overhaul of the mining and block building process, it integrates an Atomic, Read/Write Locked `BullDAG` into the `Miner` struct.
- It implements two new traits on the `Miner` Struct. 

This PR should be carefully reviewed, both due to the size, and the importance of it. It contains significant amount of fixes to issues that existed.