### PR TITLE
Scaffold Election Module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,6 @@ laminar = "0.5.0"
 futures = { version = "0.3.24", features = ["thread-pool"] }
 qp2p = "0.30.0"
 
-
 [dev-dependencies]
 cuckoofilter.workspace = true
 reqwest.workspace = true

--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -27,3 +27,4 @@ bulldag = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
+ethereum-types = { workspace = true }

--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -26,3 +26,4 @@ vrrb_vrf = { workspace = true }
 bulldag = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
+tokio = { workspace = true }

--- a/crates/block/src/convergence_block.rs
+++ b/crates/block/src/convergence_block.rs
@@ -32,7 +32,7 @@ use vrrb_core::{
     accountable::Accountable,
     claim::Claim,
     keypair::KeyPair,
-    txn::Txn,
+    txn::{TransactionDigest, Txn},
     verifiable::Verifiable,
 };
 
@@ -53,7 +53,6 @@ use crate::{
     GenesisBlock,
     ProposalBlock,
     RefHash,
-    TxnId,
 };
 
 pub struct MineArgs<'a> {
@@ -88,7 +87,7 @@ impl ConvergenceBlock {
         self.certificate = Some(cert);
     }
 
-    pub fn txn_id_set(&self) -> LinkedHashSet<&TxnId> {
+    pub fn txn_id_set(&self) -> LinkedHashSet<&TransactionDigest> {
         self.txns.iter().flat_map(|(_, set)| set).collect()
     }
 }

--- a/crates/block/src/proposal_block.rs
+++ b/crates/block/src/proposal_block.rs
@@ -7,9 +7,9 @@ use secp256k1::{
 use serde::{Deserialize, Serialize};
 use sha256::digest;
 use utils::{create_payload, hash_data};
-use vrrb_core::claim::Claim;
+use vrrb_core::{claim::Claim, txn::TransactionDigest};
 
-use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnId, TxnList};
+use crate::{BlockHash, ClaimList, ConvergenceBlock, RefHash, TxnList};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[repr(C)]
@@ -55,24 +55,29 @@ impl ProposalBlock {
     }
 
     pub fn remove_confirmed_txs(&mut self, prev_blocks: Vec<ConvergenceBlock>) {
-        let sets: Vec<LinkedHashSet<&TxnId>> =
+        let sets: Vec<LinkedHashSet<&TransactionDigest>> =
             { prev_blocks.iter().map(|block| block.txn_id_set()).collect() };
 
-        let prev_block_set: LinkedHashSet<&TxnId> = { sets.into_iter().flatten().collect() };
+        let prev_block_set: LinkedHashSet<&TransactionDigest> =
+            { sets.into_iter().flatten().collect() };
 
         let curr_txns = self.txns.clone();
 
-        let curr_set: LinkedHashSet<&TxnId> = { curr_txns.iter().map(|(id, _)| id).collect() };
+        let curr_set: LinkedHashSet<&TransactionDigest> =
+            { curr_txns.iter().map(|(id, _)| id).collect() };
 
-        let prev_confirmed: LinkedHashSet<TxnId> = {
+        let prev_confirmed: LinkedHashSet<TransactionDigest> = {
             let intersection = curr_set.intersection(&prev_block_set);
-            intersection.into_iter().map(|id| id.to_string()).collect()
+            intersection
+                .into_iter()
+                .map(|id| id.to_owned().to_owned())
+                .collect()
         };
 
         self.txns.retain(|id, _| prev_confirmed.contains(id));
     }
 
-    pub fn txn_id_set(&self) -> LinkedHashSet<TxnId> {
+    pub fn txn_id_set(&self) -> LinkedHashSet<TransactionDigest> {
         self.txns.iter().map(|(id, _)| id.clone()).collect()
     }
 }

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -35,9 +35,11 @@ use vrrb_core::{
     accountable::Accountable,
     claim::Claim,
     keypair::KeyPair,
-    txn::Txn,
+    txn::{Txn, TransactionDigest},
     verifiable::Verifiable,
 };
+use tokio::task::JoinHandle;
+use std::error::Error;
 
 #[cfg(mainnet)]
 use crate::genesis;
@@ -53,18 +55,18 @@ pub const EPOCH_BLOCK: u32 = 30_000_000;
 
 pub type CurrentUtility = i128;
 pub type NextEpochAdjustment = i128;
-pub type TxnId = String;
 pub type ClaimHash = String;
 pub type RefHash = String;
-pub type TxnList = LinkedHashMap<TxnId, Txn>;
+pub type TxnList = LinkedHashMap<TransactionDigest, Txn>;
 pub type ClaimList = LinkedHashMap<ClaimHash, Claim>;
-pub type ConsolidatedTxns = LinkedHashMap<RefHash, LinkedHashSet<TxnId>>;
+pub type ConsolidatedTxns = LinkedHashMap<RefHash, LinkedHashSet<TransactionDigest>>;
 pub type ConsolidatedClaims = LinkedHashMap<RefHash, LinkedHashSet<ClaimHash>>;
 pub type BlockHash = String;
 pub type QuorumId = String;
 pub type QuorumPubkey = String;
 pub type QuorumPubkeys = LinkedHashMap<QuorumId, QuorumPubkey>;
-pub type ConflictList = HashMap<TxnId, Conflict>;
+pub type ConflictList = HashMap<TransactionDigest, Conflict>;
+pub type ResolvedConflicts = Vec<JoinHandle<Result<Conflict, Box<dyn Error>>>>; 
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[repr(C)]
@@ -78,7 +80,7 @@ pub struct Certificate {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[repr(C)]
 pub struct Conflict {
-    pub txn_id: TxnId,
+    pub txn_id: TransactionDigest,
     pub proposers: HashSet<(Claim, RefHash)>,
     pub winner: Option<RefHash>,
 }

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -77,7 +77,7 @@ pub struct Certificate {
     pub next_root_hash: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[repr(C)]
 pub struct Conflict {
     pub txn_id: TransactionDigest,

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -4,6 +4,7 @@
 use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
+    error::Error,
     fmt,
 };
 
@@ -30,16 +31,15 @@ use secp256k1::{
 };
 use serde::{Deserialize, Serialize};
 use sha256::digest;
+use tokio::task::JoinHandle;
 use utils::{create_payload, hash_data};
 use vrrb_core::{
     accountable::Accountable,
     claim::Claim,
     keypair::KeyPair,
-    txn::{Txn, TransactionDigest},
+    txn::{TransactionDigest, Txn},
     verifiable::Verifiable,
 };
-use tokio::task::JoinHandle;
-use std::error::Error;
 
 #[cfg(mainnet)]
 use crate::genesis;
@@ -66,7 +66,7 @@ pub type QuorumId = String;
 pub type QuorumPubkey = String;
 pub type QuorumPubkeys = LinkedHashMap<QuorumId, QuorumPubkey>;
 pub type ConflictList = HashMap<TransactionDigest, Conflict>;
-pub type ResolvedConflicts = Vec<JoinHandle<Result<Conflict, Box<dyn Error>>>>; 
+pub type ResolvedConflicts = Vec<JoinHandle<Result<Conflict, Box<dyn Error>>>>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[repr(C)]

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -111,6 +111,7 @@ impl From<RunOpts> for NodeConfig {
             raptorq_gossip_address: opts.raptorq_gossip_address,
             udp_gossip_address: opts.udp_gossip_address,
             rendezvous_local_address: opts.rendezvous_local_address,
+            rendezvous_server_address: opts.rendezvous_server_address,
             http_api_address: opts.http_api_address,
             http_api_title,
             http_api_version: opts.http_api_version,
@@ -128,7 +129,6 @@ impl From<RunOpts> for NodeConfig {
             // a hack, but it works for now.
             keypair: default_node_config.keypair,
             disable_networking: opts.disable_networking,
-            rendezvous_server_address: opts.rendezvous_server_address,
         }
     }
 }

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -81,10 +81,10 @@ pub struct RunOpts {
     pub disable_networking: bool,
 
     #[clap(long, value_parser ,default_value=DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
-    pub rendzevous_local_address: SocketAddr,
+    pub rendezvous_local_address: SocketAddr,
 
     #[clap(long, value_parser, default_value = DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
-    pub rendzevous_server_address: SocketAddr,
+    pub rendezvous_server_address: SocketAddr,
 }
 
 impl From<RunOpts> for NodeConfig {
@@ -110,7 +110,7 @@ impl From<RunOpts> for NodeConfig {
             node_type,
             raptorq_gossip_address: opts.raptorq_gossip_address,
             udp_gossip_address: opts.udp_gossip_address,
-            rendzevous_local_address: opts.rendzevous_local_address,
+            rendezvous_local_address: opts.rendezvous_local_address,
             http_api_address: opts.http_api_address,
             http_api_title,
             http_api_version: opts.http_api_version,
@@ -128,7 +128,7 @@ impl From<RunOpts> for NodeConfig {
             // a hack, but it works for now.
             keypair: default_node_config.keypair,
             disable_networking: opts.disable_networking,
-            rendzevous_server_address: opts.rendzevous_server_address,
+            rendezvous_server_address: opts.rendezvous_server_address,
         }
     }
 }
@@ -155,8 +155,8 @@ impl Default for RunOpts {
             http_api_title: Default::default(),
             http_api_version: Default::default(),
             disable_networking: Default::default(),
-            rendzevous_local_address: ipv4_localhost_with_random_port,
-            rendzevous_server_address: ipv4_localhost_with_random_port,
+            rendezvous_local_address: ipv4_localhost_with_random_port,
+            rendezvous_server_address: ipv4_localhost_with_random_port,
         }
     }
 }
@@ -240,8 +240,8 @@ impl RunOpts {
             http_api_title,
             http_api_version,
             disable_networking: false,
-            rendzevous_local_address: other.rendzevous_local_address,
-            rendzevous_server_address: other.rendzevous_server_address,
+            rendezvous_local_address: other.rendezvous_local_address,
+            rendezvous_server_address: other.rendezvous_server_address,
         }
     }
 }

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -81,10 +81,10 @@ pub struct RunOpts {
     pub disable_networking: bool,
 
     #[clap(long, value_parser ,default_value=DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
-    pub rendezvous_local_address: SocketAddr,
+    pub rendzevous_local_address: SocketAddr,
 
     #[clap(long, value_parser, default_value = DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
-    pub rendezvous_server_address: SocketAddr,
+    pub rendzevous_server_address: SocketAddr,
 }
 
 impl From<RunOpts> for NodeConfig {
@@ -110,8 +110,7 @@ impl From<RunOpts> for NodeConfig {
             node_type,
             raptorq_gossip_address: opts.raptorq_gossip_address,
             udp_gossip_address: opts.udp_gossip_address,
-            rendezvous_local_address: opts.rendezvous_local_address,
-            rendezvous_server_address: opts.rendezvous_server_address,
+            rendzevous_local_address: opts.rendzevous_local_address,
             http_api_address: opts.http_api_address,
             http_api_title,
             http_api_version: opts.http_api_version,
@@ -129,6 +128,7 @@ impl From<RunOpts> for NodeConfig {
             // a hack, but it works for now.
             keypair: default_node_config.keypair,
             disable_networking: opts.disable_networking,
+            rendzevous_server_address: opts.rendzevous_server_address,
         }
     }
 }
@@ -155,8 +155,8 @@ impl Default for RunOpts {
             http_api_title: Default::default(),
             http_api_version: Default::default(),
             disable_networking: Default::default(),
-            rendezvous_local_address: ipv4_localhost_with_random_port,
-            rendezvous_server_address: ipv4_localhost_with_random_port,
+            rendzevous_local_address: ipv4_localhost_with_random_port,
+            rendzevous_server_address: ipv4_localhost_with_random_port,
         }
     }
 }
@@ -240,8 +240,8 @@ impl RunOpts {
             http_api_title,
             http_api_version,
             disable_networking: false,
-            rendezvous_local_address: other.rendezvous_local_address,
-            rendezvous_server_address: other.rendezvous_server_address,
+            rendzevous_local_address: other.rendzevous_local_address,
+            rendzevous_server_address: other.rendzevous_server_address,
         }
     }
 }

--- a/crates/consensus/dkg_engine/src/types/mod.rs
+++ b/crates/consensus/dkg_engine/src/types/mod.rs
@@ -163,7 +163,7 @@ impl DkgEngine {
     }
 
     /// It clears the state of the DKG. it happens during change of Epoch
-    pub fn clear_dkg_state(&mut self) {
+    pub fn clear_state(&mut self) {
         self.dkg_state.part_message_store.clear();
         self.dkg_state.ack_message_store.clear();
         self.dkg_state.sync_key_gen = None;

--- a/crates/consensus/dkg_engine/src/types/mod.rs
+++ b/crates/consensus/dkg_engine/src/types/mod.rs
@@ -163,7 +163,7 @@ impl DkgEngine {
     }
 
     /// It clears the state of the DKG. it happens during change of Epoch
-    pub fn clear_state(&mut self) {
+    pub fn clear_dkg_state(&mut self) {
         self.dkg_state.part_message_store.clear();
         self.dkg_state.ack_message_store.clear();
         self.dkg_state.sync_key_gen = None;

--- a/crates/consensus/quorum/Cargo.toml
+++ b/crates/consensus/quorum/Cargo.toml
@@ -12,7 +12,6 @@ vrrb_vrf = { workspace = true }
 rand_chacha = { workspace = true }
 format-bytes = { workspace = true }
 thread_local = { workspace = true }
-node = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true }
 sha256 = { workspace = true }

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -32,7 +32,6 @@ async-trait = { workspace = true }
 theater = { workspace = true }
 utils = { workspace = true }
 cuckoofilter = { workspace = true }
-quorum = { workspace = true }
 ethereum-types = { workspace = true }
 
 [dev-dependencies]

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -32,6 +32,8 @@ async-trait = { workspace = true }
 theater = { workspace = true }
 utils = { workspace = true }
 cuckoofilter = { workspace = true }
+quorum = { workspace = true }
+ethereum-types = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,12 +1,11 @@
 use std::{collections::HashMap, net::SocketAddr};
 
-use block::{convergence_block::ConvergenceBlock, Conflict, ResolvedConflicts};
+use block::Conflict;
 use ethereum_types::U256;
 use primitives::{
     Address,
     ByteVec,
     FarmerQuorumThreshold,
-    HarvesterQuorumThreshold,
     NodeId,
     NodeIdx,
     NodeType,
@@ -14,23 +13,14 @@ use primitives::{
     QuorumPublicKey,
     QuorumType,
     RawSignature,
-    TxHashString,
 };
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
-use tokio::{
-    sync::{
-        broadcast::{self, Receiver, Sender},
-        mpsc::UnboundedSender,
-    },
-    task::JoinHandle,
+use tokio::sync::{
+    broadcast::{self, Receiver, Sender},
+    mpsc::UnboundedSender,
 };
-use vrrb_core::{
-    account::Account,
-    claim::Claim,
-    keypair::Keypair,
-    txn::{TransactionDigest, Txn},
-};
+use vrrb_core::txn::{TransactionDigest, Txn};
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,19 +1,19 @@
 use std::{collections::HashMap, net::SocketAddr};
 
 use block::{convergence_block::ConvergenceBlock, Conflict, ResolvedConflicts};
+use ethereum_types::U256;
 use primitives::{
     Address,
     ByteVec,
     FarmerQuorumThreshold,
     HarvesterQuorumThreshold,
+    NodeId,
     NodeIdx,
     NodeType,
     PeerId,
-    NodeId,
     QuorumPublicKey,
     QuorumType,
     RawSignature,
-    TransactionDigest,
     TxHashString,
 };
 use serde::{Deserialize, Serialize};
@@ -26,9 +26,14 @@ use tokio::{
     task::JoinHandle,
 };
 use vrrb_core::{
-    account::Account, txn::{TransactionDigest, Txn},
+    account::Account,
+    claim::Claim,
+    keypair::Keypair,
+    txn::{TransactionDigest, Txn},
 };
+
 pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("io error: {0}")]
@@ -40,6 +45,7 @@ pub enum Error {
     #[error("{0}")]
     Other(String),
 }
+
 pub type Subscriber = UnboundedSender<Event>;
 pub type Publisher = UnboundedSender<(Topic, Event)>;
 pub type AccountBytes = Vec<u8>;
@@ -204,60 +210,6 @@ pub enum Event {
     QuorumElection(HeaderBytes),
     ConflictResolution(ConflictBytes, HeaderBytes),
     ResolvedConflict(Conflict),
-    // SendTxn(u32, String, u128), // address number, receiver address, amount
-    // ProcessTxnValidator(Vec<u8>),
-    // PendingBlock(Vec<u8>, String),
-    // InvalidBlock(Vec<u8>),
-    // ProcessClaim(Vec<u8>),
-    // CheckStateUpdateStatus((u128, Vec<u8>, u128)),
-    // StateUpdateCompleted(Vec<u8>),
-    // StoreStateDbChunk(Vec<u8>, Vec<u8>, u32, u32),
-    // SendState(String, u128),
-    // SendMessage(SocketAddr, Message),
-    // GetBalance(u32),
-    // SendGenesis(String),
-    // SendStateComponents(String, Vec<u8>, String),
-    // GetStateComponents(String, Vec<u8>, String),
-    // RequestedComponents(String, Vec<u8>, String, String),
-    // StoreStateComponents(Vec<u8>, ComponentTypes),
-    // StoreChild(Vec<u8>),
-    // StoreParent(Vec<u8>),
-    // StoreGenesis(Vec<u8>),
-    // StoreLedger(Vec<u8>),
-    // StoreNetworkState(Vec<u8>),
-    // StateUpdateComponents(Vec<u8>, ComponentTypes),
-    // UpdateAppMiner(Vec<u8>),
-    // UpdateAppBlockchain(Vec<u8>),
-    // UpdateAppMessageCache(Vec<u8>),
-    // UpdateAppWallet(Vec<u8>),
-    // Publish(Vec<u8>),
-    // Gossip(Vec<u8>),
-    // AddNewPeer(String, String),
-    // AddKnownPeers(Vec<u8>),
-    // AddExplicitPeer(String, String),
-    // ProcessPacket((Packet, SocketAddr)),
-    // Bootstrap(String, String),
-    // SendPing(String),
-    // ReturnPong(Vec<u8>, String),
-    // InitHandshake(String),
-    // ReciprocateHandshake(String, String, String),
-    // CompleteHandshake(String, String, String),
-    // ProcessAck(String, u32, String),
-    // CleanInbox(String),
-    // StartMiner,
-    // GetHeight,
-    // MineBlock,
-    // MineGenesis,
-    // StopMine,
-    // GetState,
-    // ProcessBacklog,
-    // SendAddress,
-    // NonceUp,
-    // InitDKG,
-    // SendPartMessage(Vec<u8>),
-    // SendAckMessage(Vec<u8>),
-    // PublicKeySetSync,
->>>>>>> a1ff216 (scaffold integration with mining module)
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
 use tokio::{
     sync::{
-        broadcast::{self, Sender},
-        mpsc::{UnboundedReceiver, UnboundedSender},
+        broadcast::{self, Receiver, Sender},
+        mpsc::UnboundedSender,
     },
     task::JoinHandle,
 };

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -81,14 +81,12 @@ pub struct Vote {
     /// Partial Signature
     pub signature: RawSignature,
     pub txn: Txn,
-    pub execution_result: Option<String>,
     pub quorum_public_key: Vec<u8>,
     pub quorum_threshold: usize,
+
     // May want to serialize this as a vector of bytes
     pub execution_result: Option<String>,
 }
-
-pub type SerializedConvergenceBlock = ByteVec;
 
 #[derive(Debug, Deserialize, Serialize, Hash, Clone, PartialEq, Eq)]
 pub struct BlockVote {
@@ -103,16 +101,6 @@ pub struct BlockVote {
 }
 
 pub type SerializedConvergenceBlock = ByteVec;
-
-#[derive(Debug, Deserialize, Serialize, Hash, Clone, PartialEq, Eq)]
-pub struct BlockVote {
-    pub harvester_id: Vec<u8>,
-    pub harvester_node_id: NodeIdx,
-    pub signature: RawSignature,
-    pub convergence_block: SerializedConvergenceBlock,
-    pub quorum_public_key: Vec<u8>,
-    pub quorum_threshold: usize,
-}
 
 #[derive(Debug, Deserialize, Serialize, Hash, Clone, PartialEq, Eq)]
 pub struct VoteReceipt {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -18,9 +18,9 @@ use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
 use tokio::sync::{
     broadcast::{self, Receiver, Sender},
-    mpsc::UnboundedSender,
+    mpsc::{UnboundedSender, UnboundedReceiver},
 };
-use vrrb_core::txn::{TransactionDigest, Txn};
+use vrrb_core::{txn::{TransactionDigest, Txn}, claim::Claim};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -184,10 +184,12 @@ pub enum Event {
     UpdatedAccount(AccountBytes),
     MinerElection(HeaderBytes),
     // Should we make this the ClaimHash instead of the NodeId
-    ElectedMiner((U256, NodeId)),
+    ElectedMiner((U256, Claim)),
     QuorumElection(HeaderBytes),
     ConflictResolution(ConflictBytes, HeaderBytes),
     ResolvedConflict(Conflict),
+    EmptyPeerSync,
+    PeerSyncFailed(Vec<SocketAddr>),
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, net::SocketAddr};
 
-use block::convergence_block::ConvergenceBlock;
+use block::{convergence_block::ConvergenceBlock, Conflict, ResolvedConflicts};
 use primitives::{
     Address,
     ByteVec,
@@ -9,21 +9,26 @@ use primitives::{
     NodeIdx,
     NodeType,
     PeerId,
+    NodeId,
     QuorumPublicKey,
     QuorumType,
     RawSignature,
+    TransactionDigest,
     TxHashString,
 };
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
-use tokio::sync::{
-    broadcast::{self, Receiver, Sender},
-    mpsc::{UnboundedReceiver, UnboundedSender},
+use tokio::{
+    sync::{
+        broadcast::{self, Sender},
+        mpsc::{UnboundedReceiver, UnboundedSender},
+    },
+    task::JoinHandle,
 };
-use vrrb_core::txn::{TransactionDigest, Txn};
-
+use vrrb_core::{
+    account::Account, txn::{TransactionDigest, Txn},
+};
 pub type Result<T> = std::result::Result<T, Error>;
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("io error: {0}")]
@@ -35,10 +40,12 @@ pub enum Error {
     #[error("{0}")]
     Other(String),
 }
-
 pub type Subscriber = UnboundedSender<Event>;
 pub type Publisher = UnboundedSender<(Topic, Event)>;
 pub type AccountBytes = Vec<u8>;
+pub type BlockBytes = Vec<u8>;
+pub type HeaderBytes = Vec<u8>;
+pub type ConflictBytes = Vec<u8>;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerData {
@@ -49,7 +56,7 @@ pub struct PeerData {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct SyncPeerData {
-    pub address: SocketAddr,
+    pub address: String,
     pub raptor_udp_port: u16,
     pub quic_port: u16,
     pub node_type: NodeType,
@@ -68,6 +75,21 @@ pub struct Vote {
     /// Partial Signature
     pub signature: RawSignature,
     pub txn: Txn,
+    pub execution_result: Option<String>,
+    pub quorum_public_key: Vec<u8>,
+    pub quorum_threshold: usize,
+    // May want to serialize this as a vector of bytes
+    pub execution_result: Option<String>,
+}
+
+pub type SerializedConvergenceBlock = ByteVec;
+
+#[derive(Debug, Deserialize, Serialize, Hash, Clone, PartialEq, Eq)]
+pub struct BlockVote {
+    pub harvester_id: Vec<u8>,
+    pub harvester_node_id: NodeIdx,
+    pub signature: RawSignature,
+    pub convergence_block: SerializedConvergenceBlock,
     pub quorum_public_key: Vec<u8>,
     pub quorum_threshold: usize,
     // May want to serialize this as a vector of bytes
@@ -131,8 +153,6 @@ pub enum Event {
     SlashClaims(Vec<String>),
     CheckAbandoned,
     SyncPeers(Vec<SyncPeerData>),
-    EmptyPeerSync,
-    PeerSyncFailed(Vec<SocketAddr>),
     PeerRequestedStateSync(PeerData),
 
     //Event to tell Farmer node to sign the Transaction
@@ -178,6 +198,66 @@ pub enum Event {
 
     AccountUpdateRequested((Address, AccountBytes)),
     UpdatedAccount(AccountBytes),
+    MinerElection(HeaderBytes),
+    // Should we make this the ClaimHash instead of the NodeId
+    ElectedMiner((U256, NodeId)),
+    QuorumElection(HeaderBytes),
+    ConflictResolution(ConflictBytes, HeaderBytes),
+    ResolvedConflict(Conflict),
+    // SendTxn(u32, String, u128), // address number, receiver address, amount
+    // ProcessTxnValidator(Vec<u8>),
+    // PendingBlock(Vec<u8>, String),
+    // InvalidBlock(Vec<u8>),
+    // ProcessClaim(Vec<u8>),
+    // CheckStateUpdateStatus((u128, Vec<u8>, u128)),
+    // StateUpdateCompleted(Vec<u8>),
+    // StoreStateDbChunk(Vec<u8>, Vec<u8>, u32, u32),
+    // SendState(String, u128),
+    // SendMessage(SocketAddr, Message),
+    // GetBalance(u32),
+    // SendGenesis(String),
+    // SendStateComponents(String, Vec<u8>, String),
+    // GetStateComponents(String, Vec<u8>, String),
+    // RequestedComponents(String, Vec<u8>, String, String),
+    // StoreStateComponents(Vec<u8>, ComponentTypes),
+    // StoreChild(Vec<u8>),
+    // StoreParent(Vec<u8>),
+    // StoreGenesis(Vec<u8>),
+    // StoreLedger(Vec<u8>),
+    // StoreNetworkState(Vec<u8>),
+    // StateUpdateComponents(Vec<u8>, ComponentTypes),
+    // UpdateAppMiner(Vec<u8>),
+    // UpdateAppBlockchain(Vec<u8>),
+    // UpdateAppMessageCache(Vec<u8>),
+    // UpdateAppWallet(Vec<u8>),
+    // Publish(Vec<u8>),
+    // Gossip(Vec<u8>),
+    // AddNewPeer(String, String),
+    // AddKnownPeers(Vec<u8>),
+    // AddExplicitPeer(String, String),
+    // ProcessPacket((Packet, SocketAddr)),
+    // Bootstrap(String, String),
+    // SendPing(String),
+    // ReturnPong(Vec<u8>, String),
+    // InitHandshake(String),
+    // ReciprocateHandshake(String, String, String),
+    // CompleteHandshake(String, String, String),
+    // ProcessAck(String, u32, String),
+    // CleanInbox(String),
+    // StartMiner,
+    // GetHeight,
+    // MineBlock,
+    // MineGenesis,
+    // StopMine,
+    // GetState,
+    // ProcessBacklog,
+    // SendAddress,
+    // NonceUp,
+    // InitDKG,
+    // SendPartMessage(Vec<u8>),
+    // SendAckMessage(Vec<u8>),
+    // PublicKeySetSync,
+>>>>>>> a1ff216 (scaffold integration with mining module)
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -62,7 +62,7 @@ pub struct PeerData {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct SyncPeerData {
-    pub address: String,
+    pub address: SocketAddr,
     pub raptor_udp_port: u16,
     pub quic_port: u16,
     pub node_type: NodeType,

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -191,21 +191,7 @@ impl LeftRightMempool {
 
     pub fn insert(&mut self, txn: Txn) -> Result<usize> {
         let txn_record = TxnRecord::new(txn);
-
-        self.write
-            .append(MempoolOp::Add(txn_record.to_owned()))
-            .publish();
-
-        tokio::spawn(async move {
-            match create_tx_indexer(&txn_record).await {
-                Ok(_) => {
-                    info!("Successfully sent TxnRecord to block explorer indexer");
-                },
-                Err(e) => {
-                    warn!("Error sending TxnRecord to block explorer indexer {}", e);
-                },
-            }
-        });
+        self.write.append(MempoolOp::Add(txn_record)).publish();
 
         Ok(self.size_in_kilobytes())
     }

--- a/crates/miner/Cargo.toml
+++ b/crates/miner/Cargo.toml
@@ -21,3 +21,4 @@ block = { workspace = true }
 mempool = { workspace = true }
 thiserror = { workspace = true }
 utils = { workspace = true }
+ethereum-types = { workspace = true }

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -17,7 +17,7 @@ pub mod v2 {
 mod tests {
     use std::{collections::HashMap, str::FromStr};
 
-    use block::{header::BlockHeader, Block, ConvergenceBlock};
+    use block::{TxnList, header::BlockHeader, Block, ConvergenceBlock};
     use bulldag::{graph::BullDag, vertex::Vertex};
     use primitives::{PublicKey, Signature};
     use reward::reward::Reward;
@@ -28,7 +28,8 @@ mod tests {
     };
     use sha256::digest;
     use utils::{create_payload, hash_data};
-    use vrrb_core::txn::Txn;
+    use vrrb_core::txn::{Txn, TransactionDigest};
+    use ethereum_types::U256;
 
     use super::test_helpers::create_txns;
     use crate::test_helpers::{
@@ -173,7 +174,7 @@ mod tests {
                 .unwrap()
                 .clone();
 
-            let txns: HashMap<String, Txn> = create_txns(5).collect();
+            let txns: TxnList = create_txns(5).collect();
             prop1.txns.extend(txns.clone());
             prop2.txns.extend(txns.clone());
 
@@ -264,7 +265,7 @@ mod tests {
                 let mut resolved_conflicts = cb.txns.clone();
                 resolved_conflicts.retain(|_, set| {
                     let conflicts = txns.keys().cloned().collect();
-                    let intersection: LinkedHashSet<&String> =
+                    let intersection: LinkedHashSet<&TransactionDigest> =
                         set.intersection(&conflicts).collect();
                     intersection.len() > 0
                 });
@@ -294,7 +295,7 @@ mod tests {
                 .unwrap()
                 .clone();
 
-            let txns: HashMap<String, Txn> = create_txns(5).collect();
+            let txns: HashMap<TransactionDigest, Txn> = create_txns(5).collect();
             prop1.txns.extend(txns.clone());
 
             let proposals = vec![prop1.clone(), prop2.clone()];
@@ -631,7 +632,6 @@ mod tests {
 }
 
 pub(crate) mod test_helpers {
-    use std::mem;
 
     use block::{
         invalid::InvalidBlockErrorReason,
@@ -651,8 +651,9 @@ pub(crate) mod test_helpers {
         claim::Claim,
         helpers::size_of_txn_list,
         keypair::KeyPair,
-        txn::{NewTxnArgs, Token, TransactionDigest, Txn},
+        txn::{NewTxnArgs, TransactionDigest, Txn},
     };
+    use ethereum_types::U256;
 
     use crate::{MineArgs, Miner, MinerConfig};
 
@@ -730,12 +731,14 @@ pub(crate) mod test_helpers {
 
                 let txn_hash = hash_data!(&txn);
 
-                (txn_hash.into(), txn)
+                let digest: TransactionDigest = txn_hash.as_bytes().into();
+
+                (digest, txn)
             })
             .into_iter()
     }
 
-    pub(crate) fn create_claims(n: usize) -> impl Iterator<Item = (String, Claim)> {
+    pub(crate) fn create_claims(n: usize) -> impl Iterator<Item = (U256, Claim)> {
         (0..n)
             .map(|_| {
                 let (_, pk) = create_keypair();
@@ -764,7 +767,9 @@ pub(crate) mod test_helpers {
         let miner = create_miner();
 
         let prop_block =
-            miner.build_proposal_block(ref_hash.clone(), round, epoch, txns.clone(), claims, nonce);
+            miner.build_proposal_block(
+                ref_hash.clone(), round, epoch, txns.clone(), claims, nonce
+            );
 
         let total_txns_size = size_of_txn_list(&txns);
 
@@ -792,8 +797,12 @@ pub(crate) mod test_helpers {
 
         let mut reward = {
             match last_block {
-                Block::Convergence { ref block } => block.header.next_block_reward.clone(),
-                Block::Genesis { ref block } => block.header.next_block_reward.clone(),
+                Block::Convergence { ref block } => { 
+                    block.header.next_block_reward.clone()
+                }
+                Block::Genesis { ref block } => { 
+                    block.header.next_block_reward.clone()
+                }
                 _ => return None,
             }
         };
@@ -855,8 +864,12 @@ pub(crate) mod test_helpers {
 
         let mut reward = {
             match last_block {
-                Block::Convergence { ref block } => block.header.next_block_reward.clone(),
-                Block::Genesis { ref block } => block.header.next_block_reward.clone(),
+                Block::Convergence { ref block } => {
+                    block.header.next_block_reward.clone()
+                }
+                Block::Genesis { ref block } => {
+                    block.header.next_block_reward.clone()
+                }
                 _ => return None,
             }
         };

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -651,7 +651,7 @@ pub(crate) mod test_helpers {
         claim::Claim,
         helpers::size_of_txn_list,
         keypair::KeyPair,
-        txn::{NewTxnArgs, Token, Txn},
+        txn::{NewTxnArgs, Token, TransactionDigest, Txn},
     };
 
     use crate::{MineArgs, Miner, MinerConfig};
@@ -700,7 +700,7 @@ pub(crate) mod test_helpers {
         miner.mine_genesis_block(claim_list, 1)
     }
 
-    pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (String, Txn)> {
+    pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
         (0..n)
             .map(|n| {
                 let (sk, pk) = create_keypair();
@@ -730,7 +730,7 @@ pub(crate) mod test_helpers {
 
                 let txn_hash = hash_data!(&txn);
 
-                (txn_hash, txn)
+                (txn_hash.into(), txn)
             })
             .into_iter()
     }

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -23,7 +23,6 @@ use block::{
     GenesisBlock,
     ProposalBlock,
     RefHash,
-    TxnId,
     TxnList,
 };
 use bulldag::{
@@ -43,9 +42,9 @@ use utils::{create_payload, hash_data};
 use vrrb_core::{
     claim::Claim,
     keypair::{MinerPk, MinerSk},
-    txn::Txn,
+    txn::{TransactionDigest, Txn}
 };
-
+use ethereum_types::U256;
 use crate::result::MinerError;
 
 // TODO: replace Pool with LeftRightMempool if suitable
@@ -89,8 +88,8 @@ pub struct Miner {
 pub struct MineArgs<'a> {
     pub claim: Claim,
     pub last_block: Block,
-    pub txns: LinkedHashMap<String, Txn>,
-    pub claims: LinkedHashMap<String, Claim>,
+    pub txns: LinkedHashMap<TransactionDigest, Txn>,
+    pub claims: LinkedHashMap<U256, Claim>,
     pub claim_list_hash: Option<String>,
     #[deprecated(
         note = "will be removed, unnecessary as last block needed to mine and contains next block reward"
@@ -167,8 +166,9 @@ impl Miner {
         let txns: ConsolidatedTxns = resolved_txns
             .iter()
             .map(|block| {
-                let txn_list = block.txns.iter().map(|(id, _)| id.clone()).collect();
-
+                let txn_list = block.txns.iter().map(|(id, _)| {
+                    id.clone()
+                }).collect();
                 (block.hash.clone(), txn_list)
             })
             .collect();
@@ -343,7 +343,7 @@ impl Miner {
         );
 
         let mut claims = LinkedHashMap::new();
-        claims.insert(claim.clone().public_key, claim);
+        claims.insert(claim.hash.clone(), claim);
 
         #[cfg(mainnet)]
         let txns = genesis::generate_genesis_txns();
@@ -468,7 +468,7 @@ impl Miner {
             while let Some((id, conflict)) = conflict_iter.next() {
                 if Some(block.hash.clone()) != conflict.winner {
                     // if it does insert into removals, otherwise ignore
-                    removals.insert(id.to_string());
+                    removals.insert(id.clone());
                 }
             }
 
@@ -502,12 +502,12 @@ impl Miner {
         let mut proposals = proposals.clone();
 
         // Flatten consolidated transactions from all previous blocks
-        let removals: LinkedHashSet<&TxnId> = {
+        let removals: LinkedHashSet<&TransactionDigest> = {
             // Get nested sets of all previous blocks
-            let sets: Vec<LinkedHashSet<&TxnId>> = prev_blocks
+            let sets: Vec<LinkedHashSet<&TransactionDigest>> = prev_blocks
                 .iter()
                 .map(|block| {
-                    let block_set: Vec<&LinkedHashSet<TxnId>> = {
+                    let block_set: Vec<&LinkedHashSet<TransactionDigest>> = {
                         block
                             .txns
                             .iter()
@@ -538,7 +538,9 @@ impl Miner {
         resolved
     }
 
-    fn identify_conflicts(&self, proposals: &Vec<ProposalBlock>) -> HashMap<TxnId, Conflict> {
+    fn identify_conflicts(
+        &self, proposals: &Vec<ProposalBlock>
+    ) -> HashMap<TransactionDigest, Conflict> {
         let mut conflicts: ConflictList = HashMap::new();
         proposals.iter().for_each(|block| {
             let mut txn_iter = block.txns.iter();
@@ -548,15 +550,17 @@ impl Miner {
 
             while let Some((id, _)) = txn_iter.next() {
                 let conflict = Conflict {
-                    txn_id: id.to_string(),
+                    txn_id: id.clone(),
                     proposers: proposer.clone(),
                     winner: None,
                 };
 
                 conflicts
-                    .entry(id.to_string())
+                    .entry(id.clone())
                     .and_modify(|e| {
-                        e.proposers.insert((block.from.clone(), block.hash.clone()));
+                        e.proposers.insert(
+                            (block.from.clone(), 
+                             block.hash.clone()));
                     })
                     .or_insert(conflict);
             }

--- a/crates/network/src/network.rs
+++ b/crates/network/src/network.rs
@@ -382,7 +382,6 @@ impl BroadcastEngine {
         self.endpoint.0.local_addr()
     }
 
-    #[telemetry::instrument(name = "get_address_for_packet_shards")]
     fn get_address_for_packet_shards(
         &self,
         packet_index: usize,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -59,6 +59,7 @@ lazy_static = {workspace=true}
 dashmap ={workspace=true}
 timer = {workspace=true}
 laminar = {workspace=true}
+ethereum-types = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -9,7 +9,6 @@ pub mod services;
 pub mod test_utils;
 
 use events::{DirectedEvent, Event};
-
 pub use node_type::*;
 pub use result::*;
 pub use runtime::*;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -9,6 +9,7 @@ pub mod services;
 pub mod test_utils;
 
 use events::{DirectedEvent, Event};
+
 pub use node_type::*;
 pub use result::*;
 pub use runtime::*;
@@ -17,7 +18,7 @@ pub use services::*;
 
 pub use crate::node::*;
 
-pub(crate) type EventBroadcastSender = tokio::sync::mpsc::UnboundedSender<Event>;
+pub(crate) type EventBroadcastSender = tokio::sync::mpsc::UnboundedSender<DirectedEvent>;
 pub(crate) type EventBroadcastReceiver = tokio::sync::broadcast::Receiver<Event>;
 
 /// The maximum size in kilobytes of transactions that can be in the mempool at

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -12,10 +12,11 @@ use vrrb_core::keypair::KeyPair;
 
 use crate::{
     farmer_harvester_module::QuorumMember,
+    farmer_module::QuorumMember,
     result::{NodeError, Result},
     runtime::setup_runtime_components,
     NodeType,
-    RuntimeModuleState, farmer_module::QuorumMember,
+    RuntimeModuleState,
 };
 
 /// Node represents a member of the VRRB network and it is responsible for
@@ -85,7 +86,7 @@ impl Node {
             dkg_handle,
             miner_election_handle,
             quorum_election_handle,
-            conflict_resolution_handle
+            conflict_resolution_handle,
         ) = setup_runtime_components(
             &config,
             events_tx.clone(),
@@ -97,7 +98,7 @@ impl Node {
             jsonrpc_events_rx,
             dkg_events_rx,
             miner_election_events_rx,
-            quorum_election_events_rx
+            quorum_election_events_rx,
             conflict_resolution_events_rx,
         )
         .await?;

--- a/crates/node/src/result.rs
+++ b/crates/node/src/result.rs
@@ -1,8 +1,6 @@
 use std::net::AddrParseError;
 
-use events::DirectedEvent;
 use network::{config::BroadcastError, types::config::BroadCastError};
-use theater::TheaterError;
 use thiserror::Error;
 use tokio::sync::{
     broadcast::error::RecvError,
@@ -30,16 +28,7 @@ pub enum NodeError {
     TryRecv(#[from] TryRecvError),
 
     #[error("{0}")]
-    MpscSend(#[from] SendError<DirectedEvent>),
-
-    #[error("{0}")]
-    Theater(#[from] theater::TheaterError),
-
-    #[error("{0}")]
     Event(#[from] events::Error),
-
-    #[error("{0}")]
-    BroadcastRecv(#[from] RecvError),
 
     #[error("{0}")]
     Core(#[from] vrrb_core::Error),

--- a/crates/node/src/result.rs
+++ b/crates/node/src/result.rs
@@ -6,6 +6,7 @@ use tokio::sync::{
     broadcast::error::RecvError,
     mpsc::error::{SendError, TryRecvError},
 };
+use theater::TheaterError;
 
 #[derive(Debug, Error)]
 pub enum NodeError {

--- a/crates/node/src/runtime/broadcast_module.rs
+++ b/crates/node/src/runtime/broadcast_module.rs
@@ -260,6 +260,7 @@ impl Handler<Event> for BroadcastModule {
 #[cfg(test)]
 mod tests {
     use std::io::stdout;
+
     use events::Event;
     use primitives::NodeType;
     use storage::vrrbdb::{VrrbDb, VrrbDbConfig};

--- a/crates/node/src/runtime/broadcast_module.rs
+++ b/crates/node/src/runtime/broadcast_module.rs
@@ -1,21 +1,31 @@
-use std::{net::SocketAddr, time::Duration};
+use std::{collections::HashSet, net::SocketAddr, result::Result as StdResult, time::Duration};
 
 use async_trait::async_trait;
+use block::Block;
 use bytes::Bytes;
 use events::{DirectedEvent, Event};
-use network::network::BroadcastEngine;
+use network::{
+    message::{Message, MessageBody},
+    network::BroadcastEngine,
+};
 use primitives::{NodeType, PeerId};
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::{error, instrument};
 use theater::{ActorLabel, ActorState, Handler};
-use tokio::sync::mpsc::unbounded_channel;
+use tokio::{
+    sync::{
+        broadcast::{
+            error::{RecvError, TryRecvError},
+            Receiver,
+        },
+        mpsc::{channel, Receiver as MpscReceiver, Sender},
+    },
+    task::JoinHandle,
+    time::timeout,
+};
 use uuid::Uuid;
 
-use crate::{
-    broadcast_controller::{self, BroadcastEngineController, BroadcastEngineControllerConfig},
-    NodeError,
-    Result,
-};
+use crate::{NodeError, Result, RuntimeModuleState};
 
 pub struct BroadcastModuleConfig {
     pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
@@ -33,16 +43,23 @@ pub struct BroadcastModule {
     status: ActorState,
     events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
     vrrbdb_read_handle: VrrbDbReadHandle,
-    engine_controller_handle: tokio::task::JoinHandle<()>,
-    engine_controller_tx: tokio::sync::mpsc::UnboundedSender<Event>,
-    broadcast_engine_local_addr: SocketAddr,
+    broadcast_engine: BroadcastEngine,
+    status: ActorState,
 }
 
-/// Useful alias to represent get_incomming_connections' return type
-type BytesTrifecta = (Bytes, Bytes, Bytes);
+const PACKET_TIMEOUT_DURATION: u64 = 10;
+
+trait Timeout: Sized {
+    fn timeout(self) -> tokio::time::Timeout<Self>;
+}
+
+impl<F: std::future::Future> Timeout for F {
+    fn timeout(self) -> tokio::time::Timeout<Self> {
+        tokio::time::timeout(Duration::from_secs(PACKET_TIMEOUT_DURATION), self)
+    }
+}
 
 const PACKET_TIMEOUT_DURATION: u64 = 10;
-const EMPTY_BYTES_TRIFECTA: BytesTrifecta = (Bytes::new(), Bytes::new(), Bytes::new());
 
 trait Timeout: Sized {
     fn timeout(self) -> tokio::time::Timeout<Self>;
@@ -62,43 +79,61 @@ impl BroadcastModule {
                 NodeError::Other(format!("unable to setup broadcast engine: {:?}", err))
             })?;
 
-        let broadcast_engine_local_addr = broadcast_engine.local_addr();
-
-        let events_tx = config.events_tx.clone();
-
-        let (engine_controller_tx, engine_controller_rx) = unbounded_channel();
-
-        let engine_controller_handle = tokio::spawn(async move {
-            let events_tx = events_tx;
-
-            let mut broadcast_engine = broadcast_engine;
-
-            let mut broadcast_controller =
-                BroadcastEngineController::new(BroadcastEngineControllerConfig {
-                    engine: broadcast_engine,
-                    events_tx,
-                })
-                .listen(engine_controller_rx)
-                .await;
-        });
-
         Ok(Self {
             id: Uuid::new_v4(),
             events_tx: config.events_tx,
             status: ActorState::Stopped,
             vrrbdb_read_handle: config.vrrbdb_read_handle,
-            broadcast_engine_local_addr,
-            engine_controller_tx,
-            engine_controller_handle,
+            broadcast_engine,
         })
     }
 
     pub fn local_addr(&self) -> SocketAddr {
-        self.broadcast_engine_local_addr
+        self.broadcast_engine.local_addr()
     }
 
     pub fn name(&self) -> String {
         "BroadcastModule".to_string()
+    }
+
+    pub async fn process_received_msg(&mut self) {
+        loop {
+            if let Some((_, mut incoming)) = self
+                .broadcast_engine
+                .get_incomming_connections()
+                .next()
+                .await
+            {
+                if let Ok(message_result) = incoming.next().timeout().await {
+                    if let Ok(msg_option) = message_result {
+                        if let Some(message) = msg_option {
+                            let msg = Message::from_bytes(&message.2);
+                            match msg.data {
+                                MessageBody::InvalidBlock { .. } => {},
+                                MessageBody::Disconnect { .. } => {},
+                                MessageBody::StateComponents { .. } => {},
+                                MessageBody::Genesis { .. } => {},
+                                MessageBody::Child { .. } => {},
+                                MessageBody::Parent { .. } => {},
+                                MessageBody::Ledger { .. } => {},
+                                MessageBody::NetworkState { .. } => {},
+                                MessageBody::ClaimAbandoned { .. } => {},
+                                MessageBody::ResetPeerConnection { .. } => {},
+                                MessageBody::RemovePeer { .. } => {},
+                                MessageBody::AddPeer { .. } => {},
+                                MessageBody::DKGPartCommitment {
+                                    part_commitment,
+                                    sender_id,
+                                } => {},
+                                MessageBody::DKGPartAcknowledgement { .. } => {},
+                                MessageBody::Vote { .. } => {},
+                                MessageBody::Empty => {},
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -126,14 +161,96 @@ impl Handler<Event> for BroadcastModule {
 
     #[instrument]
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
-        if let Err(err) = self.engine_controller_tx.send(event.clone()) {
-            error!("unable to send event to broadcast controller: {:?}", err);
+        match event {
+            Event::PartMessage(sender_id, part_commitment) => {
+                let status = self
+                    .broadcast_engine
+                    .quic_broadcast(Message::new(MessageBody::DKGPartCommitment {
+                        sender_id,
+                        part_commitment,
+                    }))
+                    .await;
+                match status {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!(
+                            "Error occured while broadcasting ack commitment to peers :{:?}",
+                            e
+                        );
+                    },
+                }
+            },
+            Event::SendAck(curr_node_id, sender_id, ack) => {
+                let status = self
+                    .broadcast_engine
+                    .quic_broadcast(Message::new(MessageBody::DKGPartAcknowledgement {
+                        curr_node_id,
+                        sender_id,
+                        ack,
+                    }))
+                    .await;
+                match status {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!(
+                            "Error occured while broadcasting Part commitment to peers :{:?}",
+                            e
+                        );
+                    },
+                }
+            },
+            Event::SyncPeers(peers) => {
+                let mut quic_addresses = vec![];
+                let mut raptor_peer_list = vec![];
+                for peer in peers.iter() {
+                    if let Ok(addr) = peer.address.parse::<SocketAddr>() {
+                        quic_addresses.push(addr);
+                        let mut raptor_addr = addr.clone();
+                        raptor_addr.set_port(peer.raptor_udp_port);
+                        raptor_peer_list.push(raptor_addr);
+                    }
+                }
+                self.broadcast_engine.add_raptor_peers(raptor_peer_list);
+                self.broadcast_engine.add_peer_connection(quic_addresses);
+            },
+            Event::Vote(vote, quorum_type, farmer_quorum_threshold) => {
+                let status = self
+                    .broadcast_engine
+                    .quic_broadcast(Message::new(MessageBody::Vote {
+                        vote,
+                        quorum_type,
+                        farmer_quorum_threshold,
+                    }))
+                    .await;
+                match status {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!(
+                            "Error occured while broadcasting votes to harvesters :{:?}",
+                            e
+                        );
+                    },
+                }
+            },
+            /// Broadcasting the Convergence block to the peers.
+            Event::BlockConfirmed(block) => {
+                let status = self
+                    .broadcast_engine
+                    .unreliable_broadcast(
+                        block,
+                        RAPTOR_ERASURE_COUNT,
+                        self.broadcast_engine.raptor_udp_port,
+                    )
+                    .await;
+                match status {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!("Error occured while broadcasting blocks to peers :{:?}", e);
+                    },
+                }
+            },
 
-            return Ok(ActorState::Stopped);
-        }
-
-        if matches!(event, Event::Stop) {
-            return Ok(ActorState::Stopped);
+            _ => {},
         }
 
         Ok(ActorState::Running)
@@ -143,13 +260,10 @@ impl Handler<Event> for BroadcastModule {
 #[cfg(test)]
 mod tests {
     use std::io::stdout;
-
-    use events::{Event, SyncPeerData};
+    use events::Event;
     use primitives::NodeType;
     use storage::vrrbdb::{VrrbDb, VrrbDbConfig};
-    use telemetry::TelemetrySubscriber;
-    use theater::{Actor, ActorImpl};
-    use tokio::{net::UdpSocket, sync::mpsc::unbounded_channel};
+    use tokio::sync::mpsc::unbounded_channel;
 
     use super::{BroadcastModule, BroadcastModuleConfig};
 

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -48,8 +48,8 @@ pub struct DkgModuleConfig {
 pub struct DkgModule {
     pub dkg_engine: DkgEngine,
     pub quorum_type: Option<QuorumType>,
-    pub rendzevous_local_addr: SocketAddr,
-    pub rendzevous_server_addr: SocketAddr,
+    pub rendezvous_local_addr: SocketAddr,
+    pub rendezvous_server_addr: SocketAddr,
     pub quic_port: u16,
     pub socket: Socket,
     status: ActorState,
@@ -64,8 +64,8 @@ impl DkgModule {
         node_type: NodeType,
         secret_key: hbbft::crypto::SecretKey,
         config: DkgModuleConfig,
-        rendzevous_local_addr: SocketAddr,
-        rendzevous_server_addr: SocketAddr,
+        rendezvous_local_addr: SocketAddr,
+        rendezvous_server_addr: SocketAddr,
         quic_port: u16,
         broadcast_events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
     ) -> Result<DkgModule> {
@@ -79,7 +79,7 @@ impl DkgModule {
             },
         );
         let socket_result = Socket::bind_with_config(
-            rendzevous_local_addr,
+            rendezvous_local_addr,
             Config {
                 blocking_mode: false,
                 idle_connection_timeout: Duration::from_secs(5),
@@ -101,8 +101,8 @@ impl DkgModule {
             Ok(socket) => Ok(Self {
                 dkg_engine: engine,
                 quorum_type: config.quorum_type,
-                rendzevous_local_addr,
-                rendzevous_server_addr,
+                rendezvous_local_addr,
+                rendezvous_server_addr,
                 quic_port,
                 socket,
                 status: ActorState::Stopped,
@@ -146,8 +146,8 @@ impl DkgModule {
         Self {
             dkg_engine,
             quorum_type: Some(QuorumType::Farmer),
-            rendzevous_local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
-            rendzevous_server_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
+            rendezvous_local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
+            rendezvous_server_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
             quic_port: 9090,
             socket,
             status: ActorState::Stopped,
@@ -161,14 +161,14 @@ impl DkgModule {
         String::from("DKG module")
     }
 
-    pub fn process_rendzevous_response(&self) {
+    pub fn process_rendezvous_response(&self) {
         let receiver = self.socket.get_event_receiver();
         let sender = self.socket.get_packet_sender();
         loop {
             if let Ok(event) = receiver.recv() {
                 match event {
                     SocketEvent::Packet(packet) => {
-                        if packet.addr() == self.rendzevous_server_addr {
+                        if packet.addr() == self.rendezvous_server_addr {
                             if let Ok(payload_response) =
                                 bincode::deserialize::<Data>(packet.payload())
                             {
@@ -253,7 +253,7 @@ impl DkgModule {
                                         harvester_public_key.to_bytes().to_vec(),
                                     ))){
                                 let _ = sender.send(Packet::reliable_ordered(
-                                    self.rendzevous_server_addr,
+                                    self.rendezvous_server_addr,
                                     data,
                                     None,
                                 ));
@@ -270,7 +270,7 @@ impl DkgModule {
                                             quorum_key.public_key().to_bytes().to_vec(),
                                         ))){
                                                    let _ = sender.send(Packet::reliable_ordered(
-                                        self.rendzevous_server_addr,
+                                        self.rendezvous_server_addr,
                                         data,
                                         None,
                                     ));
@@ -302,8 +302,8 @@ impl DkgModule {
                                                 signature,
                                                 msg_bytes,
                                                 SyncPeerData {
-                                                    address: self.rendzevous_local_addr.to_string(),
-                                                    raptor_udp_port: self.rendzevous_local_addr.port(),
+                                                    address: self.rendezvous_local_addr.to_string(),
+                                                    raptor_udp_port: self.rendezvous_local_addr.port(),
                                                     quic_port: self.quic_port,
                                                     node_type: self.dkg_engine.node_type,
                                                 },
@@ -311,7 +311,7 @@ impl DkgModule {
                                         ));
                                         if let Ok(payload) = payload_result {
                                             let _ = sender.send(Packet::reliable_ordered(
-                                                self.rendzevous_server_addr,
+                                                self.rendezvous_server_addr,
                                                 payload,
                                                 None,
                                             ));
@@ -331,7 +331,6 @@ impl DkgModule {
     }
 }
 
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Data {
     Request(RendezvousRequest),
@@ -392,8 +391,6 @@ pub enum RendezvousResponse {
     NamespaceRegistered,
 }
 
-
->>>>>>> d47861a (Feat change claimpointers to xor (#205))
 #[async_trait]
 impl Handler<Event> for DkgModule {
     fn id(&self) -> ActorId {

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -190,7 +190,7 @@ impl DkgModule {
                                         RendezvousResponse::Peers(peers) => {
                                             let _ = self
                                                 .broadcast_events_tx
-                                                .send((Topic::Network, Event::SyncPeers(peers)));
+                                                .send(Event::SyncPeers(peers));
                                         },
                                         RendezvousResponse::NamespaceRegistered => {
                                             info!("Namespace Registered");
@@ -302,7 +302,7 @@ impl DkgModule {
                                                 signature,
                                                 msg_bytes,
                                                 SyncPeerData {
-                                                    address: self.rendezvous_local_addr.to_string(),
+                                                    address: self.rendezvous_local_addr,
                                                     raptor_udp_port: self.rendezvous_local_addr.port(),
                                                     quic_port: self.quic_port,
                                                     node_type: self.dkg_engine.node_type,
@@ -329,36 +329,6 @@ impl DkgModule {
             }
         }
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Data {
-    Request(RendezvousRequest),
-    Response(RendezvousResponse),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum RendezvousRequest {
-    Ping,
-    Peers(Vec<u8>),
-    Namespace(NodeTypeBytes, QuorumPublicKey),
-    RegisterPeer(
-        QuorumPublicKey,
-        NodeTypeBytes,
-        PKShareBytes,
-        RawSignature,
-        PayloadBytes,
-        SyncPeerData,
-    ),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum RendezvousResponse {
-    Pong,
-    RequestPeers(QuorumPublicKey),
-    Peers(Vec<SyncPeerData>),
-    PeerRegistered,
-    NamespaceRegistered,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -190,7 +190,7 @@ impl DkgModule {
                                         RendezvousResponse::Peers(peers) => {
                                             let _ = self
                                                 .broadcast_events_tx
-                                                .send(Event::SyncPeers(peers));
+                                                .send((Topic::Network, Event::SyncPeers(peers)));
                                         },
                                         RendezvousResponse::NamespaceRegistered => {
                                             info!("Namespace Registered");
@@ -302,7 +302,7 @@ impl DkgModule {
                                                 signature,
                                                 msg_bytes,
                                                 SyncPeerData {
-                                                    address: self.rendzevous_local_addr,
+                                                    address: self.rendzevous_local_addr.to_string(),
                                                     raptor_udp_port: self.rendzevous_local_addr.port(),
                                                     quic_port: self.quic_port,
                                                     node_type: self.dkg_engine.node_type,
@@ -329,6 +329,37 @@ impl DkgModule {
             }
         }
     }
+}
+
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Data {
+    Request(RendezvousRequest),
+    Response(RendezvousResponse),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RendezvousRequest {
+    Ping,
+    Peers(Vec<u8>),
+    Namespace(NodeTypeBytes, QuorumPublicKey),
+    RegisterPeer(
+        QuorumPublicKey,
+        NodeTypeBytes,
+        PKShareBytes,
+        RawSignature,
+        PayloadBytes,
+        SyncPeerData,
+    ),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RendezvousResponse {
+    Pong,
+    RequestPeers(QuorumPublicKey),
+    Peers(Vec<SyncPeerData>),
+    PeerRegistered,
+    NamespaceRegistered,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -361,6 +392,8 @@ pub enum RendezvousResponse {
     NamespaceRegistered,
 }
 
+
+>>>>>>> d47861a (Feat change claimpointers to xor (#205))
 #[async_trait]
 impl Handler<Event> for DkgModule {
     fn id(&self) -> ActorId {

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -1,0 +1,356 @@
+use std::{collections::{HashMap, BTreeMap}, error::Error};
+use block::{
+    header::BlockHeader, 
+    ConflictList, 
+    RefHash, 
+    Conflict, 
+    ResolvedConflicts
+};
+use events::{ConflictBytes, DirectedEvent, Topic};
+use telemetry::info;
+use async_trait::async_trait;
+use primitives::NodeId;
+use storage::vrrbdb::VrrbDbReadHandle;
+use theater::{ActorId, ActorState, ActorLabel, Handler};
+use vrrb_core::{claim::Claim, event_router::{DirectedEvent, Event}};
+use serde::{Serialize, Deserialize};
+use std::fmt::Debug;
+use tokio::{task::JoinHandle, sync::mpsc::UnboundedSender};
+use ethereum_types::U256;
+
+pub type Seed = u64;
+
+pub trait ElectionType: Clone + Debug {}
+pub trait ElectionOutcome: Clone + Debug {}
+
+pub type MinerElectionResult = Vec<ElectionResult>;
+pub type QuorumElectionResult = HashMap<u8, Vec<ElectionResult>>;
+pub type ConflictResolutionResult = HashMap<String, ElectionResult>;
+
+#[derive(Clone, Debug)]
+pub struct MinerElection;
+
+#[derive(Clone, Debug)]
+pub struct QuorumElection;
+
+#[derive(Clone, Debug)]
+pub struct ConflictResolution;
+
+pub struct ElectionModuleConfig {
+    pub db_read_handle: VrrbDbReadHandle,
+    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+    pub local_claim: Claim,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ElectionResult {
+    pub claim_pointer: u128,
+    pub claim_hash: String,
+    pub node_id: NodeId,
+}
+
+#[derive(Clone, Debug)]
+pub struct ElectionModule<E, T> 
+where 
+    E: ElectionType,
+    T: ElectionOutcome,
+{
+    election_type: E,
+    status: ActorState,
+    id: ActorId,
+    label: ActorLabel,
+    pub db_read_handle: VrrbDbReadHandle,
+    pub local_claim: Claim,
+    pub outcome: Option<T>,
+    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>, 
+}
+
+impl ElectionModule<MinerElection, MinerElectionResult> {
+    pub fn new(
+        config: ElectionModuleConfig
+    ) -> ElectionModule<MinerElection, MinerElectionResult> 
+    {
+        ElectionModule {
+            election_type: MinerElection,
+            status: ActorState::Stopped,
+            id: uuid::Uuid::new_v4().to_string(),
+            label: String::from("State module"),
+            db_read_handle: config.db_read_handle,
+            local_claim: config.local_claim,
+            outcome: None,
+            events_tx: config.events_tx
+        }
+    }
+
+    pub fn name(&self) -> ActorLabel {
+        String::from("Miner Election Module") 
+    }
+}
+
+impl ElectionModule<QuorumElection, QuorumElectionResult> {
+    pub fn new(
+        config: ElectionModuleConfig
+    ) -> ElectionModule<QuorumElection, QuorumElectionResult> {
+        ElectionModule { 
+            election_type: QuorumElection, 
+            status: ActorState::Stopped, 
+            id: uuid::Uuid::new_v4().to_string(), 
+            label: String::from("State module"), 
+            db_read_handle: config.db_read_handle, 
+            local_claim: config.local_claim, 
+            outcome: None, 
+            events_tx: config.events_tx 
+        } 
+    }
+
+    pub fn name(&self) -> ActorLabel {
+        String::from("Quorum Election Module") 
+    }
+}
+
+impl ElectionModule<ConflictResolution, ConflictResolutionResult> {
+    pub fn new(
+        config: ElectionModuleConfig 
+    ) -> ElectionModule<ConflictResolution, ConflictResolutionResult> {
+        ElectionModule { 
+            election_type: ConflictResolution, 
+            status: ActorState::Stopped, 
+            id: uuid::Uuid::new_v4().to_string(), 
+            label: String::from("State module"), 
+            db_read_handle: config.db_read_handle, 
+            local_claim: config.local_claim, 
+            outcome: None, 
+            events_tx: config.events_tx 
+        } 
+
+    }
+
+    pub fn name(&self) -> ActorLabel {
+        String::from("Conflict Resultion Election Module") 
+    }
+}
+
+
+impl ElectionType for MinerElection {}
+impl ElectionType for QuorumElection {}
+impl ElectionType for ConflictResolution {}
+
+impl ElectionOutcome for MinerElectionResult {}
+impl ElectionOutcome for QuorumElectionResult {}
+impl ElectionOutcome for ConflictResolutionResult {}
+
+#[async_trait]
+impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
+    fn id(&self) -> ActorId {
+        self.id.clone()
+    }
+
+    fn label(&self) -> ActorLabel {
+        self.name()
+    }
+
+    fn status(&self) -> ActorState {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, actor_status: ActorState) {
+        self.status = actor_status;
+    }
+
+    fn on_stop(&self) {
+        info!(
+            "{}-{} received stop signal. Stopping",
+            self.name(),
+            self.label()
+        );
+    }
+
+    async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
+        match event {
+            Event::MinerElection(header_bytes) => {
+                let header_result: Result<BlockHeader> = serde_json::from_slice(
+                    &header_bytes
+                );
+                if let Ok(header) = header_result {
+                    let claims = self.db_read_handle.claim_store_values();
+                    let mut election_results: BTreeMap<U256, String> = elect_miner(
+                        claims, header.block_seed
+                    );
+                    
+                    let winner = get_winner(&mut election_results); 
+
+                    let directed_event = (Topic::Consensus, Event::ElectedMiner(winner));
+                    let _ = self.events_tx.send(directed_event);
+                }
+            }
+            _ => {},
+        }
+
+        Ok(ActorState::Running)
+    }
+}
+
+#[async_trait]
+impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
+
+    fn id(&self) -> ActorId {
+        self.id.clone()
+    }
+
+    fn label(&self) -> ActorLabel {
+        self.name()
+    }
+
+    fn status(&self) -> ActorState {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, actor_status: ActorState) {
+        self.status = actor_status;
+    }
+
+    fn on_stop(&self) {
+        info!(
+            "{}-{} received stop signal. Stopping",
+            self.name(),
+            self.label()
+        );
+    }
+
+    async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
+        match event {
+            //TODO: Implement
+            _ => {},
+        }
+
+        Ok(ActorState::Running)
+    }
+}
+
+#[async_trait]
+impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionResult> {
+
+    fn id(&self) -> ActorId {
+        self.id.clone()
+    }
+
+    fn label(&self) -> ActorLabel {
+        self.name()
+    }
+
+    fn status(&self) -> ActorState {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, actor_status: ActorState) {
+        self.status = actor_status;
+    }
+
+    fn on_stop(&self) {
+        info!(
+            "{}-{} received stop signal. Stopping",
+            self.name(),
+            self.label()
+        );
+    }
+
+    async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
+        match event {
+            Event::ConflictResolution(ConflictBytes, HeaderBytes) => {
+                let cl_res: Result<ConflictList> = serde_json::from_slice(
+                    &ConflictBytes
+                );
+
+                let header_res: Result<BlockHeader> = serde_json::from_slice(
+                    &HeaderBytes
+                );
+                
+                if let Ok(conflicts) = cl_res {
+                    if let Ok(header) = header_res {
+                        let handles: ResolvedConflicts = 
+                            conflicts.iter()
+                                .map(|(txnid, conflict)| {
+                                    let inner_header = header.clone();
+                                    let events_tx = self.events_tx.clone();
+                                    let mut inner_conflict: Conflict = conflict.clone();
+                                    tokio::spawn(async move {
+                                        resolve_conflict(
+                                            &mut inner_conflict, 
+                                            inner_header.clone(),
+                                            events_tx,
+                                        ).await;
+                                    }
+                                );
+                            }
+                        ).collect();
+                    }
+                }
+            }
+            _ => {},
+        }
+
+        Ok(ActorState::Running)
+    }
+}
+
+fn elect_miner(
+    claims: HashMap<NodeId, Claim>,
+    block_seed: u64 
+) -> BTreeMap<U256, NodeId> {
+
+    claims.iter()
+        .filter(|(_, claim)| claim.eligible)
+        .map(|(nodeid, claim)| single_miner_results(claim, nodeid, block_seed)
+    ).collect()
+}
+
+fn single_miner_results(
+    claim: Claim,
+    node_id: NodeId,
+    block_seed: u64,
+) -> (U256, NodeId) {
+    (claim.get_election_result(block_seed), node_id)
+}
+
+fn get_winner(
+    results: &mut BTreeMap<U256, NodeId>
+) -> (U256, NodeId) {
+
+    let mut first: Option<(U256, NodeId)> = election_results.pop_first();
+    while let None = first {
+        first = election_results.pop_first();
+    }
+
+    return first
+}
+
+async fn resolve_conflict(
+    conflict: &mut Conflict, 
+    header: BlockHeader,
+    events_tx: UnboundedSender<DirectedEvent>
+) {
+
+    let propopsers = conflict.proposers.clone();
+    let resoultion_results: BTreeMap<U256, String> = proposers.iter()
+        .map(|(claim, refhash)| {
+            (claim.get_election_results(
+            inner_header.block_seed.clone() 
+            ), refhash.clone());
+        }
+    ).collect(); 
+
+    let winner = {
+
+        let mut first: Option<(U256, NodeId)> = resolution_results.pop_first();
+
+        while let None = first {
+            first = resolution_results.pop_first();
+        }
+
+        return first
+    };
+
+    conflict.winner = Some(winner.1);
+    let directed_event = (Topic::Consensus, Event::ConflictResolved(conflict));
+    let _ = events_tx.send(directed_event);
+}

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -1,22 +1,23 @@
-use std::{collections::{HashMap, BTreeMap}, error::Error};
-use block::{
-    header::BlockHeader, 
-    ConflictList, 
-    RefHash, 
-    Conflict, 
-    ResolvedConflicts
+use std::{
+    collections::{BTreeMap, HashMap},
+    error::Error,
+    fmt::Debug,
 };
-use events::{ConflictBytes, DirectedEvent, Topic};
-use telemetry::info;
+
 use async_trait::async_trait;
-use primitives::NodeId;
-use storage::vrrbdb::VrrbDbReadHandle;
-use theater::{ActorId, ActorState, ActorLabel, Handler};
-use vrrb_core::{claim::Claim, event_router::{DirectedEvent, Event}};
-use serde::{Serialize, Deserialize};
-use std::fmt::Debug;
-use tokio::{task::JoinHandle, sync::mpsc::UnboundedSender};
+use block::{header::BlockHeader, Conflict, ConflictList, RefHash, ResolvedConflicts};
 use ethereum_types::U256;
+use events::{ConflictBytes, DirectedEvent, Topic};
+use primitives::NodeId;
+use serde::{Deserialize, Serialize};
+use storage::vrrbdb::VrrbDbReadHandle;
+use telemetry::info;
+use theater::{ActorId, ActorLabel, ActorState, Handler};
+use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
+use vrrb_core::{
+    claim::Claim,
+    event_router::{DirectedEvent, Event},
+};
 
 pub type Seed = u64;
 
@@ -50,8 +51,8 @@ pub struct ElectionResult {
 }
 
 #[derive(Clone, Debug)]
-pub struct ElectionModule<E, T> 
-where 
+pub struct ElectionModule<E, T>
+where
     E: ElectionType,
     T: ElectionOutcome,
 {
@@ -62,14 +63,11 @@ where
     pub db_read_handle: VrrbDbReadHandle,
     pub local_claim: Claim,
     pub outcome: Option<T>,
-    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>, 
+    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
 }
 
 impl ElectionModule<MinerElection, MinerElectionResult> {
-    pub fn new(
-        config: ElectionModuleConfig
-    ) -> ElectionModule<MinerElection, MinerElectionResult> 
-    {
+    pub fn new(config: ElectionModuleConfig) -> ElectionModule<MinerElection, MinerElectionResult> {
         ElectionModule {
             election_type: MinerElection,
             status: ActorState::Stopped,
@@ -78,55 +76,54 @@ impl ElectionModule<MinerElection, MinerElectionResult> {
             db_read_handle: config.db_read_handle,
             local_claim: config.local_claim,
             outcome: None,
-            events_tx: config.events_tx
+            events_tx: config.events_tx,
         }
     }
 
     pub fn name(&self) -> ActorLabel {
-        String::from("Miner Election Module") 
+        String::from("Miner Election Module")
     }
 }
 
 impl ElectionModule<QuorumElection, QuorumElectionResult> {
     pub fn new(
-        config: ElectionModuleConfig
+        config: ElectionModuleConfig,
     ) -> ElectionModule<QuorumElection, QuorumElectionResult> {
-        ElectionModule { 
-            election_type: QuorumElection, 
-            status: ActorState::Stopped, 
-            id: uuid::Uuid::new_v4().to_string(), 
-            label: String::from("State module"), 
-            db_read_handle: config.db_read_handle, 
-            local_claim: config.local_claim, 
-            outcome: None, 
-            events_tx: config.events_tx 
-        } 
+        ElectionModule {
+            election_type: QuorumElection,
+            status: ActorState::Stopped,
+            id: uuid::Uuid::new_v4().to_string(),
+            label: String::from("State module"),
+            db_read_handle: config.db_read_handle,
+            local_claim: config.local_claim,
+            outcome: None,
+            events_tx: config.events_tx,
+        }
     }
 
     pub fn name(&self) -> ActorLabel {
-        String::from("Quorum Election Module") 
+        String::from("Quorum Election Module")
     }
 }
 
 impl ElectionModule<ConflictResolution, ConflictResolutionResult> {
     pub fn new(
-        config: ElectionModuleConfig 
+        config: ElectionModuleConfig,
     ) -> ElectionModule<ConflictResolution, ConflictResolutionResult> {
-        ElectionModule { 
-            election_type: ConflictResolution, 
-            status: ActorState::Stopped, 
-            id: uuid::Uuid::new_v4().to_string(), 
-            label: String::from("State module"), 
-            db_read_handle: config.db_read_handle, 
-            local_claim: config.local_claim, 
-            outcome: None, 
-            events_tx: config.events_tx 
-        } 
-
+        ElectionModule {
+            election_type: ConflictResolution,
+            status: ActorState::Stopped,
+            id: uuid::Uuid::new_v4().to_string(),
+            label: String::from("State module"),
+            db_read_handle: config.db_read_handle,
+            local_claim: config.local_claim,
+            outcome: None,
+            events_tx: config.events_tx,
+        }
     }
 
     pub fn name(&self) -> ActorLabel {
-        String::from("Conflict Resultion Election Module") 
+        String::from("Conflict Resultion Election Module")
     }
 }
 
@@ -168,21 +165,18 @@ impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
             Event::MinerElection(header_bytes) => {
-                let header_result: Result<BlockHeader> = serde_json::from_slice(
-                    &header_bytes
-                );
+                let header_result: Result<BlockHeader> = serde_json::from_slice(&header_bytes);
                 if let Ok(header) = header_result {
                     let claims = self.db_read_handle.claim_store_values();
-                    let mut election_results: BTreeMap<U256, String> = elect_miner(
-                        claims, header.block_seed
-                    );
-                    
-                    let winner = get_winner(&mut election_results); 
+                    let mut election_results: BTreeMap<U256, String> =
+                        elect_miner(claims, header.block_seed);
+
+                    let winner = get_winner(&mut election_results);
 
                     let directed_event = (Topic::Consensus, Event::ElectedMiner(winner));
                     let _ = self.events_tx.send(directed_event);
                 }
-            }
+            },
             _ => {},
         }
 
@@ -192,7 +186,6 @@ impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
 
 #[async_trait]
 impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
-
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -229,7 +222,6 @@ impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
 
 #[async_trait]
 impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionResult> {
-
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -257,35 +249,31 @@ impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionRes
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
             Event::ConflictResolution(ConflictBytes, HeaderBytes) => {
-                let cl_res: Result<ConflictList> = serde_json::from_slice(
-                    &ConflictBytes
-                );
+                let cl_res: Result<ConflictList> = serde_json::from_slice(&ConflictBytes);
 
-                let header_res: Result<BlockHeader> = serde_json::from_slice(
-                    &HeaderBytes
-                );
-                
+                let header_res: Result<BlockHeader> = serde_json::from_slice(&HeaderBytes);
+
                 if let Ok(conflicts) = cl_res {
                     if let Ok(header) = header_res {
-                        let handles: ResolvedConflicts = 
-                            conflicts.iter()
-                                .map(|(txnid, conflict)| {
-                                    let inner_header = header.clone();
-                                    let events_tx = self.events_tx.clone();
-                                    let mut inner_conflict: Conflict = conflict.clone();
-                                    tokio::spawn(async move {
-                                        resolve_conflict(
-                                            &mut inner_conflict, 
-                                            inner_header.clone(),
-                                            events_tx,
-                                        ).await;
-                                    }
-                                );
-                            }
-                        ).collect();
+                        let handles: ResolvedConflicts = conflicts
+                            .iter()
+                            .map(|(txnid, conflict)| {
+                                let inner_header = header.clone();
+                                let events_tx = self.events_tx.clone();
+                                let mut inner_conflict: Conflict = conflict.clone();
+                                tokio::spawn(async move {
+                                    resolve_conflict(
+                                        &mut inner_conflict,
+                                        inner_header.clone(),
+                                        events_tx,
+                                    )
+                                    .await;
+                                });
+                            })
+                            .collect();
                     }
                 }
-            }
+            },
             _ => {},
         }
 
@@ -293,61 +281,51 @@ impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionRes
     }
 }
 
-fn elect_miner(
-    claims: HashMap<NodeId, Claim>,
-    block_seed: u64 
-) -> BTreeMap<U256, NodeId> {
-
-    claims.iter()
+fn elect_miner(claims: HashMap<NodeId, Claim>, block_seed: u64) -> BTreeMap<U256, NodeId> {
+    claims
+        .iter()
         .filter(|(_, claim)| claim.eligible)
-        .map(|(nodeid, claim)| single_miner_results(claim, nodeid, block_seed)
-    ).collect()
+        .map(|(nodeid, claim)| single_miner_results(claim, nodeid, block_seed))
+        .collect()
 }
 
-fn single_miner_results(
-    claim: Claim,
-    node_id: NodeId,
-    block_seed: u64,
-) -> (U256, NodeId) {
+fn single_miner_results(claim: Claim, node_id: NodeId, block_seed: u64) -> (U256, NodeId) {
     (claim.get_election_result(block_seed), node_id)
 }
 
-fn get_winner(
-    results: &mut BTreeMap<U256, NodeId>
-) -> (U256, NodeId) {
-
+fn get_winner(results: &mut BTreeMap<U256, NodeId>) -> (U256, NodeId) {
     let mut first: Option<(U256, NodeId)> = election_results.pop_first();
     while let None = first {
         first = election_results.pop_first();
     }
 
-    return first
+    return first;
 }
 
 async fn resolve_conflict(
-    conflict: &mut Conflict, 
+    conflict: &mut Conflict,
     header: BlockHeader,
-    events_tx: UnboundedSender<DirectedEvent>
+    events_tx: UnboundedSender<DirectedEvent>,
 ) {
-
     let propopsers = conflict.proposers.clone();
-    let resoultion_results: BTreeMap<U256, String> = proposers.iter()
+    let resoultion_results: BTreeMap<U256, String> = proposers
+        .iter()
         .map(|(claim, refhash)| {
-            (claim.get_election_results(
-            inner_header.block_seed.clone() 
-            ), refhash.clone());
-        }
-    ).collect(); 
+            (
+                claim.get_election_results(inner_header.block_seed.clone()),
+                refhash.clone(),
+            );
+        })
+        .collect();
 
     let winner = {
-
         let mut first: Option<(U256, NodeId)> = resolution_results.pop_first();
 
         while let None = first {
             first = resolution_results.pop_first();
         }
 
-        return first
+        return first;
     };
 
     conflict.winner = Some(winner.1);

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -7,17 +7,15 @@ use std::{
 use async_trait::async_trait;
 use block::{header::BlockHeader, Conflict, ConflictList, RefHash, ResolvedConflicts};
 use ethereum_types::U256;
-use events::{ConflictBytes, DirectedEvent, Topic};
+use events::{ConflictBytes, Event};
 use primitives::NodeId;
 use serde::{Deserialize, Serialize};
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::info;
-use theater::{ActorId, ActorLabel, ActorState, Handler};
+use theater::{ActorId, ActorLabel, ActorState, Handler, TheaterError};
 use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
-use vrrb_core::{
-    claim::Claim,
-    event_router::{DirectedEvent, Event},
-};
+use vrrb_core::claim::Claim;
+
 
 pub type Seed = u64;
 
@@ -26,7 +24,6 @@ pub trait ElectionOutcome: Clone + Debug {}
 
 pub type MinerElectionResult = Vec<ElectionResult>;
 pub type QuorumElectionResult = HashMap<u8, Vec<ElectionResult>>;
-pub type ConflictResolutionResult = HashMap<String, ElectionResult>;
 
 #[derive(Clone, Debug)]
 pub struct MinerElection;
@@ -34,12 +31,9 @@ pub struct MinerElection;
 #[derive(Clone, Debug)]
 pub struct QuorumElection;
 
-#[derive(Clone, Debug)]
-pub struct ConflictResolution;
-
 pub struct ElectionModuleConfig {
     pub db_read_handle: VrrbDbReadHandle,
-    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+    pub events_tx: tokio::sync::mpsc::UnboundedSender<Event>,
     pub local_claim: Claim,
 }
 
@@ -63,7 +57,7 @@ where
     pub db_read_handle: VrrbDbReadHandle,
     pub local_claim: Claim,
     pub outcome: Option<T>,
-    pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+    pub events_tx: tokio::sync::mpsc::UnboundedSender<Event>,
 }
 
 impl ElectionModule<MinerElection, MinerElectionResult> {
@@ -106,35 +100,11 @@ impl ElectionModule<QuorumElection, QuorumElectionResult> {
     }
 }
 
-impl ElectionModule<ConflictResolution, ConflictResolutionResult> {
-    pub fn new(
-        config: ElectionModuleConfig,
-    ) -> ElectionModule<ConflictResolution, ConflictResolutionResult> {
-        ElectionModule {
-            election_type: ConflictResolution,
-            status: ActorState::Stopped,
-            id: uuid::Uuid::new_v4().to_string(),
-            label: String::from("State module"),
-            db_read_handle: config.db_read_handle,
-            local_claim: config.local_claim,
-            outcome: None,
-            events_tx: config.events_tx,
-        }
-    }
-
-    pub fn name(&self) -> ActorLabel {
-        String::from("Conflict Resultion Election Module")
-    }
-}
-
-
 impl ElectionType for MinerElection {}
 impl ElectionType for QuorumElection {}
-impl ElectionType for ConflictResolution {}
 
 impl ElectionOutcome for MinerElectionResult {}
 impl ElectionOutcome for QuorumElectionResult {}
-impl ElectionOutcome for ConflictResolutionResult {}
 
 #[async_trait]
 impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
@@ -165,16 +135,17 @@ impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
             Event::MinerElection(header_bytes) => {
-                let header_result: Result<BlockHeader> = serde_json::from_slice(&header_bytes);
+                let header_result: serde_json::Result<BlockHeader> = serde_json::from_slice(
+                    &header_bytes
+                );
                 if let Ok(header) = header_result {
                     let claims = self.db_read_handle.claim_store_values();
-                    let mut election_results: BTreeMap<U256, String> =
+                    let mut election_results: BTreeMap<U256, Claim> =
                         elect_miner(claims, header.block_seed);
 
                     let winner = get_winner(&mut election_results);
 
-                    let directed_event = (Topic::Consensus, Event::ElectedMiner(winner));
-                    let _ = self.events_tx.send(directed_event);
+                    let _ = self.events_tx.send(Event::ElectedMiner(winner));
                 }
             },
             _ => {},
@@ -220,115 +191,36 @@ impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
     }
 }
 
-#[async_trait]
-impl Handler<Event> for ElectionModule<ConflictResolution, ConflictResolutionResult> {
-    fn id(&self) -> ActorId {
-        self.id.clone()
-    }
-
-    fn label(&self) -> ActorLabel {
-        self.name()
-    }
-
-    fn status(&self) -> ActorState {
-        self.status.clone()
-    }
-
-    fn set_status(&mut self, actor_status: ActorState) {
-        self.status = actor_status;
-    }
-
-    fn on_stop(&self) {
-        info!(
-            "{}-{} received stop signal. Stopping",
-            self.name(),
-            self.label()
-        );
-    }
-
-    async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
-        match event {
-            Event::ConflictResolution(ConflictBytes, HeaderBytes) => {
-                let cl_res: Result<ConflictList> = serde_json::from_slice(&ConflictBytes);
-
-                let header_res: Result<BlockHeader> = serde_json::from_slice(&HeaderBytes);
-
-                if let Ok(conflicts) = cl_res {
-                    if let Ok(header) = header_res {
-                        let handles: ResolvedConflicts = conflicts
-                            .iter()
-                            .map(|(txnid, conflict)| {
-                                let inner_header = header.clone();
-                                let events_tx = self.events_tx.clone();
-                                let mut inner_conflict: Conflict = conflict.clone();
-                                tokio::spawn(async move {
-                                    resolve_conflict(
-                                        &mut inner_conflict,
-                                        inner_header.clone(),
-                                        events_tx,
-                                    )
-                                    .await;
-                                });
-                            })
-                            .collect();
-                    }
-                }
-            },
-            _ => {},
-        }
-
-        Ok(ActorState::Running)
-    }
-}
-
-fn elect_miner(claims: HashMap<NodeId, Claim>, block_seed: u64) -> BTreeMap<U256, NodeId> {
+fn elect_miner(
+    claims: HashMap<NodeId, Claim>, 
+    block_seed: u64
+) -> BTreeMap<U256, Claim> {
     claims
         .iter()
         .filter(|(_, claim)| claim.eligible)
-        .map(|(nodeid, claim)| single_miner_results(claim, nodeid, block_seed))
-        .collect()
+        .map(|(nodeid, claim)| {
+            single_miner_results(claim, block_seed)
+        }).collect()
 }
 
-fn single_miner_results(claim: Claim, node_id: NodeId, block_seed: u64) -> (U256, NodeId) {
-    (claim.get_election_result(block_seed), node_id)
+fn single_miner_results(
+    claim: &Claim, 
+    block_seed: u64
+) -> (U256, Claim) {
+    (claim.get_election_result(block_seed), claim.clone()) 
 }
 
-fn get_winner(results: &mut BTreeMap<U256, NodeId>) -> (U256, NodeId) {
-    let mut first: Option<(U256, NodeId)> = election_results.pop_first();
-    while let None = first {
-        first = election_results.pop_first();
+fn get_winner(
+    election_results: &mut BTreeMap<U256, Claim>
+) -> (U256, Claim) {
+    let mut iter = election_results.iter();
+    let mut first: (U256, Claim);
+    loop {
+        if let Some((pointer_sum, claim)) = iter.next() {
+            first = (pointer_sum.clone(), claim.clone());
+            break
+        }
     }
 
     return first;
-}
-
-async fn resolve_conflict(
-    conflict: &mut Conflict,
-    header: BlockHeader,
-    events_tx: UnboundedSender<DirectedEvent>,
-) {
-    let propopsers = conflict.proposers.clone();
-    let resoultion_results: BTreeMap<U256, String> = proposers
-        .iter()
-        .map(|(claim, refhash)| {
-            (
-                claim.get_election_results(inner_header.block_seed.clone()),
-                refhash.clone(),
-            );
-        })
-        .collect();
-
-    let winner = {
-        let mut first: Option<(U256, NodeId)> = resolution_results.pop_first();
-
-        while let None = first {
-            first = resolution_results.pop_first();
-        }
-
-        return first;
-    };
-
-    conflict.winner = Some(winner.1);
-    let directed_event = (Topic::Consensus, Event::ConflictResolved(conflict));
-    let _ = events_tx.send(directed_event);
 }

--- a/crates/node/src/runtime/farmer_harvester_module.rs
+++ b/crates/node/src/runtime/farmer_harvester_module.rs
@@ -162,10 +162,13 @@ impl FarmerHarvesterModule {
                 JobResult::Votes((votes, farmer_quorum_threshold)) => {
                     for vote_opt in votes.iter() {
                         if let Some(vote) = vote_opt {
-                            let _ = broadcast_events_tx.send(Event::Vote(
-                                vote.clone(),
-                                QuorumType::Harvester,
-                                farmer_quorum_threshold,
+                            let _ = broadcast_events_tx.send((
+                                Topic::Network,
+                                Event::Vote(
+                                    vote.clone(),
+                                    QuorumType::Harvester,
+                                    farmer_quorum_threshold,
+                                ),
                             ));
                         }
                     }

--- a/crates/node/src/runtime/farmer_harvester_module.rs
+++ b/crates/node/src/runtime/farmer_harvester_module.rs
@@ -6,7 +6,7 @@ use std::{
 use async_trait::async_trait;
 use crossbeam_channel::{Receiver, Sender};
 use dashmap::DashMap;
-use events::{DirectedEvent, Event, QuorumCertifiedTxn, Topic, Vote, VoteReceipt};
+use events::{DirectedEvent, Event, QuorumCertifiedTxn, Vote, VoteReceipt};
 use lr_trie::ReadHandleFactory;
 use mempool::mempool::{LeftRightMempool, TxnStatus};
 use patriecia::{db::MemoryDB, inner::InnerTrie};
@@ -162,14 +162,13 @@ impl FarmerHarvesterModule {
                 JobResult::Votes((votes, farmer_quorum_threshold)) => {
                     for vote_opt in votes.iter() {
                         if let Some(vote) = vote_opt {
-                            let _ = broadcast_events_tx.send((
-                                Topic::Network,
+                            let _ = broadcast_events_tx.send(
                                 Event::Vote(
                                     vote.clone(),
                                     QuorumType::Harvester,
                                     farmer_quorum_threshold,
                                 ),
-                            ));
+                            );
                         }
                     }
                 },

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -95,10 +95,9 @@ impl FarmerModule {
                 JobResult::Votes((votes, farmer)) => {
                     for vote_opt in votes.iter() {
                         if let Some(vote) = vote_opt {
-                            let _ = broadcast_events_tx.send(Event::Vote(
-                                vote.clone(),
-                                QuorumType::Harvester,
-                                farmer,
+                            let _ = broadcast_events_tx.send((
+                                Topic::Network,
+                                Event::Vote(vote.clone(), QuorumType::Harvester, farmer),
                             ));
                         }
                     }

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -95,10 +95,13 @@ impl FarmerModule {
                 JobResult::Votes((votes, farmer)) => {
                     for vote_opt in votes.iter() {
                         if let Some(vote) = vote_opt {
-                            let _ = broadcast_events_tx.send((
-                                Topic::Network,
-                                Event::Vote(vote.clone(), QuorumType::Harvester, farmer),
-                            ));
+                            let _ = broadcast_events_tx.send(
+                                Event::Vote(
+                                    vote.clone(), 
+                                    QuorumType::Harvester, 
+                                    farmer
+                                )
+                            );
                         }
                     }
                 },

--- a/crates/node/src/runtime/mempool_module.rs
+++ b/crates/node/src/runtime/mempool_module.rs
@@ -92,7 +92,7 @@ impl Handler<Event> for MempoolModule {
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 self.events_tx
-                    .send(Event::TxnAddedToMempool(txn_hash.clone()))
+                    .send((Topic::Consensus, Event::TxnAddedToMempool(txn_hash.clone())))
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 info!("Transaction {} sent to mempool", txn_hash);
@@ -104,9 +104,12 @@ impl Handler<Event> for MempoolModule {
                     self.cutoff_transaction = Some(txn_hash.clone());
 
                     self.events_tx
-                        .send(Event::MempoolSizeThesholdReached {
-                            cutoff_transaction: txn_hash,
-                        })
+                        .send((
+                            Topic::Consensus,
+                            Event::MempoolSizeThesholdReached {
+                                cutoff_transaction: txn_hash,
+                            },
+                        ))
                         .map_err(|err| TheaterError::Other(err.to_string()))?;
                 }
             },

--- a/crates/node/src/runtime/mempool_module.rs
+++ b/crates/node/src/runtime/mempool_module.rs
@@ -92,7 +92,7 @@ impl Handler<Event> for MempoolModule {
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 self.events_tx
-                    .send((Topic::Consensus, Event::TxnAddedToMempool(txn_hash.clone())))
+                    .send(Event::TxnAddedToMempool(txn_hash.clone()))
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 info!("Transaction {} sent to mempool", txn_hash);
@@ -104,12 +104,11 @@ impl Handler<Event> for MempoolModule {
                     self.cutoff_transaction = Some(txn_hash.clone());
 
                     self.events_tx
-                        .send((
-                            Topic::Consensus,
+                        .send(
                             Event::MempoolSizeThesholdReached {
                                 cutoff_transaction: txn_hash,
                             },
-                        ))
+                        )
                         .map_err(|err| TheaterError::Other(err.to_string()))?;
                 }
             },

--- a/crates/node/src/runtime/mining_module.rs
+++ b/crates/node/src/runtime/mining_module.rs
@@ -51,7 +51,10 @@ impl MiningModule {
         // TODO: drain mempool instead then commit changes
         handle
             .drain(..cutoff_idx)
-            .map(|(id, record)| record.txn)
+            .map(|(id, record)| {
+                dbg!(id);
+                record.txn
+            })
             .collect()
     }
 
@@ -97,12 +100,17 @@ impl Handler<Event> for MiningModule {
                 return Ok(ActorState::Stopped);
             },
             // Event::TxnAddedToMempool(txn_digest) => {
-            Event::TxnAddedToMempool(_) => {},
+            Event::TxnAddedToMempool(_) => {
+                // dbg!(txn_digest.to_string());
+            },
             Event::MempoolSizeThesholdReached { cutoff_transaction } => {
                 let handle = self.mempool_read_handle_factory.handle();
 
                 if let Some(idx) = handle.get_index_of(&cutoff_transaction) {
+                    dbg!(handle.len());
                     let transaction_snapshot = self.take_snapshot_until_cutoff(idx);
+                    dbg!(transaction_snapshot.len());
+                    dbg!(handle.len());
 
                     self.mark_snapshot_transactions(idx);
                 } else {
@@ -111,7 +119,12 @@ impl Handler<Event> for MiningModule {
                     );
                 }
             },
+            Event::MinerElection() => {
+                
+            },
+            Event::ResolvedConflict(conflict) => {
 
+            }
             Event::BlockConfirmed(_) => {
                 // do something
             },

--- a/crates/node/src/runtime/mining_module.rs
+++ b/crates/node/src/runtime/mining_module.rs
@@ -119,12 +119,8 @@ impl Handler<Event> for MiningModule {
                     );
                 }
             },
-            Event::MinerElection() => {
-                
-            },
-            Event::ResolvedConflict(conflict) => {
-
-            }
+            Event::MinerElection() => {},
+            Event::ResolvedConflict(conflict) => {},
             Event::BlockConfirmed(_) => {
                 // do something
             },

--- a/crates/node/src/runtime/mining_module.rs
+++ b/crates/node/src/runtime/mining_module.rs
@@ -119,7 +119,7 @@ impl Handler<Event> for MiningModule {
                     );
                 }
             },
-            Event::MinerElection() => {},
+            Event::MinerElection(_) => {},
             Event::ResolvedConflict(conflict) => {},
             Event::BlockConfirmed(_) => {
                 // do something

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -367,8 +367,8 @@ fn setup_dkg_module(
             /* Need to be decided either will be preconfigured or decided
              * by Bootstrap Node */
         },
-        config.rendzevous_local_address,
-        config.rendzevous_local_address,
+        config.rendezvous_local_address,
+        config.rendezvous_local_address,
         config.udp_gossip_address.port(),
         events_tx,
     );

--- a/crates/node/src/services/broadcast_controller.rs
+++ b/crates/node/src/services/broadcast_controller.rs
@@ -126,7 +126,7 @@ impl BroadcastEngineController {
                 if peers.is_empty() {
                     warn!("No peers to sync with");
 
-                    self.events_tx.send(Event::EmptyPeerSync)?;
+                    self.events_tx.send(Event::EmptyPeerSync);
 
                     // TODO: revisit this return
                     return Ok(());
@@ -155,7 +155,9 @@ impl BroadcastEngineController {
                 if let Err(err) = peer_connection_result {
                     error!("unable to add peer connection: {err}");
 
-                    self.events_tx.send(Event::PeerSyncFailed(quic_addresses))?;
+                    self.events_tx.send(
+                        Event::PeerSyncFailed(quic_addresses)
+                    );
 
                     return Err(err.into());
                 }

--- a/crates/node/src/services/broadcast_controller.rs
+++ b/crates/node/src/services/broadcast_controller.rs
@@ -2,12 +2,24 @@ use std::net::SocketAddr;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use events::{Event, Topic};
+use events::{DirectedEvent, Event};
 use network::{
     message::{Message, MessageBody},
     network::{BroadcastEngine, ConnectionIncoming},
 };
 use telemetry::{error, info, warn};
+use theater::{ActorLabel, ActorState, Handler};
+use tokio::{
+    sync::{
+        broadcast::{
+            error::{RecvError, TryRecvError},
+            Receiver,
+        },
+        mpsc::Sender,
+    },
+    task::JoinHandle,
+};
+use uuid::Uuid;
 
 use crate::{EventBroadcastSender, NodeError, Result};
 

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -22,8 +22,8 @@ pub fn create_mock_full_node_config() -> NodeConfig {
     let jsonrpc_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let udp_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let raptorq_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let rendzevous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let rendzevous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let rendezvous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let rendezvous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
 
     let main_bootstrap_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 10)), 0);
     let bootstrap_node_addresses = vec![main_bootstrap_addr];
@@ -44,8 +44,8 @@ pub fn create_mock_full_node_config() -> NodeConfig {
         .udp_gossip_address(udp_gossip_address)
         .jsonrpc_server_address(jsonrpc_server_address)
         .keypair(Keypair::random())
-        .rendzevous_local_address(rendzevous_local_address)
-        .rendzevous_server_address(rendzevous_server_address)
+        .rendezvous_local_address(rendezvous_local_address)
+        .rendezvous_server_address(rendezvous_server_address)
         .disable_networking(false)
         .build()
         .unwrap()

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -22,8 +22,8 @@ pub fn create_mock_full_node_config() -> NodeConfig {
     let jsonrpc_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let udp_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let raptorq_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let rendezvous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let rendezvous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let rendzevous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let rendzevous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
 
     let main_bootstrap_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 10)), 0);
     let bootstrap_node_addresses = vec![main_bootstrap_addr];
@@ -44,8 +44,8 @@ pub fn create_mock_full_node_config() -> NodeConfig {
         .udp_gossip_address(udp_gossip_address)
         .jsonrpc_server_address(jsonrpc_server_address)
         .keypair(Keypair::random())
-        .rendezvous_local_address(rendezvous_local_address)
-        .rendezvous_server_address(rendezvous_server_address)
+        .rendzevous_local_address(rendzevous_local_address)
+        .rendzevous_server_address(rendzevous_server_address)
         .disable_networking(false)
         .build()
         .unwrap()

--- a/crates/node/tests/state_sync.rs
+++ b/crates/node/tests/state_sync.rs
@@ -14,7 +14,6 @@ use vrrb_core::txn::NewTxnArgs;
 use vrrb_rpc::rpc::{api::RpcApiClient, client::create_client};
 
 #[tokio::test]
-#[ignore]
 async fn nodes_can_synchronize_state() {
     // NOTE: two instances of a config are required because the node will create a
     // data directory for the database which cannot be the same for both nodes

--- a/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
+++ b/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use lr_trie::{InnerTrieWrapper, ReadHandleFactory};
+use patriecia::inner::InnerTrie;
+use primitives::NodeId;
+use sha2::Digest;
+use storage_utils::{Result, StorageError};
+use vrrb_core::claim::Claim;
+
+use crate::RocksDbAdapter;
+
+#[derive(Debug, Clone)]
+pub struct ClaimStoreReadHandle {
+    inner: InnerTrieWrapper<RocksDbAdapter>,
+}
+
+impl ClaimStoreReadHandle {
+    pub fn new(inner: InnerTrieWrapper<RocksDbAdapter>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns `Some(Claim)` if an account exist under given PublicKey.
+    /// Otherwise returns `None`.
+    pub fn get(&self, key: &NodeId) -> Result<Claim> {
+        self.inner
+            .get(key)
+            .map_err(|err| StorageError::Other(err.to_string()))
+    }
+
+    /// Get a batch of claims by providing Vec of PublicKeysHash
+    ///
+    /// Returns HashMap indexed by PublicKeys and containing either
+    /// Some(account) or None if account was not found.
+    pub fn batch_get(&self, keys: Vec<NodeId>) -> HashMap<NodeId, Option<Claim>> {
+        let mut claims = HashMap::new();
+
+        keys.iter().for_each(|key| {
+            let value = self.get(key).ok();
+            claims.insert(key.to_owned(), value);
+        });
+
+        claims
+    }
+
+    pub fn entries(&self) -> HashMap<NodeId, Claim> {
+        // TODO: revisit and refactor into inner wrapper
+        self.inner
+            .iter()
+            .filter_map(|(key, value)| {
+                if let Ok(key) = bincode::deserialize(&key) {
+                    if let Ok(value) = bincode::deserialize(&value) {
+                        return Some((key, value));
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
+    /// Returns a number of initialized claims in the database
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns the information about the ClaimDb being empty
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ClaimStoreReadHandleFactory {
+    inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>,
+}
+
+impl ClaimStoreReadHandleFactory {
+    pub fn new(inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>) -> Self {
+        Self { inner }
+    }
+
+    pub fn handle(&self) -> ClaimStoreReadHandle {
+        let handle = self
+            .inner
+            .handle()
+            .enter()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
+
+        let inner = InnerTrieWrapper::new(handle);
+
+        ClaimStoreReadHandle { inner }
+    }
+}

--- a/crates/storage/vrrbdb/src/claim_store/mod.rs
+++ b/crates/storage/vrrbdb/src/claim_store/mod.rs
@@ -60,18 +60,17 @@ impl ClaimStore {
 
     // Maybe initialize is better name for that?
     fn insert_uncommited(&mut self, key: NodeIdentifier, claim: Claim) -> Result<()> {
-
-//        if claim.debits != 0 {
-//            return Err(StorageError::Other(
-//                "cannot insert claim with debit".to_string(),
-//            ));
-//        }
-//
-//        if claim.nonce != 0 {
-//            return Err(StorageError::Other(
-//                "cannot insert claim with nonce bigger than 0".to_string(),
-//            ));
-//        }
+        //        if claim.debits != 0 {
+        //            return Err(StorageError::Other(
+        //                "cannot insert claim with debit".to_string(),
+        //            ));
+        //        }
+        //
+        //        if claim.nonce != 0 {
+        //            return Err(StorageError::Other(
+        //                "cannot insert claim with nonce bigger than 0".to_string(),
+        //            ));
+        //        }
 
         self.trie.insert_uncommitted(key, claim);
 
@@ -148,123 +147,125 @@ impl ClaimStore {
         self.trie.len()
     }
 
-// TODO: We need to figure out what "updating" a claim means, if anything
-// for now I am leaving these methods out. There will only be inserts, 
-// however, updating a claim should include:
-// 1. Stake
-// 2. !Eligible
-//
+    // TODO: We need to figure out what "updating" a claim means, if anything
+    // for now I am leaving these methods out. There will only be inserts,
+    // however, updating a claim should include:
+    // 1. Stake
+    // 2. !Eligible
+    //
     /// Updates a given claim if it exists within the store
-//    fn update_uncommited(&mut self, key: NodeId, update: UpdateArgs) -> Result<()> {
-//        let mut claim = self
-//            .read_handle()
-//            .get(&key)
-//            .map_err(|err| StorageError::Other(err.to_string()))?;
-//
-//        claim
-//            .update(update)
-//            .map_err(|err| StorageError::Other(err.to_string()))?;
-//
-//        Ok(())
-//    }
-//
-//    /// Updates an Claim in the database under given PublicKey
-//    ///
-//    /// If succesful commits the change. Otherwise returns an error.
-//    pub fn update(&mut self, key: NodeId, update: UpdateArgs) -> Result<()> {
-//        self.update_uncommited(key, update)?;
-//        self.commit_changes();
-//        Ok(())
-//    }
-//
-//    // IDEA: Insted of grouping updates by key in advance, we'll just clear oplog
-//    // from given keys in case error hapens Cannot borrow oplog mutably though
-//    /// Updates claims with batch of updates provied in a `updates` vector.
-//    ///
-//    /// If there are multiple updates for single PublicKey, those are sorted by
-//    /// the `nonce` and applied in correct order.
-//    ///
-//    /// If at least one update for given claim fails, the whole batch for that
-//    /// `PublicKey` is abandoned.
-//    ///
-//    /// All failed batches are returned in vector, with all data - PublicKey for
-//    /// the claim for which the update failed, vector of all updates for that
-//    /// claim, and error that prevented the update.
-//    pub fn batch_update(
-//        &mut self,
-//        mut updates: Vec<(NodeId, UpdateArgs)>,
-//    ) -> Option<FailedClaimUpdates> {
-//        // Store and return all failures as (PublicKey, AllPushedUpdates, Error)
-//        // This way caller is provided with all info -> They know which claims were
-//        // not modified, have a list of all updates to try again And an error
-//        // thrown so that they can fix it
-//        let mut failed = FailedClaimUpdates::new();
-//
-//        // We sort updates by nonce (that's impl of Ord in ClaimField)
-//        // This way all provided updates are used in order (doesn't matter for different
-//        // claims, but important for multiple ops on single PubKey)
-//        updates.sort_by(|a, b| a.1.cmp(&b.1));
-//
-//        // We'll segregate the batch of updates by key (since it's possible that in
-//        // provided Vec there is a chance that not every PublicKey is unique)
-//        let mut update_batches = HashMap::<&NodeId, Vec<UpdateArgs>>::new();
-//
-//        updates.iter().for_each(|update| {
-//            if let Some(vec_of_updates) = update_batches.get_mut(&update.0) {
-//                vec_of_updates.push(update.1.clone());
-//            } else {
-//                update_batches.insert(&update.0, vec![update.1.clone()]);
-//            }
-//        });
-//
-//        // For each PublicKey we try to apply every ClaimFieldsUpdate on a copy of
-//        // current claim if event one fails, the whole batch is abandoned with
-//        // no changes on ClaimDb when that happens, the key, batch of updates and
-//        // error are pushed into result vec On success we update the claim at
-//        // given index (PublicKey) We don't need to commit the changes, since we
-//        // never go back to that key in this function, saving a lot of time (we
-//        // don't need to wait for all readers to finish)
-//        update_batches.drain().for_each(|(k, v)| {
-//            let mut fail: (bool, Result<()>) = (false, Ok(()));
-//            let mut final_claim = Claim::default();
-//
-//            let claim_result = self.read_handle().get(k);
-//
-//            match claim_result {
-//                Ok(mut claim) => {
-//                    for update in v.as_slice() {
-//                        let update_result = claim
-//                            .update(update.clone())
-//                            .map_err(|err| StorageError::Other(err.to_string()));
-//
-//                        if let Err(err) = update_result {
-//                            fail = (true, Err(err));
-//                            break;
-//                        }
-//                    }
-//                    final_claim = claim;
-//                },
-//                Err(err) => fail = (true, Err(err)),
-//            }
-//
-//            if fail.0 {
-//                failed.push((k.to_owned(), v, fail.1));
-//            } else {
-//                // TODO: implement an update method on underlying lr trie
-//                self.trie.insert(k.to_owned(), final_claim);
-//            };
-//        });
-//
-//        if failed.len() != updates.len() {
-//            self.commit_changes();
-//        };
-//
-//        if failed.is_empty() {
-//            return None;
-//        }
-//
-//        Some(failed)
-//    }
+    //    fn update_uncommited(&mut self, key: NodeId, update: UpdateArgs) ->
+    // Result<()> {        let mut claim = self
+    //            .read_handle()
+    //            .get(&key)
+    //            .map_err(|err| StorageError::Other(err.to_string()))?;
+    //
+    //        claim
+    //            .update(update)
+    //            .map_err(|err| StorageError::Other(err.to_string()))?;
+    //
+    //        Ok(())
+    //    }
+    //
+    //    /// Updates an Claim in the database under given PublicKey
+    //    ///
+    //    /// If succesful commits the change. Otherwise returns an error.
+    //    pub fn update(&mut self, key: NodeId, update: UpdateArgs) -> Result<()> {
+    //        self.update_uncommited(key, update)?;
+    //        self.commit_changes();
+    //        Ok(())
+    //    }
+    //
+    //    // IDEA: Insted of grouping updates by key in advance, we'll just clear
+    // oplog    // from given keys in case error hapens Cannot borrow oplog
+    // mutably though    /// Updates claims with batch of updates provied in a
+    // `updates` vector.    ///
+    //    /// If there are multiple updates for single PublicKey, those are sorted
+    // by    /// the `nonce` and applied in correct order.
+    //    ///
+    //    /// If at least one update for given claim fails, the whole batch for that
+    //    /// `PublicKey` is abandoned.
+    //    ///
+    //    /// All failed batches are returned in vector, with all data - PublicKey
+    // for    /// the claim for which the update failed, vector of all updates
+    // for that    /// claim, and error that prevented the update.
+    //    pub fn batch_update(
+    //        &mut self,
+    //        mut updates: Vec<(NodeId, UpdateArgs)>,
+    //    ) -> Option<FailedClaimUpdates> {
+    //        // Store and return all failures as (PublicKey, AllPushedUpdates,
+    // Error)        // This way caller is provided with all info -> They know
+    // which claims were        // not modified, have a list of all updates to
+    // try again And an error        // thrown so that they can fix it
+    //        let mut failed = FailedClaimUpdates::new();
+    //
+    //        // We sort updates by nonce (that's impl of Ord in ClaimField)
+    //        // This way all provided updates are used in order (doesn't matter for
+    // different        // claims, but important for multiple ops on single
+    // PubKey)        updates.sort_by(|a, b| a.1.cmp(&b.1));
+    //
+    //        // We'll segregate the batch of updates by key (since it's possible
+    // that in        // provided Vec there is a chance that not every PublicKey
+    // is unique)        let mut update_batches = HashMap::<&NodeId,
+    // Vec<UpdateArgs>>::new();
+    //
+    //        updates.iter().for_each(|update| {
+    //            if let Some(vec_of_updates) = update_batches.get_mut(&update.0) {
+    //                vec_of_updates.push(update.1.clone());
+    //            } else {
+    //                update_batches.insert(&update.0, vec![update.1.clone()]);
+    //            }
+    //        });
+    //
+    //        // For each PublicKey we try to apply every ClaimFieldsUpdate on a
+    // copy of        // current claim if event one fails, the whole batch is
+    // abandoned with        // no changes on ClaimDb when that happens, the
+    // key, batch of updates and        // error are pushed into result vec On
+    // success we update the claim at        // given index (PublicKey) We don't
+    // need to commit the changes, since we        // never go back to that key
+    // in this function, saving a lot of time (we        // don't need to wait
+    // for all readers to finish)        update_batches.drain().for_each(|(k,
+    // v)| {            let mut fail: (bool, Result<()>) = (false, Ok(()));
+    //            let mut final_claim = Claim::default();
+    //
+    //            let claim_result = self.read_handle().get(k);
+    //
+    //            match claim_result {
+    //                Ok(mut claim) => {
+    //                    for update in v.as_slice() {
+    //                        let update_result = claim
+    //                            .update(update.clone())
+    //                            .map_err(|err|
+    // StorageError::Other(err.to_string()));
+    //
+    //                        if let Err(err) = update_result {
+    //                            fail = (true, Err(err));
+    //                            break;
+    //                        }
+    //                    }
+    //                    final_claim = claim;
+    //                },
+    //                Err(err) => fail = (true, Err(err)),
+    //            }
+    //
+    //            if fail.0 {
+    //                failed.push((k.to_owned(), v, fail.1));
+    //            } else {
+    //                // TODO: implement an update method on underlying lr trie
+    //                self.trie.insert(k.to_owned(), final_claim);
+    //            };
+    //        });
+    //
+    //        if failed.len() != updates.len() {
+    //            self.commit_changes();
+    //        };
+    //
+    //        if failed.is_empty() {
+    //            return None;
+    //        }
+    //
+    //        Some(failed)
+    //    }
 
     pub fn root_hash(&self) -> Option<H256> {
         self.trie.root()

--- a/crates/storage/vrrbdb/src/claim_store/mod.rs
+++ b/crates/storage/vrrbdb/src/claim_store/mod.rs
@@ -1,0 +1,282 @@
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use lr_trie::{LeftRightTrie, H256};
+use primitives::{NodeId, NodeIdentifier};
+use sha2::Digest;
+use storage_utils::{Result, StorageError};
+use vrrb_core::claim::Claim;
+
+use crate::RocksDbAdapter;
+
+mod claim_store_rh;
+pub use claim_store_rh::*;
+
+pub type Claims = Vec<Claim>;
+pub type FailedClaimUpdates = Vec<(NodeId, Claims, Result<()>)>;
+
+#[derive(Debug, Clone)]
+pub struct ClaimStore {
+    trie: LeftRightTrie<'static, NodeId, Claim, RocksDbAdapter>,
+}
+
+impl Default for ClaimStore {
+    fn default() -> Self {
+        let db_path = storage_utils::get_node_data_dir()
+            .unwrap_or_default()
+            .join("db")
+            .join("claim");
+
+        let db_adapter = RocksDbAdapter::new(db_path, "claim").unwrap_or_default();
+
+        let trie = LeftRightTrie::new(Arc::new(db_adapter));
+
+        Self { trie }
+    }
+}
+
+impl ClaimStore {
+    /// Returns new, empty instance of ClaimDb
+
+    pub fn new(path: &PathBuf) -> Self {
+        let path = path.join("claim");
+        let db_adapter = RocksDbAdapter::new(path.to_owned(), "claim").unwrap_or_default();
+        let trie = LeftRightTrie::new(Arc::new(db_adapter));
+
+        Self { trie }
+    }
+
+    /// Returns new ReadHandle to the VrrDb data. As long as the returned value
+    /// lives, no write to the database will be committed.
+    pub fn read_handle(&self) -> ClaimStoreReadHandle {
+        let inner = self.trie.handle();
+        ClaimStoreReadHandle::new(inner)
+    }
+
+    /// Commits uncommitted changes to the underlying trie by calling
+    /// `publish()` Will wait for EACH ReadHandle to be consumed.
+    fn commit_changes(&mut self) {
+        self.trie.publish();
+    }
+
+    // Maybe initialize is better name for that?
+    fn insert_uncommited(&mut self, key: NodeIdentifier, claim: Claim) -> Result<()> {
+
+//        if claim.debits != 0 {
+//            return Err(StorageError::Other(
+//                "cannot insert claim with debit".to_string(),
+//            ));
+//        }
+//
+//        if claim.nonce != 0 {
+//            return Err(StorageError::Other(
+//                "cannot insert claim with nonce bigger than 0".to_string(),
+//            ));
+//        }
+
+        self.trie.insert_uncommitted(key, claim);
+
+        Ok(())
+    }
+
+    /// Inserts new claim into ClaimDb.
+    pub fn insert(&mut self, key: NodeId, claim: Claim) -> Result<()> {
+        self.insert_uncommited(key, claim)?;
+        self.commit_changes();
+        Ok(())
+    }
+
+    // Iterates over provided (PublicKey,DBRecord) pairs, inserting valid ones into
+    // the db Returns Option with vec of NOT inserted (PublicKey,DBRecord,e)
+    // pairs e being the error which prevented (PublicKey,DBRecord) from being
+    // inserted
+    fn batch_insert_uncommited(
+        &mut self,
+        inserts: Vec<(NodeId, Claim)>,
+    ) -> Option<Vec<(NodeId, Claim, StorageError)>> {
+        let mut failed_inserts: Vec<(NodeId, Claim, StorageError)> = vec![];
+
+        inserts.iter().for_each(|item| {
+            let (k, v) = item;
+            if let Err(e) = self.insert_uncommited(k.to_owned(), v.clone()) {
+                failed_inserts.push((k.to_owned(), v.clone(), e));
+            }
+        });
+
+        if failed_inserts.is_empty() {
+            None
+        } else {
+            Some(failed_inserts)
+        }
+    }
+
+    /// Inserts a batch of claims provided in a vector
+    ///
+    /// Returns None if all inserts were succesfully commited.
+    ///
+    /// Otherwise returns vector of (key, claim_to_be_inserted, error).
+    pub fn batch_insert(
+        &mut self,
+        inserts: Vec<(NodeId, Claim)>,
+    ) -> Option<Vec<(NodeId, Claim, StorageError)>> {
+        let failed_inserts = self.batch_insert_uncommited(inserts);
+        self.commit_changes();
+        failed_inserts
+    }
+
+    /// Retain returns new ClaimDb with which all Claims that fulfill `filter`
+    /// cloned to it.
+    pub fn retain<F>(&self, _filter: F) -> ClaimStore
+    where
+        F: FnMut(&Claim) -> bool,
+    {
+        todo!()
+        // let mut subdb = ClaimStore::new(self.);
+        //
+        // self.trie.entries().iter().for_each(|(key, value)| {
+        //     let claim = value.to_owned();
+        //     if filter(&claim) {
+        //         subdb.insert_uncommited(key.to_string(), claim);
+        //     }
+        // });
+        //
+        // subdb.trie.publish();
+        // subdb
+    }
+
+    /// Returns a number of initialized claims in the database
+    pub fn len(&self) -> usize {
+        self.trie.len()
+    }
+
+// TODO: We need to figure out what "updating" a claim means, if anything
+// for now I am leaving these methods out. There will only be inserts, 
+// however, updating a claim should include:
+// 1. Stake
+// 2. !Eligible
+//
+    /// Updates a given claim if it exists within the store
+//    fn update_uncommited(&mut self, key: NodeId, update: UpdateArgs) -> Result<()> {
+//        let mut claim = self
+//            .read_handle()
+//            .get(&key)
+//            .map_err(|err| StorageError::Other(err.to_string()))?;
+//
+//        claim
+//            .update(update)
+//            .map_err(|err| StorageError::Other(err.to_string()))?;
+//
+//        Ok(())
+//    }
+//
+//    /// Updates an Claim in the database under given PublicKey
+//    ///
+//    /// If succesful commits the change. Otherwise returns an error.
+//    pub fn update(&mut self, key: NodeId, update: UpdateArgs) -> Result<()> {
+//        self.update_uncommited(key, update)?;
+//        self.commit_changes();
+//        Ok(())
+//    }
+//
+//    // IDEA: Insted of grouping updates by key in advance, we'll just clear oplog
+//    // from given keys in case error hapens Cannot borrow oplog mutably though
+//    /// Updates claims with batch of updates provied in a `updates` vector.
+//    ///
+//    /// If there are multiple updates for single PublicKey, those are sorted by
+//    /// the `nonce` and applied in correct order.
+//    ///
+//    /// If at least one update for given claim fails, the whole batch for that
+//    /// `PublicKey` is abandoned.
+//    ///
+//    /// All failed batches are returned in vector, with all data - PublicKey for
+//    /// the claim for which the update failed, vector of all updates for that
+//    /// claim, and error that prevented the update.
+//    pub fn batch_update(
+//        &mut self,
+//        mut updates: Vec<(NodeId, UpdateArgs)>,
+//    ) -> Option<FailedClaimUpdates> {
+//        // Store and return all failures as (PublicKey, AllPushedUpdates, Error)
+//        // This way caller is provided with all info -> They know which claims were
+//        // not modified, have a list of all updates to try again And an error
+//        // thrown so that they can fix it
+//        let mut failed = FailedClaimUpdates::new();
+//
+//        // We sort updates by nonce (that's impl of Ord in ClaimField)
+//        // This way all provided updates are used in order (doesn't matter for different
+//        // claims, but important for multiple ops on single PubKey)
+//        updates.sort_by(|a, b| a.1.cmp(&b.1));
+//
+//        // We'll segregate the batch of updates by key (since it's possible that in
+//        // provided Vec there is a chance that not every PublicKey is unique)
+//        let mut update_batches = HashMap::<&NodeId, Vec<UpdateArgs>>::new();
+//
+//        updates.iter().for_each(|update| {
+//            if let Some(vec_of_updates) = update_batches.get_mut(&update.0) {
+//                vec_of_updates.push(update.1.clone());
+//            } else {
+//                update_batches.insert(&update.0, vec![update.1.clone()]);
+//            }
+//        });
+//
+//        // For each PublicKey we try to apply every ClaimFieldsUpdate on a copy of
+//        // current claim if event one fails, the whole batch is abandoned with
+//        // no changes on ClaimDb when that happens, the key, batch of updates and
+//        // error are pushed into result vec On success we update the claim at
+//        // given index (PublicKey) We don't need to commit the changes, since we
+//        // never go back to that key in this function, saving a lot of time (we
+//        // don't need to wait for all readers to finish)
+//        update_batches.drain().for_each(|(k, v)| {
+//            let mut fail: (bool, Result<()>) = (false, Ok(()));
+//            let mut final_claim = Claim::default();
+//
+//            let claim_result = self.read_handle().get(k);
+//
+//            match claim_result {
+//                Ok(mut claim) => {
+//                    for update in v.as_slice() {
+//                        let update_result = claim
+//                            .update(update.clone())
+//                            .map_err(|err| StorageError::Other(err.to_string()));
+//
+//                        if let Err(err) = update_result {
+//                            fail = (true, Err(err));
+//                            break;
+//                        }
+//                    }
+//                    final_claim = claim;
+//                },
+//                Err(err) => fail = (true, Err(err)),
+//            }
+//
+//            if fail.0 {
+//                failed.push((k.to_owned(), v, fail.1));
+//            } else {
+//                // TODO: implement an update method on underlying lr trie
+//                self.trie.insert(k.to_owned(), final_claim);
+//            };
+//        });
+//
+//        if failed.len() != updates.len() {
+//            self.commit_changes();
+//        };
+//
+//        if failed.is_empty() {
+//            return None;
+//        }
+//
+//        Some(failed)
+//    }
+
+    pub fn root_hash(&self) -> Option<H256> {
+        self.trie.root()
+    }
+
+    pub fn extend(&mut self, claims: Vec<(NodeId, Claim)>) {
+        self.trie.extend(claims)
+    }
+
+    pub fn factory(&self) -> ClaimStoreReadHandleFactory {
+        let inner = self.trie.factory();
+
+        ClaimStoreReadHandleFactory::new(inner)
+    }
+}

--- a/crates/storage/vrrbdb/src/lib.rs
+++ b/crates/storage/vrrbdb/src/lib.rs
@@ -1,4 +1,3 @@
-
 mod claim_store;
 mod event_store;
 pub mod result;

--- a/crates/storage/vrrbdb/src/lib.rs
+++ b/crates/storage/vrrbdb/src/lib.rs
@@ -1,3 +1,5 @@
+
+mod claim_store;
 mod event_store;
 pub mod result;
 mod rocksdb_adapter;
@@ -7,6 +9,7 @@ mod vrrbdb;
 mod vrrbdb_read_handle;
 mod vrrbdb_serialized_values;
 
+pub use claim_store::*;
 pub use event_store::*;
 pub use rocksdb_adapter::*;
 pub use state_store::*;

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -122,7 +122,7 @@ impl StateStore {
         failed_inserts
     }
 
-    /// Retain returns new StateDb with witch all Accounts that fulfill `filter`
+    /// Retain returns new StateDb with which all Accounts that fulfill `filter`
     /// cloned to it.
     pub fn retain<F>(&self, _filter: F) -> StateStore
     where

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -1,15 +1,17 @@
 use std::{collections::HashMap, fmt::Display, path::PathBuf};
 
 use lr_trie::H256;
-use primitives::Address;
+use primitives::{Address, NodeId};
 use serde_json::json;
 use storage_utils::{Result, StorageError};
 use vrrb_core::{
     account::{Account, UpdateArgs},
-    txn::Txn,
+    txn::Txn, claim::Claim,
 };
 
 use crate::{
+    ClaimStore,
+    ClaimStoreReadHandleFactory,
     StateStore,
     StateStoreReadHandleFactory,
     TransactionStore,
@@ -23,6 +25,15 @@ pub struct VrrbDbConfig {
     pub state_store_path: Option<String>,
     pub transaction_store_path: Option<String>,
     pub event_store_path: Option<String>,
+    pub claim_store_path: Option<String>, 
+}
+
+impl VrrbDbConfig {
+    pub fn with_path(&mut self, path: PathBuf) -> Self {
+        self.path = path;
+
+        self.clone()
+    }
 }
 
 impl VrrbDbConfig {
@@ -44,6 +55,7 @@ impl Default for VrrbDbConfig {
             state_store_path: None,
             transaction_store_path: None,
             event_store_path: None,
+            claim_store_path: None,
         }
     }
 }
@@ -52,27 +64,40 @@ impl Default for VrrbDbConfig {
 pub struct VrrbDb {
     state_store: StateStore,
     transaction_store: TransactionStore,
+    claim_store: ClaimStore,
 }
 
 impl VrrbDb {
     pub fn new(config: VrrbDbConfig) -> Self {
         let state_store = StateStore::new(&config.path);
         let transaction_store = TransactionStore::new(&config.path);
+        let claim_store = ClaimStore::new(&config.path);
 
         Self {
             state_store,
             transaction_store,
+            claim_store,
         }
     }
 
     pub fn read_handle(&self) -> VrrbDbReadHandle {
-        VrrbDbReadHandle::new(self.state_store.factory(), self.transaction_store_factory())
+        VrrbDbReadHandle::new(
+            self.state_store.factory(), 
+            self.transaction_store_factory(),
+            self.claim_store_factory(),
+            )
     }
 
-    pub fn new_with_stores(state_store: StateStore, transaction_store: TransactionStore) -> Self {
+    pub fn new_with_stores(
+        state_store: StateStore, 
+        transaction_store: TransactionStore,
+        claim_store: ClaimStore
+    ) -> Self {
+
         Self {
             state_store,
             transaction_store,
+            claim_store,
         }
     }
 
@@ -82,6 +107,10 @@ impl VrrbDb {
 
     pub fn transaction_store(&self) -> &TransactionStore {
         &self.transaction_store
+    }
+
+    pub fn claim_store(&self) -> &ClaimStore {
+        &self.claim_store 
     }
 
     /// Returns the current state store trie's root hash.
@@ -94,6 +123,12 @@ impl VrrbDb {
         self.transaction_store.root_hash()
     }
 
+    /// Returns the claim store trie's root hash.
+    pub fn claims_root_hash(&self) -> Option<H256> {
+        self.claim_store.root_hash() 
+    }
+
+
     /// Produces a reader factory that can be used to generate read handles into
     /// the state trie.
     pub fn state_store_factory(&self) -> StateStoreReadHandleFactory {
@@ -104,6 +139,12 @@ impl VrrbDb {
     /// the the transaction trie.
     pub fn transaction_store_factory(&self) -> TransactionStoreReadHandleFactory {
         self.transaction_store.factory()
+    }
+
+    /// Produces a reader factory that can be used to generate read_handles into 
+    /// the claim trie
+    pub fn claim_store_factory(&self) -> ClaimStoreReadHandleFactory {
+        self.claim_store.factory() 
     }
 
     /// Inserts an account to current state tree.
@@ -139,7 +180,7 @@ impl VrrbDb {
         self.transaction_store.insert(txn)
     }
 
-    /// Adds multiplpe accounts to current state tree. Does not check if
+    /// Adds multiplpe transactions to current state tree. Does not check if
     /// accounts involved in the transaction actually exist.
     pub fn extend_transactions_unchecked(&mut self, transactions: Vec<Txn>) {
         self.transaction_store.extend(transactions);
@@ -151,11 +192,32 @@ impl VrrbDb {
         self.transaction_store.insert(txn)
     }
 
-    /// Adds multiplpe accounts to current state tree. Does not check if
+    /// Adds multiplpe transactions to current transaction tree. Does not check if
     /// accounts involved in the transaction actually exist.
     pub fn extend_transactions(&mut self, transactions: Vec<Txn>) {
         self.transaction_store.extend(transactions);
     }
+
+    /// Inserts a confirmed claim to the current claim tree. 
+    pub fn insert_claim_unchecked(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
+        self.claim_store.insert(node_id, claim)
+    }
+
+    /// Adds multiple claims to the current claim tree.  
+    pub fn extend_claims_unchecked(&mut self, claims: Vec<(NodeId, Claim)>) {
+        self.claim_store.extend(claims)
+    }
+
+    /// Inserts a confirmed claim into the claim tree. 
+    pub fn insert_claim(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
+        self.claim_store.insert(node_id, claim) 
+    }
+    
+    /// Inserts multiple claims into the current claim trie
+    pub fn extend_claims(&mut self, claims: Vec<(NodeId, Claim)>) {
+        self.claim_store.extend(claims)
+    }
+
 }
 
 impl Clone for VrrbDb {
@@ -163,6 +225,7 @@ impl Clone for VrrbDb {
         Self {
             state_store: self.state_store.clone(),
             transaction_store: self.transaction_store.clone(),
+            claim_store: self.claim_store.clone(),
         }
     }
 }
@@ -177,6 +240,7 @@ impl Display for VrrbDb {
             .into_iter()
             .map(|(digest, txn)| (digest.to_string(), txn))
             .collect::<HashMap<String, Txn>>();
+        let claim_entries = self.claim_store_factory().handle().entries();
 
         let out = json!({
             "state": {
@@ -186,6 +250,10 @@ impl Display for VrrbDb {
             "transactions": {
                 "count": transaction_entries.len(),
                 "entries": transaction_entries,
+            },
+            "claims": {
+                "count": claim_entries.len(),
+                "entries": claim_entries,
             },
         });
 

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -6,7 +6,8 @@ use serde_json::json;
 use storage_utils::{Result, StorageError};
 use vrrb_core::{
     account::{Account, UpdateArgs},
-    txn::Txn, claim::Claim,
+    claim::Claim,
+    txn::Txn,
 };
 
 use crate::{
@@ -25,15 +26,7 @@ pub struct VrrbDbConfig {
     pub state_store_path: Option<String>,
     pub transaction_store_path: Option<String>,
     pub event_store_path: Option<String>,
-    pub claim_store_path: Option<String>, 
-}
-
-impl VrrbDbConfig {
-    pub fn with_path(&mut self, path: PathBuf) -> Self {
-        self.path = path;
-
-        self.clone()
-    }
+    pub claim_store_path: Option<String>,
 }
 
 impl VrrbDbConfig {
@@ -82,18 +75,17 @@ impl VrrbDb {
 
     pub fn read_handle(&self) -> VrrbDbReadHandle {
         VrrbDbReadHandle::new(
-            self.state_store.factory(), 
+            self.state_store.factory(),
             self.transaction_store_factory(),
             self.claim_store_factory(),
-            )
+        )
     }
 
     pub fn new_with_stores(
-        state_store: StateStore, 
+        state_store: StateStore,
         transaction_store: TransactionStore,
-        claim_store: ClaimStore
+        claim_store: ClaimStore,
     ) -> Self {
-
         Self {
             state_store,
             transaction_store,
@@ -110,7 +102,7 @@ impl VrrbDb {
     }
 
     pub fn claim_store(&self) -> &ClaimStore {
-        &self.claim_store 
+        &self.claim_store
     }
 
     /// Returns the current state store trie's root hash.
@@ -125,9 +117,8 @@ impl VrrbDb {
 
     /// Returns the claim store trie's root hash.
     pub fn claims_root_hash(&self) -> Option<H256> {
-        self.claim_store.root_hash() 
+        self.claim_store.root_hash()
     }
-
 
     /// Produces a reader factory that can be used to generate read handles into
     /// the state trie.
@@ -141,10 +132,10 @@ impl VrrbDb {
         self.transaction_store.factory()
     }
 
-    /// Produces a reader factory that can be used to generate read_handles into 
+    /// Produces a reader factory that can be used to generate read_handles into
     /// the claim trie
     pub fn claim_store_factory(&self) -> ClaimStoreReadHandleFactory {
-        self.claim_store.factory() 
+        self.claim_store.factory()
     }
 
     /// Inserts an account to current state tree.
@@ -192,13 +183,13 @@ impl VrrbDb {
         self.transaction_store.insert(txn)
     }
 
-    /// Adds multiplpe transactions to current transaction tree. Does not check if
-    /// accounts involved in the transaction actually exist.
+    /// Adds multiplpe transactions to current transaction tree. Does not check
+    /// if accounts involved in the transaction actually exist.
     pub fn extend_transactions(&mut self, transactions: Vec<Txn>) {
         self.transaction_store.extend(transactions);
     }
 
-    /// Inserts a confirmed claim to the current claim tree. 
+    /// Inserts a confirmed claim to the current claim tree.
     pub fn insert_claim_unchecked(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
         self.claim_store.insert(node_id, claim)
     }
@@ -208,16 +199,15 @@ impl VrrbDb {
         self.claim_store.extend(claims)
     }
 
-    /// Inserts a confirmed claim into the claim tree. 
+    /// Inserts a confirmed claim into the claim tree.
     pub fn insert_claim(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
-        self.claim_store.insert(node_id, claim) 
+        self.claim_store.insert(node_id, claim)
     }
-    
+
     /// Inserts multiple claims into the current claim trie
     pub fn extend_claims(&mut self, claims: Vec<(NodeId, Claim)>) {
         self.claim_store.extend(claims)
     }
-
 }
 
 impl Clone for VrrbDb {

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -1,27 +1,37 @@
 use std::collections::HashMap;
 
-use primitives::Address;
+use primitives::{Address, NodeId};
 use vrrb_core::{
     account::Account,
     txn::{TransactionDigest, Txn},
+    claim::Claim,
 };
 
-use crate::{StateStoreReadHandleFactory, TransactionStoreReadHandleFactory};
+use crate::{
+    StateStoreReadHandleFactory, 
+    TransactionStoreReadHandleFactory, 
+    ClaimStoreReadHandleFactory
+};
 
 #[derive(Debug, Clone)]
 pub struct VrrbDbReadHandle {
     state_store_handle_factory: StateStoreReadHandleFactory,
     transaction_store_handle_factory: TransactionStoreReadHandleFactory,
+    claim_store_handle_factory: ClaimStoreReadHandleFactory,
 }
 
 impl VrrbDbReadHandle {
+
     pub fn new(
         state_store_handle_factory: StateStoreReadHandleFactory,
         transaction_store_handle_factory: TransactionStoreReadHandleFactory,
+        claim_store_handle_factory: ClaimStoreReadHandleFactory,
     ) -> Self {
+
         Self {
             state_store_handle_factory,
             transaction_store_handle_factory,
+            claim_store_handle_factory,
         }
     }
 
@@ -34,4 +44,9 @@ impl VrrbDbReadHandle {
     pub fn transaction_store_values(&self) -> HashMap<TransactionDigest, Txn> {
         self.transaction_store_handle_factory.handle().entries()
     }
+
+    pub fn claim_store_values(&self) -> HashMap<NodeId, Claim> {
+        self.claim_store_handle_factory.handle().entries()
+    }
 }
+

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -3,14 +3,14 @@ use std::collections::HashMap;
 use primitives::{Address, NodeId};
 use vrrb_core::{
     account::Account,
-    txn::{TransactionDigest, Txn},
     claim::Claim,
+    txn::{TransactionDigest, Txn},
 };
 
 use crate::{
-    StateStoreReadHandleFactory, 
-    TransactionStoreReadHandleFactory, 
-    ClaimStoreReadHandleFactory
+    ClaimStoreReadHandleFactory,
+    StateStoreReadHandleFactory,
+    TransactionStoreReadHandleFactory,
 };
 
 #[derive(Debug, Clone)]
@@ -21,13 +21,11 @@ pub struct VrrbDbReadHandle {
 }
 
 impl VrrbDbReadHandle {
-
     pub fn new(
         state_store_handle_factory: StateStoreReadHandleFactory,
         transaction_store_handle_factory: TransactionStoreReadHandleFactory,
         claim_store_handle_factory: ClaimStoreReadHandleFactory,
     ) -> Self {
-
         Self {
             state_store_handle_factory,
             transaction_store_handle_factory,
@@ -49,4 +47,3 @@ impl VrrbDbReadHandle {
         self.claim_store_handle_factory.handle().entries()
     }
 }
-

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -1,7 +1,8 @@
-use primitives::{Address, SecretKey};
+use primitives::{Address, SecretKey, NodeId};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secp256k1::{Message, Secp256k1};
 use vrrb_core::{
+    claim::Claim,
     keypair::Keypair,
     txn::{NewTxnArgs, Txn},
 };
@@ -66,4 +67,14 @@ pub fn generate_random_valid_transaction() -> Txn {
         validators: None,
         nonce: 10,
     })
+}
+
+pub fn generate_random_claim() -> Claim {
+    let keypair = Keypair::random(); 
+
+    Claim::new(
+        keypair.miner_kp.1.clone().to_string(), 
+        Address::new(keypair.miner_kp.1).to_string(), 
+        0
+    ) 
 }

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -1,4 +1,4 @@
-use primitives::{Address, SecretKey, NodeId};
+use primitives::{Address, NodeId, SecretKey};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secp256k1::{Message, Secp256k1};
 use vrrb_core::{
@@ -70,11 +70,11 @@ pub fn generate_random_valid_transaction() -> Txn {
 }
 
 pub fn generate_random_claim() -> Claim {
-    let keypair = Keypair::random(); 
+    let keypair = Keypair::random();
 
     Claim::new(
-        keypair.miner_kp.1.clone().to_string(), 
-        Address::new(keypair.miner_kp.1).to_string(), 
-        0
-    ) 
+        keypair.miner_kp.1.clone().to_string(),
+        Address::new(keypair.miner_kp.1).to_string(),
+        0,
+    )
 }

--- a/crates/storage/vrrbdb/tests/test_claim_store.rs
+++ b/crates/storage/vrrbdb/tests/test_claim_store.rs
@@ -1,4 +1,3 @@
-
 use vrrbdb::{VrrbDb, VrrbDbConfig};
 
 mod common;
@@ -17,35 +16,18 @@ fn claims_can_be_added() {
     let claim4 = generate_random_claim();
     let claim5 = generate_random_claim();
 
-    db.insert_claim(
-        claim1.public_key.clone(),
-        claim1
-    )
-    .unwrap();
+    db.insert_claim(claim1.public_key.clone(), claim1).unwrap();
 
-    db.insert_claim(
-        claim2.public_key.clone(),
-        claim2
-    )
-    .unwrap();
+    db.insert_claim(claim2.public_key.clone(), claim2).unwrap();
 
     let entries = db.claim_store_factory().handle().entries();
 
     assert_eq!(entries.len(), 2);
 
     db.extend_claims(vec![
-        (
-            claim3.public_key.clone(),
-            claim3
-        ),
-        (
-            claim4.public_key.clone(),
-            claim4
-        ),
-        (
-            claim5.public_key.clone(),
-            claim5
-        ),
+        (claim3.public_key.clone(), claim3),
+        (claim4.public_key.clone(), claim4),
+        (claim5.public_key.clone(), claim5),
     ]);
 
     let entries = db.claim_store_factory().handle().entries();

--- a/crates/storage/vrrbdb/tests/test_claim_store.rs
+++ b/crates/storage/vrrbdb/tests/test_claim_store.rs
@@ -1,0 +1,54 @@
+
+use vrrbdb::{VrrbDb, VrrbDbConfig};
+
+mod common;
+use common::generate_random_claim;
+use serial_test::serial;
+
+
+#[test]
+#[serial]
+fn claims_can_be_added() {
+    let mut db = VrrbDb::new(VrrbDbConfig::default());
+
+    let claim1 = generate_random_claim();
+    let claim2 = generate_random_claim();
+    let claim3 = generate_random_claim();
+    let claim4 = generate_random_claim();
+    let claim5 = generate_random_claim();
+
+    db.insert_claim(
+        claim1.public_key.clone(),
+        claim1
+    )
+    .unwrap();
+
+    db.insert_claim(
+        claim2.public_key.clone(),
+        claim2
+    )
+    .unwrap();
+
+    let entries = db.claim_store_factory().handle().entries();
+
+    assert_eq!(entries.len(), 2);
+
+    db.extend_claims(vec![
+        (
+            claim3.public_key.clone(),
+            claim3
+        ),
+        (
+            claim4.public_key.clone(),
+            claim4
+        ),
+        (
+            claim5.public_key.clone(),
+            claim5
+        ),
+    ]);
+
+    let entries = db.claim_store_factory().handle().entries();
+
+    assert_eq!(entries.len(), 5);
+}

--- a/crates/storage/vrrbdb/tests/test_transaction_store.rs
+++ b/crates/storage/vrrbdb/tests/test_transaction_store.rs
@@ -29,6 +29,7 @@ fn transactions_can_be_added() {
         state_store_path: None,
         transaction_store_path: None,
         event_store_path: None,
+        claim_store_path: None,
     });
 
     let txn1 = generate_random_valid_transaction();

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -33,12 +33,11 @@ pub struct NodeConfig {
 
     /// This is the address that the node will use to connect to the rendzevous
     /// server.
-    pub rendezvous_local_address: SocketAddr,
+    pub rendzevous_local_address: SocketAddr,
 
     /// This is the address that the node will use to connect to the rendzevous
     /// server.
     pub rendezvous_server_address: SocketAddr,
-
     /// The type of the node, used for custom impl's based on the type the
     /// capabilities may vary.
     //TODO: Change this to a generic that takes anything that implements the NodeAuth trait.
@@ -133,8 +132,8 @@ impl Default for NodeConfig {
                 .join("db"),
             raptorq_gossip_address: ipv4_localhost_with_random_port,
             udp_gossip_address: ipv4_localhost_with_random_port,
-            rendezvous_local_address: ipv4_localhost_with_random_port,
-            rendezvous_server_address: ipv4_localhost_with_random_port,
+            rendzevous_local_address: ipv4_localhost_with_random_port,
+            rendzevous_server_address: ipv4_localhost_with_random_port,
             node_type: NodeType::Full,
             bootstrap_node_addresses: vec![],
             http_api_address: ipv4_localhost_with_random_port,

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -31,11 +31,11 @@ pub struct NodeConfig {
     /// Address the node listens for network events through udp2p
     pub udp_gossip_address: SocketAddr,
 
-    /// This is the address that the node will use to connect to the rendzevous
+    /// This is the address that the node will use to connect to the rendezvous
     /// server.
-    pub rendzevous_local_address: SocketAddr,
+    pub rendezvous_local_address: SocketAddr,
 
-    /// This is the address that the node will use to connect to the rendzevous
+    /// This is the address that the node will use to connect to the rendezvous
     /// server.
     pub rendezvous_server_address: SocketAddr,
     /// The type of the node, used for custom impl's based on the type the
@@ -132,8 +132,8 @@ impl Default for NodeConfig {
                 .join("db"),
             raptorq_gossip_address: ipv4_localhost_with_random_port,
             udp_gossip_address: ipv4_localhost_with_random_port,
-            rendzevous_local_address: ipv4_localhost_with_random_port,
-            rendzevous_server_address: ipv4_localhost_with_random_port,
+            rendezvous_local_address: ipv4_localhost_with_random_port,
+            rendezvous_server_address: ipv4_localhost_with_random_port,
             node_type: NodeType::Full,
             bootstrap_node_addresses: vec![],
             http_api_address: ipv4_localhost_with_random_port,

--- a/crates/vrrb_core/Cargo.toml
+++ b/crates/vrrb_core/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = { workspace = true }
 theater = { workspace = true }
 utils = { workspace = true }
 cuckoofilter = { workspace = true }
+ethereum-types = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -1,13 +1,13 @@
+use ethereum_types::U256;
 use primitives::Address;
 use serde::{Deserialize, Serialize};
 /// a Module for creating, maintaining, and using a claim in the fair,
 /// computationally inexpensive, collission proof, fully decentralized, fully
 /// permissionless Proof of Claim Miner Election algorithm
 use serde_json;
-use sha2::{Sha256, Digest};
-use ethereum_types::U256;
+use sha2::{Digest, Sha256};
 
-use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable, keypair::Keypair};
+use crate::{keypair::Keypair, nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable};
 
 /// A custom error type for invalid claims that are used/attempted to be used
 /// in the mining of a block.
@@ -59,7 +59,7 @@ impl Claim {
     pub fn get_election_result(&self, block_seed: u64) -> U256 {
         let mut xor_val = [0u64; 4];
         self.hash.0.iter().enumerate().for_each(|(idx, x)| {
-           xor_val[idx] = x ^ block_seed; 
+            xor_val[idx] = x ^ block_seed;
         });
 
         U256(xor_val)
@@ -73,7 +73,6 @@ impl Claim {
     // has been discovered, or returning None if we can't match a character.
     #[deprecated(note = "Please use get_election_result")]
     pub fn get_pointer(&self, block_seed: u128) -> Option<u128> {
-        
         // get the hexadecimal format of the block seed
         let block_seed_hex = format!("{block_seed:x}");
         // Get the length of the hexadecimal representation of the block seed
@@ -176,36 +175,12 @@ impl Ownable for Claim {
     }
 }
 
-/// Implements the Nonceble train on the `Claim`
-impl Nonceable for Claim {
-    fn nonceable(&self) -> bool {
-        true
-    }
-
-    fn nonce_up(&mut self) {
-        self.nonce += 1;
-        let iters = if let Some(n) = self.nonce.checked_mul(10) {
-            n
-        } else {
-            self.nonce
-        };
-
-        let mut hash = self.public_key.clone();
-        (0..iters).for_each(|_| {
-            hash = digest(hash.as_bytes());
-        });
-
-        self.hash = hash;
-    }
-}
-
-
 impl From<Keypair> for Claim {
     fn from(item: Keypair) -> Claim {
         Claim::new(
-           item.miner_kp.1.to_string(),
-           Address::new(item.miner_kp.1).to_string(),
-           0
+            item.miner_kp.1.to_string(),
+            Address::new(item.miner_kp.1).to_string(),
+            0,
         )
     }
 }

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -1,11 +1,13 @@
+use primitives::Address;
 use serde::{Deserialize, Serialize};
 /// a Module for creating, maintaining, and using a claim in the fair,
 /// computationally inexpensive, collission proof, fully decentralized, fully
 /// permissionless Proof of Claim Miner Election algorithm
 use serde_json;
-use sha256::digest;
+use sha2::{Sha256, Digest};
+use ethereum_types::U256;
 
-use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable};
+use crate::{nonceable::Nonceable, ownable::Ownable, verifiable::Verifiable, keypair::Keypair};
 
 /// A custom error type for invalid claims that are used/attempted to be used
 /// in the mining of a block.
@@ -22,7 +24,7 @@ pub struct InvalidClaimError {
 pub struct Claim {
     pub public_key: String,
     pub address: String,
-    pub hash: String,
+    pub hash: U256,
     pub nonce: u128,
     pub eligible: bool,
 }
@@ -33,19 +35,15 @@ impl Claim {
     pub fn new(public_key: String, address: String, claim_nonce: u128) -> Claim {
         // Calculate the number of times the pubkey should be hashed to generate the
         // claim hash
-        let iters = if let Some(n) = claim_nonce.checked_mul(10) {
-            n
-        } else {
-            claim_nonce
-        };
-
-        let mut hash = public_key.clone();
         // sequentially hash the public key the correct number of times
         // for the given nonce.
-        (0..iters).for_each(|_| {
-            hash = digest(hash.as_bytes());
+        let mut hasher = Sha256::new();
+        (0..claim_nonce).for_each(|_| {
+            hasher.update(public_key.clone());
         });
 
+        let result = hasher.finalize();
+        let hash = U256::from_big_endian(&result[..]);
         Claim {
             public_key,
             address,
@@ -55,16 +53,28 @@ impl Claim {
         }
     }
 
+    /// Uses XOR of the ClaimHash as a U256 against a block seed of u64
+    /// U256 is represented as a [u64; 4] so we XOR each of the 4
+    /// u64 values in the U256 against the block seed.
+    pub fn get_election_result(&self, block_seed: u64) -> U256 {
+        let mut xor_val = [0u64; 4];
+        self.hash.0.iter().enumerate().for_each(|(idx, x)| {
+           xor_val[idx] = x ^ block_seed; 
+        });
+
+        U256(xor_val)
+    }
+
     /// Calculates the claims pointer sum
     // TODO: Rename to `get_pointer_sum` to better represent the purpose of the
     // function. This can be made significantly faster (if necessary to scale
     // network) by concurrently calculating the index position of each matched
     // character, and summing the total at the end after every match position
     // has been discovered, or returning None if we can't match a character.
+    #[deprecated(note = "Please use get_election_result")]
     pub fn get_pointer(&self, block_seed: u128) -> Option<u128> {
+        
         // get the hexadecimal format of the block seed
-        // TODO: Make the block seed hexadecimal to begin with in the `Block` itself
-        // No reason for miners to have to do this conversion.
         let block_seed_hex = format!("{block_seed:x}");
         // Get the length of the hexadecimal representation of the block seed
         // for later use
@@ -73,10 +83,14 @@ impl Claim {
         let mut pointers = vec![];
         // iterate through (and enumerate for index position) the characters
         // of the block seed.
+        let mut hash_bytes = [0u8; 32];
+        self.hash.to_big_endian(&mut hash_bytes);
+        let hash_string = hex::encode(hash_bytes);
+
         block_seed_hex.chars().enumerate().for_each(|(idx, c)| {
             // Check if the character is in the claim hash, and save the index position into
             // a variable `n`.
-            let res = self.hash.find(c);
+            let res = hash_string.find(c);
             if let Some(n) = res {
                 // convert `n` to a u128 and calculate an integer overflow safe
                 // exponential of the `n` to the power of idx
@@ -182,5 +196,16 @@ impl Nonceable for Claim {
         });
 
         self.hash = hash;
+    }
+}
+
+
+impl From<Keypair> for Claim {
+    fn from(item: Keypair) -> Claim {
+        Claim::new(
+           item.miner_kp.1.to_string(),
+           Address::new(item.miner_kp.1).to_string(),
+           0
+        )
     }
 }

--- a/crates/vrrb_core/src/helpers.rs
+++ b/crates/vrrb_core/src/helpers.rs
@@ -5,7 +5,10 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use ritelinked::LinkedHashMap;
 use secp256k1::generate_keypair;
 
-use crate::{txn::Txn, Error};
+use crate::{
+    txn::{TransactionDigest, Txn},
+    Error,
+};
 
 pub fn gen_hex_encoded_string<T: AsRef<[u8]>>(data: T) -> String {
     hex::encode(data)
@@ -32,7 +35,7 @@ macro_rules! is_enum_variant {
     };
 }
 
-pub fn size_of_txn_list(txns: &LinkedHashMap<String, Txn>) -> usize {
+pub fn size_of_txn_list(txns: &LinkedHashMap<TransactionDigest, Txn>) -> usize {
     txns.iter()
         .map(|(_, set)| set)
         .map(|txn| std::mem::size_of_val(&txn))

--- a/crates/vrrb_core/src/lib.rs
+++ b/crates/vrrb_core/src/lib.rs
@@ -7,7 +7,6 @@ pub mod component;
 pub mod handler;
 pub mod helpers;
 pub mod keypair;
-pub mod ledger;
 pub mod nonceable;
 pub mod ownable;
 pub mod result;


### PR DESCRIPTION
Creates, implements, and integrates a claim_store to serve as a "table" in the vrrbdb.... (#199)

* add a claim_store 'table' to be added to the VrrbDb to efficiently track and use claims for elections

* add claim_store methods and test ability to insert claim

* add methods for claim_store and integrate into vrrbdb, add unit test to ensure claims can be added to vrrbdb

implement  method for ElectionModule<MinerElection> type. Add an event to  that ElectionModule will receive to initiate the election. Use a BTreeMap to determine winner for sorting upon insertion, and therefore reduce sorting time as the number of claims increases

merge claim_store pr into election module branch

Fix db directory config during VrrbDb setup (#188)

Add missing runtime component setup modules for dkg, farmer and harvester modules (#189)

* Rendzevous Integration Done,
* Requesting cross quorum peers is left
* Harvester Public key will be broadcasted after Validator Quorum Election
* PR-177 Comments resolved

* few modules and services setup is left. Broadcast Module Receiver integration is left

Scaffold Election Module

implement conflict resolution logic in election module

integrate ElectionModule into node runtime

The work here is pending unit and integration tests which will be built in parent branch, currently still awaiting the implementation of ElectionModule<QuorumElection, QuorumElectionResult>, but the MinerElection and ConflictResolution versions have been implemented and integrated. Also implemented From<Keypair> for Claim struct for easier conversion given the claim object can be build directly from the miner public key and the miner public key is in the Keypair which is in the NodeConfig, this way we can create the Claim upon startup, and we need the local claim in the ElectionModule right now, though we are not currently doing anything with it and will likely remove it, as the MinerModule, FarmerModule and HarvesterModule will have this information and can check from the return election result whether or not they have been elected. (#204)

Feat change claimpointers to xor (#205)

* Fix db directory config during VrrbDb setup (#188)

* Add missing runtime component setup modules for dkg, farmer and harvester modules (#189)

* Rendzevous Integration Done,
* Requesting cross quorum peers is left
* Harvester Public key will be broadcasted after Validator Quorum Election
* PR-177 Comments resolved

* few modules and services setup is left. Broadcast Module Receiver integration is left

* convert Claim Hash to ethereum_types U256 struct based on claim hash digest. Use sha2's Sha256 hasher to create it, hashing the public key n times, and create new election algorithm using XOR of U256 (which contains a single field which is '[u64; 4]) against the block seed, each of the 4 u64s in the U256 array is XORd'

* update election module to use functions inside handle method

---------

Co-authored-by: Daniel <dmartinez@vrrb.io>

scaffold integration with mining module