### PR TITLE
Remove unnecessary muts from codebase 

### DIFF
--- a/build_log.txt
+++ b/build_log.txt
@@ -1,0 +1,2029 @@
+warning: use of deprecated associated function `txn::Txn::digest`
+   --> crates/vrrb_core/src/txn.rs:373:13
+    |
+373 |         txn.digest()
+    |             ^^^^^^
+    |
+    = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated associated function `txn::Txn::digest`
+   --> crates/vrrb_core/src/txn.rs:409:14
+    |
+409 |         self.digest() == other.digest()
+    |              ^^^^^^
+
+warning: use of deprecated associated function `txn::Txn::digest`
+   --> crates/vrrb_core/src/txn.rs:409:32
+    |
+409 |         self.digest() == other.digest()
+    |                                ^^^^^^
+
+warning: irrefutable `if let` pattern
+   --> crates/vrrb_core/src/txn.rs:286:12
+    |
+286 |         if let payload = self.build_payload() {
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: `#[warn(irrefutable_let_patterns)]` on by default
+    = note: this pattern will always match, so the `if let` is useless
+    = help: consider replacing the `if let` with a `let`
+
+warning: `vrrb_core` (lib) generated 4 warnings
+warning: use of deprecated associated function `reward::Reward::new_epoch`: deprecated as a result of self.update() method being deprecated
+  --> crates/consensus/reward/src/reward.rs:94:14
+   |
+94 |         self.new_epoch(adjustment_to_next_epoch);
+   |              ^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: `reward` (lib) generated 1 warning
+warning: unused variable: `key`
+  --> crates/storage/lr_trie/src/trie.rs:67:29
+   |
+67 |     pub fn get_proof(&self, key: K) -> Result<Vec<Proof>> {
+   |                             ^^^ help: if this is intentional, prefix it with an underscore: `_key`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `root`
+  --> crates/storage/lr_trie/src/trie.rs:72:32
+   |
+72 |     pub fn verify_proof(&self, root: H256, key: K, proof: Vec<Proof>) -> Result<Option<Proof>> {
+   |                                ^^^^ help: if this is intentional, prefix it with an underscore: `_root`
+
+warning: unused variable: `key`
+  --> crates/storage/lr_trie/src/trie.rs:72:44
+   |
+72 |     pub fn verify_proof(&self, root: H256, key: K, proof: Vec<Proof>) -> Result<Option<Proof>> {
+   |                                            ^^^ help: if this is intentional, prefix it with an underscore: `_key`
+
+warning: unused variable: `proof`
+  --> crates/storage/lr_trie/src/trie.rs:72:52
+   |
+72 |     pub fn verify_proof(&self, root: H256, key: K, proof: Vec<Proof>) -> Result<Option<Proof>> {
+   |                                                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_proof`
+
+warning: `lr_trie` (lib) generated 4 warnings
+warning: unused import: `collections::HashMap`
+ --> crates/storage/vrrbdb/src/claim_store/mod.rs:1:11
+  |
+1 | use std::{collections::HashMap, path::PathBuf, sync::Arc};
+  |           ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused import: `base`
+ --> crates/storage/vrrbdb/src/rocksdb_adapter.rs:2:18
+  |
+2 | use primitives::{base, get_vrrb_environment, Environment, DEFAULT_VRRB_DB_PATH};
+  |                  ^^^^
+
+warning: unused import: `self`
+ --> crates/storage/vrrbdb/src/vrrbdb.rs:9:20
+  |
+9 |     claim::{Claim, self},
+  |                    ^^^^
+
+warning: use of deprecated associated function `vrrb_core::txn::Txn::digest`
+  --> crates/storage/vrrbdb/src/transaction_store/mod.rs:54:30
+   |
+54 |         self.trie.insert(txn.digest(), txn);
+   |                              ^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated associated function `vrrb_core::txn::Txn::digest`
+  --> crates/storage/vrrbdb/src/transaction_store/mod.rs:61:29
+   |
+61 |             .map(|txn| (txn.digest(), txn))
+   |                             ^^^^^^
+
+warning: unused import: `sha2::Digest`
+ --> crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs:6:5
+  |
+6 | use sha2::Digest;
+  |     ^^^^^^^^^^^^
+
+warning: unused import: `sha2::Digest`
+ --> crates/storage/vrrbdb/src/claim_store/mod.rs:5:5
+  |
+5 | use sha2::Digest;
+  |     ^^^^^^^^^^^^
+
+warning: unused import: `sha2::Digest`
+ --> crates/storage/vrrbdb/src/state_store/mod.rs:5:5
+  |
+5 | use sha2::Digest;
+  |     ^^^^^^^^^^^^
+
+warning: unused import: `sha2::Digest`
+ --> crates/storage/vrrbdb/src/state_store/state_store_rh.rs:6:5
+  |
+6 | use sha2::Digest;
+  |     ^^^^^^^^^^^^
+
+warning: unused imports: `error`, `info`, `warn`
+  --> crates/mempool/src/mempool.rs:11:17
+   |
+11 | use telemetry::{error, info, warn};
+   |                 ^^^^^  ^^^^  ^^^^
+   |
+   = note: `#[warn(unused_imports)]` on by default
+
+warning: unused import: `tokio`
+  --> crates/mempool/src/mempool.rs:12:5
+   |
+12 | use tokio;
+   |     ^^^^^
+
+warning: unused import: `crate::create_tx_indexer`
+  --> crates/mempool/src/mempool.rs:16:5
+   |
+16 | use crate::create_tx_indexer;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated struct `pool::Pool`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:13:12
+   |
+13 | pub struct Pool<K: Serialize + Eq + Hash, V: Verifiable> {
+   |            ^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated struct `pool::Pool`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:25:47
+   |
+25 | impl<K: Serialize + Eq + Hash, V: Verifiable> Pool<K, V> {
+   |                                               ^^^^
+
+warning: use of deprecated struct `pool::Pool`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:26:35
+   |
+26 |     pub fn new(kind: PoolKind) -> Pool<K, V> {
+   |                                   ^^^^
+
+warning: use of deprecated struct `pool::Pool`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:28:30
+   |
+28 |             PoolKind::Txn => Pool {
+   |                              ^^^^
+
+warning: use of deprecated struct `pool::Pool`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:33:32
+   |
+33 |             PoolKind::Claim => Pool {
+   |                                ^^^^
+
+warning: use of deprecated associated function `vrrb_core::txn::Txn::digest`
+   --> crates/mempool/src/mempool.rs:319:29
+    |
+319 |         match self.get(&txn.digest()) {
+    |                             ^^^^^^
+
+warning: use of deprecated associated function `vrrb_core::txn::Txn::digest`
+   --> crates/mempool/src/mempool.rs:323:60
+    |
+323 |             _ => Err(MempoolError::TransactionNotFound(txn.digest())),
+    |                                                            ^^^^^^
+
+warning: use of deprecated field `pool::Pool::kind`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:29:17
+   |
+29 |                 kind,
+   |                 ^^^^
+
+warning: use of deprecated field `pool::Pool::pending`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:30:17
+   |
+30 |                 pending: LinkedHashMap::new(),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated field `pool::Pool::confirmed`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:31:17
+   |
+31 |                 confirmed: LinkedHashMap::new(),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated field `pool::Pool::kind`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:34:17
+   |
+34 |                 kind,
+   |                 ^^^^
+
+warning: use of deprecated field `pool::Pool::pending`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:35:17
+   |
+35 |                 pending: LinkedHashMap::new(),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated field `pool::Pool::confirmed`: meant to be replaced with a Left-Right wrapped structure
+  --> crates/mempool/src/pool.rs:36:17
+   |
+36 |                 confirmed: LinkedHashMap::new(),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `primitives::PublicKey`
+ --> crates/consensus/quorum/src/quorum.rs:8:5
+  |
+8 | use primitives::PublicKey;
+  |     ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused variable: `claims`
+   --> crates/consensus/quorum/src/quorum.rs:175:41
+    |
+175 |     pub fn get_trusted_peers(&mut self, claims: Vec<Claim>) -> Self {
+    |                                         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_claims`
+    |
+    = note: `#[warn(unused_variables)]` on by default
+
+warning: type alias `Timestamp` is never used
+  --> crates/consensus/quorum/src/quorum.rs:44:6
+   |
+44 | type Timestamp = u128;
+   |      ^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: `vrrbdb` (lib) generated 9 warnings
+warning: `mempool` (lib) generated 16 warnings
+warning: `quorum` (lib) generated 3 warnings
+warning: unused variable: `topic`
+   --> crates/events/src/lib.rs:290:33
+    |
+290 |     pub fn add_topic(&mut self, topic: Topic, size: Option<usize>) {}
+    |                                 ^^^^^ help: if this is intentional, prefix it with an underscore: `_topic`
+    |
+    = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `size`
+   --> crates/events/src/lib.rs:290:47
+    |
+290 |     pub fn add_topic(&mut self, topic: Topic, size: Option<usize>) {}
+    |                                               ^^^^ help: if this is intentional, prefix it with an underscore: `_size`
+
+warning: unused variable: `x`
+   --> crates/events/src/lib.rs:292:29
+    |
+292 |     pub fn subscribe(&self, x: &Topic) -> Receiver<Event> {
+    |                             ^ help: if this is intentional, prefix it with an underscore: `_x`
+
+warning: `events` (lib) generated 3 warnings
+warning: unused import: `Error`
+ --> crates/consensus/dkg_engine/src/dkg.rs:3:27
+  |
+3 | use hbbft::sync_key_gen::{Error, PartOutcome, SyncKeyGen};
+  |                           ^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused import: `QuorumType`
+ --> crates/consensus/dkg_engine/src/types/mod.rs:8:37
+  |
+8 | use primitives::{NodeIdx, NodeType, QuorumType};
+  |                                     ^^^^^^^^^^
+
+warning: `dkg_engine` (lib) generated 2 warnings
+warning: unused import: `events::Event`
+ --> crates/vrrb_rpc/src/http/router.rs:2:5
+  |
+2 | use events::Event;
+  |     ^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused import: `Route`
+ --> crates/vrrb_rpc/src/http/routes/accounts.rs:2:31
+  |
+2 |     routing::{get, post, put, Route},
+  |                               ^^^^^
+
+warning: unused import: `TcpStream`
+ --> crates/vrrb_rpc/src/http/server.rs:3:36
+  |
+3 |     net::{SocketAddr, TcpListener, TcpStream},
+  |                                    ^^^^^^^^^
+
+warning: unused import: `net::SocketAddr`
+ --> crates/vrrb_rpc/src/rpc/api.rs:1:33
+  |
+1 | use std::{collections::HashMap, net::SocketAddr};
+  |                                 ^^^^^^^^^^^^^^^
+
+warning: unused import: `async_trait::async_trait`
+ --> crates/vrrb_rpc/src/rpc/api.rs:3:5
+  |
+3 | use async_trait::async_trait;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `types::SubscriptionResult`
+ --> crates/vrrb_rpc/src/rpc/api.rs:4:48
+  |
+4 | use jsonrpsee::{core::Error, proc_macros::rpc, types::SubscriptionResult};
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `SerializedPublicKey`
+ --> crates/vrrb_rpc/src/rpc/api.rs:5:37
+  |
+5 | use primitives::{Address, NodeType, SerializedPublicKey};
+  |                                     ^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `async_trait::async_trait`
+ --> crates/vrrb_rpc/src/rpc/server.rs:3:5
+  |
+3 | use async_trait::async_trait;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `DirectedEvent`, `Topic`
+ --> crates/vrrb_rpc/src/rpc/server.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |              ^^^^^^^^^^^^^         ^^^^^
+
+warning: unused imports: `SubscriptionSink`, `core::Error`, `types::SubscriptionResult`
+ --> crates/vrrb_rpc/src/rpc/server.rs:6:5
+  |
+6 |     core::Error,
+  |     ^^^^^^^^^^^
+7 |     server::{ServerBuilder, ServerHandle, SubscriptionSink},
+  |                                           ^^^^^^^^^^^^^^^^
+8 |     types::SubscriptionResult,
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `Mempool`
+  --> crates/vrrb_rpc/src/rpc/server.rs:10:33
+   |
+10 | use mempool::{LeftRightMempool, Mempool, MempoolReadHandleFactory};
+   |                                 ^^^^^^^
+
+warning: unused imports: `account::Account`, `txn::NewTxnArgs`
+  --> crates/vrrb_rpc/src/rpc/server.rs:14:17
+   |
+14 | use vrrb_core::{account::Account, txn::NewTxnArgs};
+   |                 ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^
+
+warning: unused import: `net::SocketAddr`
+ --> crates/vrrb_rpc/src/rpc/server_impl.rs:1:33
+  |
+1 | use std::{collections::HashMap, net::SocketAddr, str::FromStr};
+  |                                 ^^^^^^^^^^^^^^^
+
+warning: unused import: `Topic`
+ --> crates/vrrb_rpc/src/rpc/server_impl.rs:4:36
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |                                    ^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/vrrb_rpc/src/rpc/server.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |              ^^^^^^^^^^^^^
+  |
+  = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/vrrb_rpc/src/rpc/server_impl.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/vrrb_rpc/src/rpc/server_impl.rs:30:36
+   |
+30 |     pub events_tx: UnboundedSender<DirectedEvent>,
+   |                                    ^^^^^^^^^^^^^
+
+warning: use of deprecated associated function `vrrb_core::txn::Txn::digest`
+  --> crates/vrrb_rpc/src/rpc/api.rs:48:21
+   |
+48 |             id: txn.digest().to_string(),
+   |                     ^^^^^^
+
+warning: use of deprecated associated function `vrrb_core::txn::Txn::digest`
+   --> crates/vrrb_rpc/src/rpc/server_impl.rs:158:35
+    |
+158 |                 values.insert(txn.digest().to_string(), txn_record);
+    |                                   ^^^^^^
+
+warning: unused variable: `config`
+  --> crates/vrrb_rpc/src/http/router.rs:11:22
+   |
+11 | pub fn create_router(config: &HttpApiRouterConfig) -> Router {
+   |                      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_config`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `err`
+   --> crates/vrrb_rpc/src/rpc/server_impl.rs:124:23
+    |
+124 |             .map_err(|err| Error::Custom("unable to parse transaction digest".to_string()))?;
+    |                       ^^^ help: if this is intentional, prefix it with an underscore: `_err`
+
+warning: function `create_key_router` is never used
+  --> crates/vrrb_rpc/src/http/routes/accounts.rs:32:10
+   |
+32 | async fn create_key_router() {
+   |          ^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: function `create_token_router` is never used
+  --> crates/vrrb_rpc/src/http/routes/accounts.rs:36:10
+   |
+36 | async fn create_token_router() {
+   |          ^^^^^^^^^^^^^^^^^^^
+
+warning: function `get_key` is never used
+  --> crates/vrrb_rpc/src/http/routes/accounts.rs:40:10
+   |
+40 | async fn get_key() {
+   |          ^^^^^^^
+
+warning: function `create_token` is never used
+  --> crates/vrrb_rpc/src/http/routes/accounts.rs:44:10
+   |
+44 | async fn create_token() {
+   |          ^^^^^^^^^^^^
+
+warning: function `update_token` is never used
+  --> crates/vrrb_rpc/src/http/routes/accounts.rs:48:10
+   |
+48 | async fn update_token() {
+   |          ^^^^^^^^^^^^
+
+warning: function `get_token` is never used
+  --> crates/vrrb_rpc/src/http/routes/accounts.rs:52:10
+   |
+52 | async fn get_token() {
+   |          ^^^^^^^^^
+
+warning: function `delete_token` is never used
+  --> crates/vrrb_rpc/src/http/routes/accounts.rs:56:10
+   |
+56 | async fn delete_token() {
+   |          ^^^^^^^^^^^^
+
+warning: value assigned to `workers_count` is never read
+   --> crates/consensus/job_pool/src/pool.rs:129:21
+    |
+129 |                     workers_count = waiting_workers;
+    |                     ^^^^^^^^^^^^^
+    |
+    = note: `#[warn(unused_assignments)]` on by default
+    = help: maybe it is overwritten before being read?
+
+warning: `vrrb_rpc` (lib) generated 28 warnings
+warning: `job_pool` (lib) generated 1 warning
+warning: unused import: `debug`
+  --> crates/wallet/src/v2/mod.rs:12:17
+   |
+12 | use telemetry::{debug, error};
+   |                 ^^^^^
+   |
+   = note: `#[warn(unused_imports)]` on by default
+
+warning: unused imports: `TransactionDigest`, `Txn`, `helpers::write_keypair_file`, `keypair::KeyPairError`
+  --> crates/wallet/src/v2/mod.rs:16:5
+   |
+16 |     helpers::write_keypair_file,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+17 |     keypair::KeyPairError,
+   |     ^^^^^^^^^^^^^^^^^^^^^
+18 |     txn::{Token, TransactionDigest, Txn},
+   |                  ^^^^^^^^^^^^^^^^^  ^^^
+
+warning: unused variable: `result`
+   --> crates/wallet/src/v2/mod.rs:317:13
+    |
+317 |         let result = self
+    |             ^^^^^^ help: if this is intentional, prefix it with an underscore: `_result`
+    |
+    = note: `#[warn(unused_variables)]` on by default
+
+warning: unused import: `instrument`
+  --> crates/network/src/network.rs:23:30
+   |
+23 | use telemetry::{error, info, instrument};
+   |                              ^^^^^^^^^^
+   |
+   = note: `#[warn(unused_imports)]` on by default
+
+warning: `wallet` (lib) generated 3 warnings
+warning: `network` (lib) generated 1 warning
+warning: unused imports: `HashSet`, `SystemTime`, `UNIX_EPOCH`
+ --> crates/validator/src/txn_validator.rs:2:28
+  |
+2 |     collections::{HashMap, HashSet},
+  |                            ^^^^^^^
+...
+5 |     time::{SystemTime, UNIX_EPOCH},
+  |            ^^^^^^^^^^  ^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused import: `left_right::ReadHandle`
+ --> crates/validator/src/txn_validator.rs:8:5
+  |
+8 | use left_right::ReadHandle;
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `lr_trie::LeftRightTrieError`
+ --> crates/validator/src/txn_validator.rs:9:5
+  |
+9 | use lr_trie::LeftRightTrieError;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `error::TrieError`, `inner::InnerTrie`
+  --> crates/validator/src/txn_validator.rs:10:31
+   |
+10 | use patriecia::{db::Database, error::TrieError, inner::InnerTrie};
+   |                               ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused imports: `MinerPk`, `self`, `serde_helpers::decode_from_binary_byte_slice`
+  --> crates/validator/src/txn_validator.rs:14:24
+   |
+14 |     keypair::{KeyPair, MinerPk},
+   |                        ^^^^^^^
+15 |     serde_helpers::decode_from_binary_byte_slice,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+16 |     txn::{self, Txn},
+   |           ^^^^
+
+warning: unused imports: `*`, `Receiver`, `SendError`, `Sender`, `channel`, `self`
+ --> crates/validator/src/validator_core.rs:3:18
+  |
+3 |     sync::mpsc::{channel, Receiver, RecvError, SendError, Sender},
+  |                  ^^^^^^^  ^^^^^^^^             ^^^^^^^^^  ^^^^^^
+4 |     thread::{self, *},
+  |              ^^^^  ^
+
+warning: unused imports: `ReadHandleFactory`, `ReadHandle`
+ --> crates/validator/src/validator_core.rs:7:18
+  |
+7 | use left_right::{ReadHandle, ReadHandleFactory};
+  |                  ^^^^^^^^^^  ^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `*`, `FetchFiltered`
+ --> crates/validator/src/validator_core.rs:8:24
+  |
+8 | use mempool::mempool::{FetchFiltered, *};
+  |                        ^^^^^^^^^^^^^  ^
+
+warning: unused imports: `db::Database`, `inner::InnerTrie`
+ --> crates/validator/src/validator_core.rs:9:17
+  |
+9 | use patriecia::{db::Database, inner::InnerTrie};
+  |                 ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused import: `CoreError`
+  --> crates/validator/src/validator_core_manager.rs:10:28
+   |
+10 |     validator_core::{Core, CoreError, CoreId},
+   |                            ^^^^^^^^^
+
+warning: unused import: `db::Database`
+  --> crates/validator/src/txn_validator.rs:10:17
+   |
+10 | use patriecia::{db::Database, error::TrieError, inner::InnerTrie};
+   |                 ^^^^^^^^^^^^
+
+warning: unused variable: `validator`
+  --> crates/validator/src/validator_core_manager.rs:21:16
+   |
+21 |     pub fn new(validator: TxnValidator, cores: usize) -> Result<Self> {
+   |                ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_validator`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `cores`
+  --> crates/validator/src/validator_core_manager.rs:21:41
+   |
+21 |     pub fn new(validator: TxnValidator, cores: usize) -> Result<Self> {
+   |                                         ^^^^^ help: if this is intentional, prefix it with an underscore: `_cores`
+
+warning: constant `GENESIS_ALLOWED_MINERS` is never used
+  --> crates/miner/src/miner.rs:51:7
+   |
+51 | const GENESIS_ALLOWED_MINERS: [&str; 2] = [
+   |       ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: `validator` (lib) generated 13 warnings
+warning: `miner` (lib) generated 1 warning
+warning: unused import: `DirectedEvent`
+ --> crates/node/src/node.rs:3:14
+  |
+3 | use events::{DirectedEvent, Event, EventRouter, Topic};
+  |              ^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused import: `farmer_module::QuorumMember`
+  --> crates/node/src/node.rs:14:5
+   |
+14 |     farmer_module::QuorumMember,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `types::config::BroadCastError`
+ --> crates/node/src/result.rs:3:39
+  |
+3 | use network::{config::BroadcastError, types::config::BroadCastError};
+  |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `SendError`, `broadcast::error::RecvError`
+ --> crates/node/src/result.rs:6:5
+  |
+6 |     broadcast::error::RecvError,
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 |     mpsc::error::{SendError, TryRecvError},
+  |                   ^^^^^^^^^
+
+warning: unused import: `RecvError`
+ --> crates/node/src/runtime/mod.rs:9:36
+  |
+9 | use crossbeam_channel::{unbounded, RecvError, Sender};
+  |                                    ^^^^^^^^^
+
+warning: unused imports: `JobResult`, `Topic`
+  --> crates/node/src/runtime/mod.rs:10:49
+   |
+10 | use events::{DirectedEvent, Event, EventRouter, JobResult, Topic};
+   |                                                 ^^^^^^^^^  ^^^^^
+
+warning: unused import: `job_scheduler::JobScheduler`
+  --> crates/node/src/runtime/mod.rs:11:5
+   |
+11 | use job_scheduler::JobScheduler;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `storage_utils`
+  --> crates/node/src/runtime/mod.rs:17:5
+   |
+17 |     storage_utils,
+   |     ^^^^^^^^^^^^^
+
+warning: unused imports: `BROADCAST_CONTROLLER_BUFFER_SIZE`, `EventBroadcastReceiver`, `Node`
+  --> crates/node/src/runtime/mod.rs:49:55
+   |
+49 |     broadcast_controller::{BroadcastEngineController, BROADCAST_CONTROLLER_BUFFER_SIZE},
+   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+52 |     EventBroadcastReceiver,
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+53 |     EventBroadcastSender,
+54 |     Node,
+   |     ^^^^
+
+warning: unused imports: `collections::HashSet`, `result::Result as StdResult`
+ --> crates/node/src/runtime/broadcast_module.rs:1:11
+  |
+1 | use std::{collections::HashSet, net::SocketAddr, result::Result as StdResult, time::Duration};
+  |           ^^^^^^^^^^^^^^^^^^^^                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `block::Block`
+ --> crates/node/src/runtime/broadcast_module.rs:4:5
+  |
+4 | use block::Block;
+  |     ^^^^^^^^^^^^
+
+warning: unused import: `bytes::Bytes`
+ --> crates/node/src/runtime/broadcast_module.rs:5:5
+  |
+5 | use bytes::Bytes;
+  |     ^^^^^^^^^^^^
+
+warning: unused imports: `Receiver as MpscReceiver`, `Receiver`, `RecvError`, `Sender`, `TryRecvError`, `channel`, `task::JoinHandle`, `time::timeout`
+  --> crates/node/src/runtime/broadcast_module.rs:18:21
+   |
+18 |             error::{RecvError, TryRecvError},
+   |                     ^^^^^^^^^  ^^^^^^^^^^^^
+19 |             Receiver,
+   |             ^^^^^^^^
+20 |         },
+21 |         mpsc::{channel, Receiver as MpscReceiver, Sender},
+   |                ^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^
+22 |     },
+23 |     task::JoinHandle,
+   |     ^^^^^^^^^^^^^^^^
+24 |     time::timeout,
+   |     ^^^^^^^^^^^^^
+
+warning: unused import: `RuntimeModuleState`
+  --> crates/node/src/runtime/broadcast_module.rs:28:32
+   |
+28 | use crate::{NodeError, Result, RuntimeModuleState};
+   |                                ^^^^^^^^^^^^^^^^^^
+
+warning: unused doc comment
+   --> crates/node/src/runtime/broadcast_module.rs:221:13
+    |
+221 |               /// Broadcasting the Convergence block to the peers.
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+222 | /             Event::BlockConfirmed(block) => {
+223 | |                 let status = self
+224 | |                     .broadcast_engine
+225 | |                     .unreliable_broadcast(
+...   |
+236 | |                 }
+237 | |             },
+    | |_____________- rustdoc does not generate documentation for match arms
+    |
+    = note: `#[warn(unused_doc_comments)]` on by default
+    = help: use `//` for a plain comment
+
+warning: unused imports: `IpAddr`, `Ipv4Addr`
+ --> crates/node/src/runtime/dkg_module.rs:2:23
+  |
+2 |     net::{SocketAddr, Ipv4Addr, IpAddr},
+  |                       ^^^^^^^^  ^^^^^^
+
+warning: unused imports: `Hash`, `error::Error`, `hash_map::DefaultHasher`
+ --> crates/node/src/runtime/election_module.rs:2:19
+  |
+2 |     collections::{hash_map::DefaultHasher, BTreeMap, HashMap},
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^
+3 |     error::Error,
+  |     ^^^^^^^^^^^^
+4 |     fmt::Debug,
+5 |     hash::{Hash, Hasher},
+  |            ^^^^
+
+warning: unused imports: `ConflictList`, `Conflict`, `RefHash`, `ResolvedConflicts`, `invalid::BlockError`
+ --> crates/node/src/runtime/election_module.rs:9:34
+  |
+9 | use block::{header::BlockHeader, Conflict, ConflictList, RefHash, ResolvedConflicts, invalid::BlockError};
+  |                                  ^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^  ^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `ConflictBytes`
+  --> crates/node/src/runtime/election_module.rs:11:14
+   |
+11 | use events::{ConflictBytes, Event};
+   |              ^^^^^^^^^^^^^
+
+warning: unused import: `TheaterError`
+  --> crates/node/src/runtime/election_module.rs:16:57
+   |
+16 | use theater::{ActorId, ActorLabel, ActorState, Handler, TheaterError};
+   |                                                         ^^^^^^^^^^^^
+
+warning: unused imports: `sync::mpsc::UnboundedSender`, `task::JoinHandle`
+  --> crates/node/src/runtime/election_module.rs:17:13
+   |
+17 | use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused import: `Sha256`
+  --> crates/node/src/runtime/election_module.rs:19:12
+   |
+19 | use sha2::{Sha256, Digest};
+   |            ^^^^^^
+
+warning: unused import: `std::thread`
+ --> crates/node/src/runtime/farmer_module.rs:1:5
+  |
+1 | use std::thread;
+  |     ^^^^^^^^^^^
+
+warning: unused import: `Receiver`
+ --> crates/node/src/runtime/farmer_module.rs:4:25
+  |
+4 | use crossbeam_channel::{Receiver, Sender};
+  |                         ^^^^^^^^
+
+warning: unused import: `dashmap::DashMap`
+ --> crates/node/src/runtime/farmer_module.rs:5:5
+  |
+5 | use dashmap::DashMap;
+  |     ^^^^^^^^^^^^^^^^
+
+warning: unused imports: `QuorumCertifiedTxn`, `Topic`, `VoteReceipt`, `Vote`
+ --> crates/node/src/runtime/farmer_module.rs:6:47
+  |
+6 | use events::{DirectedEvent, Event, JobResult, QuorumCertifiedTxn, Topic, Vote, VoteReceipt};
+  |                                               ^^^^^^^^^^^^^^^^^^  ^^^^^  ^^^^  ^^^^^^^^^^^
+
+warning: unused import: `lr_trie::ReadHandleFactory`
+ --> crates/node/src/runtime/farmer_module.rs:7:5
+  |
+7 | use lr_trie::ReadHandleFactory;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `db::MemoryDB`, `inner::InnerTrie`
+ --> crates/node/src/runtime/farmer_module.rs:9:17
+  |
+9 | use patriecia::{db::MemoryDB, inner::InnerTrie};
+  |                 ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused import: `RawSignature`
+  --> crates/node/src/runtime/farmer_module.rs:10:80
+   |
+10 | use primitives::{GroupPublicKey, NodeIdx, PeerId, QuorumThreshold, QuorumType, RawSignature};
+   |                                                                                ^^^^^^^^^^^^
+
+warning: unused imports: `IntoParallelIterator`, `IntoParallelRefIterator`, `ParallelIterator`
+  --> crates/node/src/runtime/farmer_module.rs:11:22
+   |
+11 | use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+   |                      ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused imports: `Deserialize`, `Serialize`
+  --> crates/node/src/runtime/farmer_module.rs:12:13
+   |
+12 | use serde::{Deserialize, Serialize};
+   |             ^^^^^^^^^^^  ^^^^^^^^^
+
+warning: unused import: `Signer`
+  --> crates/node/src/runtime/farmer_module.rs:13:41
+   |
+13 | use signer::signer::{SignatureProvider, Signer};
+   |                                         ^^^^^^
+
+warning: unused imports: `Message`, `TheaterError`
+  --> crates/node/src/runtime/farmer_module.rs:15:64
+   |
+15 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+   |                                                                ^^^^^^^  ^^^^^^^^^^^^
+
+warning: unused imports: `UnboundedReceiver`, `broadcast::error::TryRecvError`
+  --> crates/node/src/runtime/farmer_module.rs:17:5
+   |
+17 |     broadcast::error::TryRecvError,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+18 |     mpsc::{UnboundedReceiver, UnboundedSender},
+   |            ^^^^^^^^^^^^^^^^^
+
+warning: unused import: `tracing::error`
+  --> crates/node/src/runtime/farmer_module.rs:20:5
+   |
+20 | use tracing::error;
+   |     ^^^^^^^^^^^^^^
+
+warning: unused import: `bloom::Bloom`
+  --> crates/node/src/runtime/farmer_module.rs:22:5
+   |
+22 |     bloom::Bloom,
+   |     ^^^^^^^^^^^^
+
+warning: unused imports: `NodeError`, `result::Result`
+  --> crates/node/src/runtime/farmer_module.rs:26:13
+   |
+26 | use crate::{result::Result, scheduler::Job, NodeError};
+   |             ^^^^^^^^^^^^^^                  ^^^^^^^^^
+
+warning: unused imports: `Borrow`, `thread`
+ --> crates/node/src/runtime/harvester_module.rs:2:14
+  |
+2 |     borrow::{Borrow, BorrowMut},
+  |              ^^^^^^
+3 |     thread,
+  |     ^^^^^^
+
+warning: unused import: `Topic`
+ --> crates/node/src/runtime/harvester_module.rs:9:67
+  |
+9 | use events::{DirectedEvent, Event, JobResult, QuorumCertifiedTxn, Topic, Vote, VoteReceipt};
+  |                                                                   ^^^^^
+
+warning: unused import: `lr_trie::ReadHandleFactory`
+  --> crates/node/src/runtime/harvester_module.rs:10:5
+   |
+10 | use lr_trie::ReadHandleFactory;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `db::MemoryDB`, `inner::InnerTrie`
+  --> crates/node/src/runtime/harvester_module.rs:12:17
+   |
+12 | use patriecia::{db::MemoryDB, inner::InnerTrie};
+   |                 ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused imports: `FarmerQuorumThreshold`, `NodeIdx`, `PeerId`, `QuorumType`, `RawSignature`
+  --> crates/node/src/runtime/harvester_module.rs:14:5
+   |
+14 |     FarmerQuorumThreshold,
+   |     ^^^^^^^^^^^^^^^^^^^^^
+...
+17 |     NodeIdx,
+   |     ^^^^^^^
+18 |     PeerId,
+   |     ^^^^^^
+19 |     QuorumThreshold,
+20 |     QuorumType,
+   |     ^^^^^^^^^^
+21 |     RawSignature,
+   |     ^^^^^^^^^^^^
+
+warning: unused imports: `IntoParallelIterator`, `IntoParallelRefIterator`
+  --> crates/node/src/runtime/harvester_module.rs:23:22
+   |
+23 | use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+   |                      ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `Deserialize`, `Serialize`
+  --> crates/node/src/runtime/harvester_module.rs:24:13
+   |
+24 | use serde::{Deserialize, Serialize};
+   |             ^^^^^^^^^^^  ^^^^^^^^^
+
+warning: unused import: `Signer`
+  --> crates/node/src/runtime/harvester_module.rs:25:41
+   |
+25 | use signer::signer::{SignatureProvider, Signer};
+   |                                         ^^^^^^
+
+warning: unused imports: `Message`, `TheaterError`
+  --> crates/node/src/runtime/harvester_module.rs:27:64
+   |
+27 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+   |                                                                ^^^^^^^  ^^^^^^^^^^^^
+
+warning: unused import: `broadcast::error::TryRecvError`
+  --> crates/node/src/runtime/harvester_module.rs:29:5
+   |
+29 |     broadcast::error::TryRecvError,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `NodeError`, `farmer_module::PULL_TXN_BATCH_SIZE`, `result::Result`
+  --> crates/node/src/runtime/harvester_module.rs:38:13
+   |
+38 | use crate::{farmer_module::PULL_TXN_BATCH_SIZE, result::Result, scheduler::Job, NodeError};
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^                  ^^^^^^^^^
+
+warning: unused imports: `hash::Hash`, `path::PathBuf`
+ --> crates/node/src/runtime/mempool_module.rs:1:11
+  |
+1 | use std::{hash::Hash, path::PathBuf};
+  |           ^^^^^^^^^^  ^^^^^^^^^^^^^
+
+warning: unused imports: `DirectedEvent`, `Topic`
+ --> crates/node/src/runtime/mempool_module.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |              ^^^^^^^^^^^^^         ^^^^^
+
+warning: unused import: `lr_trie::ReadHandleFactory`
+ --> crates/node/src/runtime/mempool_module.rs:5:5
+  |
+5 | use lr_trie::ReadHandleFactory;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `db::MemoryDB`, `inner::InnerTrie`
+ --> crates/node/src/runtime/mempool_module.rs:7:17
+  |
+7 | use patriecia::{db::MemoryDB, inner::InnerTrie};
+  |                 ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused imports: `VrrbDbReadHandle`, `VrrbDb`
+ --> crates/node/src/runtime/mempool_module.rs:8:23
+  |
+8 | use storage::vrrbdb::{VrrbDb, VrrbDbReadHandle};
+  |                       ^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused import: `Message`
+  --> crates/node/src/runtime/mempool_module.rs:10:64
+   |
+10 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+   |                                                                ^^^^^^^
+
+warning: unused import: `tokio::sync::broadcast::error::TryRecvError`
+  --> crates/node/src/runtime/mempool_module.rs:11:5
+   |
+11 | use tokio::sync::broadcast::error::TryRecvError;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `Txn`
+  --> crates/node/src/runtime/mempool_module.rs:12:41
+   |
+12 | use vrrb_core::txn::{TransactionDigest, Txn};
+   |                                         ^^^
+
+warning: unused imports: `NodeError`, `result::Result`
+  --> crates/node/src/runtime/mempool_module.rs:14:13
+   |
+14 | use crate::{result::Result, EventBroadcastSender, NodeError, MEMPOOL_THRESHOLD_SIZE};
+   |             ^^^^^^^^^^^^^^                        ^^^^^^^^^
+
+warning: unused imports: `Block`, `convergence_block`
+ --> crates/node/src/runtime/mining_module.rs:2:13
+  |
+2 | use block::{Block, convergence_block};
+  |             ^^^^^  ^^^^^^^^^^^^^^^^^
+
+warning: unused import: `DirectedEvent`
+ --> crates/node/src/runtime/mining_module.rs:3:14
+  |
+3 | use events::{DirectedEvent, Event};
+  |              ^^^^^^^^^^^^^
+
+warning: unused imports: `Receiver`, `error::TryRecvError`
+ --> crates/node/src/runtime/mining_module.rs:9:30
+  |
+9 | use tokio::sync::broadcast::{error::TryRecvError, Receiver};
+  |                              ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^
+
+warning: unused imports: `hash::Hash`, `path::PathBuf`
+ --> crates/node/src/runtime/state_module.rs:1:11
+  |
+1 | use std::{hash::Hash, path::PathBuf};
+  |           ^^^^^^^^^^  ^^^^^^^^^^^^^
+
+warning: unused import: `Topic`
+ --> crates/node/src/runtime/state_module.rs:4:36
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |                                    ^^^^^
+
+warning: unused import: `Message`
+  --> crates/node/src/runtime/state_module.rs:10:64
+   |
+10 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+   |                                                                ^^^^^^^
+
+warning: unused import: `tokio::sync::broadcast::error::TryRecvError`
+  --> crates/node/src/runtime/state_module.rs:11:5
+   |
+11 | use tokio::sync::broadcast::error::TryRecvError;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `hash::Hash`, `path::PathBuf`
+ --> crates/node/src/runtime/swarm_module.rs:1:11
+  |
+1 | use std::{hash::Hash, net::SocketAddr, path::PathBuf};
+  |           ^^^^^^^^^^                   ^^^^^^^^^^^^^
+
+warning: unused import: `Topic`
+ --> crates/node/src/runtime/swarm_module.rs:4:36
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |                                    ^^^^^
+
+warning: unused import: `lr_trie::ReadHandleFactory`
+ --> crates/node/src/runtime/swarm_module.rs:6:5
+  |
+6 | use lr_trie::ReadHandleFactory;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `db::MemoryDB`, `inner::InnerTrie`
+ --> crates/node/src/runtime/swarm_module.rs:7:17
+  |
+7 | use patriecia::{db::MemoryDB, inner::InnerTrie};
+  |                 ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
+
+warning: unused imports: `Message`, `TheaterError`
+ --> crates/node/src/runtime/swarm_module.rs:9:64
+  |
+9 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+  |                                                                ^^^^^^^  ^^^^^^^^^^^^
+
+warning: unused import: `tokio::sync::broadcast::error::TryRecvError`
+  --> crates/node/src/runtime/swarm_module.rs:10:5
+   |
+10 | use tokio::sync::broadcast::error::TryRecvError;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `tracing::error`
+  --> crates/node/src/runtime/swarm_module.rs:11:5
+   |
+11 | use tracing::error;
+   |     ^^^^^^^^^^^^^^
+
+warning: unused import: `std::net::SocketAddr`
+ --> crates/node/src/services/broadcast_controller.rs:1:5
+  |
+1 | use std::net::SocketAddr;
+  |     ^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `async_trait::async_trait`
+ --> crates/node/src/services/broadcast_controller.rs:3:5
+  |
+3 | use async_trait::async_trait;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `crossbeam_channel::unbounded`
+ --> crates/node/src/services/broadcast_controller.rs:5:5
+  |
+5 | use crossbeam_channel::unbounded;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `DirectedEvent`
+ --> crates/node/src/services/broadcast_controller.rs:6:14
+  |
+6 | use events::{DirectedEvent, Event};
+  |              ^^^^^^^^^^^^^
+
+warning: unused import: `packet::RaptorBroadCastedData`
+  --> crates/node/src/services/broadcast_controller.rs:10:5
+   |
+10 |     packet::RaptorBroadCastedData,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `ActorLabel`, `ActorState`, `Handler`
+  --> crates/node/src/services/broadcast_controller.rs:13:15
+   |
+13 | use theater::{ActorLabel, ActorState, Handler};
+   |               ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^
+
+warning: unused imports: `RecvError`, `TryRecvError`, `mpsc::Sender`, `task::JoinHandle`
+  --> crates/node/src/services/broadcast_controller.rs:17:21
+   |
+17 |             error::{RecvError, TryRecvError},
+   |                     ^^^^^^^^^  ^^^^^^^^^^^^
+...
+20 |         mpsc::Sender,
+   |         ^^^^^^^^^^^^
+21 |     },
+22 |     task::JoinHandle,
+   |     ^^^^^^^^^^^^^^^^
+
+warning: unused import: `uuid::Uuid`
+  --> crates/node/src/services/broadcast_controller.rs:24:5
+   |
+24 | use uuid::Uuid;
+   |     ^^^^^^^^^^
+
+warning: unused import: `DirectedEvent`
+ --> crates/node/src/services/scheduler.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, JobResult, Vote};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/lib.rs:11:14
+   |
+11 | use events::{DirectedEvent, Event};
+   |              ^^^^^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/lib.rs:20:75
+   |
+20 | pub(crate) type EventBroadcastSender = tokio::sync::mpsc::UnboundedSender<DirectedEvent>;
+   |                                                                           ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/node.rs:3:14
+  |
+3 | use events::{DirectedEvent, Event, EventRouter, Topic};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `network::config::BroadCastError`: here for backwards compatibility
+ --> crates/node/src/result.rs:3:54
+  |
+3 | use network::{config::BroadcastError, types::config::BroadCastError};
+  |                                                      ^^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/mod.rs:10:14
+   |
+10 | use events::{DirectedEvent, Event, EventRouter, JobResult, Topic};
+   |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+   --> crates/node/src/runtime/mod.rs:210:73
+    |
+210 |     let (events_tx, events_rx) = tokio::sync::mpsc::unbounded_channel::<DirectedEvent>();
+    |                                                                         ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+   --> crates/node/src/runtime/mod.rs:547:34
+    |
+547 |     events_rx: UnboundedReceiver<DirectedEvent>,
+    |                                  ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+   --> crates/node/src/runtime/mod.rs:577:32
+    |
+577 |     events_tx: UnboundedSender<DirectedEvent>,
+    |                                ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/runtime/broadcast_module.rs:6:14
+  |
+6 | use events::{DirectedEvent, Event};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/broadcast_module.rs:31:55
+   |
+31 |     pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+   |                                                       ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/broadcast_module.rs:44:51
+   |
+44 |     events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+   |                                                   ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/runtime/farmer_module.rs:6:14
+  |
+6 | use events::{DirectedEvent, Event, JobResult, QuorumCertifiedTxn, Topic, Vote, VoteReceipt};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/farmer_module.rs:59:42
+   |
+59 |     broadcast_events_tx: UnboundedSender<DirectedEvent>,
+   |                                          ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/farmer_module.rs:71:46
+   |
+71 |         broadcast_events_tx: UnboundedSender<DirectedEvent>,
+   |                                              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/runtime/harvester_module.rs:9:14
+  |
+9 | use events::{DirectedEvent, Event, JobResult, QuorumCertifiedTxn, Topic, Vote, VoteReceipt};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/harvester_module.rs:88:42
+   |
+88 |     broadcast_events_tx: UnboundedSender<DirectedEvent>,
+   |                                          ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/harvester_module.rs:89:34
+   |
+89 |     events_rx: UnboundedReceiver<DirectedEvent>,
+   |                                  ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+   --> crates/node/src/runtime/harvester_module.rs:101:38
+    |
+101 |         events_rx: UnboundedReceiver<DirectedEvent>,
+    |                                      ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+   --> crates/node/src/runtime/harvester_module.rs:102:46
+    |
+102 |         broadcast_events_tx: UnboundedSender<DirectedEvent>,
+    |                                              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/runtime/mempool_module.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/runtime/mining_module.rs:3:14
+  |
+3 | use events::{DirectedEvent, Event};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/runtime/state_module.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated trait `runtime_module::RuntimeModule`
+  --> crates/node/src/runtime/state_module.rs:14:40
+   |
+14 | use crate::{result::Result, NodeError, RuntimeModule};
+   |                                        ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/state_module.rs:18:55
+   |
+18 |     pub events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+   |                                                       ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/state_module.rs:27:51
+   |
+27 |     events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+   |                                                   ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/runtime/swarm_module.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, Topic};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/swarm_module.rs:35:51
+   |
+35 |     events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+   |                                                   ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+  --> crates/node/src/runtime/swarm_module.rs:43:55
+   |
+43 |         events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+   |                                                       ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/services/broadcast_controller.rs:6:14
+  |
+6 | use events::{DirectedEvent, Event};
+  |              ^^^^^^^^^^^^^
+
+warning: use of deprecated type alias `events::DirectedEvent`
+ --> crates/node/src/services/scheduler.rs:4:14
+  |
+4 | use events::{DirectedEvent, Event, JobResult, Vote};
+  |              ^^^^^^^^^^^^^
+
+warning: unreachable statement
+   --> crates/node/src/runtime/mod.rs:159:13
+    |
+150 | /             loop {
+151 | |                 if let Ok(data) = raptor_receiver.recv() {
+152 | |                     match data {
+153 | |                         RaptorBroadCastedData::Block(block) => {
+...   |
+157 | |                 }
+158 | |             }
+    | |_____________- any code following this expression is unreachable
+159 |               return true;
+    |               ^^^^^^^^^^^^ unreachable statement
+    |
+    = note: `#[warn(unreachable_code)]` on by default
+
+warning: use of deprecated associated function `events::EventRouter::add_topic`
+   --> crates/node/src/node.rs:237:22
+    |
+237 |         event_router.add_topic(Topic::Control, Some(1));
+    |                      ^^^^^^^^^
+
+warning: use of deprecated associated function `events::EventRouter::add_topic`
+   --> crates/node/src/node.rs:238:22
+    |
+238 |         event_router.add_topic(Topic::State, Some(1));
+    |                      ^^^^^^^^^
+
+warning: use of deprecated associated function `events::EventRouter::add_topic`
+   --> crates/node/src/node.rs:239:22
+    |
+239 |         event_router.add_topic(Topic::Network, Some(100));
+    |                      ^^^^^^^^^
+
+warning: use of deprecated associated function `events::EventRouter::add_topic`
+   --> crates/node/src/node.rs:240:22
+    |
+240 |         event_router.add_topic(Topic::Consensus, Some(100));
+    |                      ^^^^^^^^^
+
+warning: use of deprecated associated function `events::EventRouter::add_topic`
+   --> crates/node/src/node.rs:241:22
+    |
+241 |         event_router.add_topic(Topic::Storage, Some(100));
+    |                      ^^^^^^^^^
+
+warning: use of deprecated associated function `events::EventRouter::add_topic`
+   --> crates/node/src/node.rs:242:22
+    |
+242 |         event_router.add_topic(Topic::Throttle, Some(100));
+    |                      ^^^^^^^^^
+
+warning: unused import: `Hasher`
+ --> crates/node/src/runtime/election_module.rs:5:18
+  |
+5 |     hash::{Hash, Hasher},
+  |                  ^^^^^^
+
+warning: unused import: `Digest`
+  --> crates/node/src/runtime/election_module.rs:19:20
+   |
+19 | use sha2::{Sha256, Digest};
+   |                    ^^^^^^
+
+warning: unused import: `Actor`
+  --> crates/node/src/runtime/farmer_module.rs:15:15
+   |
+15 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+   |               ^^^^^
+
+warning: unused import: `ParallelIterator`
+  --> crates/node/src/runtime/harvester_module.rs:23:69
+   |
+23 | use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+   |                                                                     ^^^^^^^^^^^^^^^^
+
+warning: unused import: `Actor`
+  --> crates/node/src/runtime/harvester_module.rs:27:15
+   |
+27 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+   |               ^^^^^
+
+warning: unused import: `Actor`
+  --> crates/node/src/runtime/mempool_module.rs:10:15
+   |
+10 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+   |               ^^^^^
+
+warning: unused import: `Actor`
+  --> crates/node/src/runtime/state_module.rs:10:15
+   |
+10 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+   |               ^^^^^
+
+warning: unused import: `RuntimeModule`
+  --> crates/node/src/runtime/state_module.rs:14:40
+   |
+14 | use crate::{result::Result, NodeError, RuntimeModule};
+   |                                        ^^^^^^^^^^^^^
+
+warning: unused import: `Actor`
+ --> crates/node/src/runtime/swarm_module.rs:9:15
+  |
+9 | use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
+  |               ^^^^^
+
+warning: unused import: `Handler`
+  --> crates/node/src/runtime/mod.rs:21:33
+   |
+21 | use theater::{Actor, ActorImpl, Handler};
+   |                                 ^^^^^^^
+
+warning: unused variable: `part_commitment`
+   --> crates/node/src/runtime/broadcast_module.rs:112:37
+    |
+112 | ...                   part_commitment,
+    |                       ^^^^^^^^^^^^^^^ help: try ignoring the field: `part_commitment: _`
+    |
+    = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `sender_id`
+   --> crates/node/src/runtime/broadcast_module.rs:113:37
+    |
+113 | ...                   sender_id,
+    |                       ^^^^^^^^^ help: try ignoring the field: `sender_id: _`
+
+warning: unused variable: `e`
+   --> crates/node/src/runtime/dkg_module.rs:523:29
+    |
+523 |                         Err(e) => {
+    |                             ^ help: if this is intentional, prefix it with an underscore: `_e`
+
+warning: unused variable: `nodeid`
+   --> crates/node/src/runtime/election_module.rs:219:16
+    |
+219 |         .map(|(nodeid, claim)| {
+    |                ^^^^^^ help: if this is intentional, prefix it with an underscore: `_nodeid`
+
+warning: unused variable: `quorum`
+   --> crates/node/src/runtime/harvester_module.rs:225:31
+    |
+225 |             Event::Vote(vote, quorum, farmer_quorum_threshold) => {
+    |                               ^^^^^^ help: if this is intentional, prefix it with an underscore: `_quorum`
+
+warning: unused variable: `mempool_size`
+  --> crates/node/src/runtime/mempool_module.rs:83:21
+   |
+83 |                 let mempool_size = self
+   |                     ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_mempool_size`
+
+warning: unused variable: `winner_claim_hash`
+   --> crates/node/src/runtime/mining_module.rs:103:34
+    |
+103 |             Event::ElectedMiner((winner_claim_hash, winner_claim)) => {
+    |                                  ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_winner_claim_hash`
+
+warning: variable `raptor_handle` is assigned to, but never used
+   --> crates/node/src/runtime/mod.rs:130:13
+    |
+130 |     let mut raptor_handle = None;
+    |             ^^^^^^^^^^^^^
+    |
+    = note: consider using `_raptor_handle` instead
+
+warning: value assigned to `raptor_handle` is never read
+   --> crates/node/src/runtime/mod.rs:143:9
+    |
+143 |         raptor_handle = new_raptor_handle;
+    |         ^^^^^^^^^^^^^
+    |
+    = note: `#[warn(unused_assignments)]` on by default
+    = help: maybe it is overwritten before being read?
+
+warning: unused variable: `mempool_read_handle_factory`
+   --> crates/node/src/runtime/mod.rs:325:5
+    |
+325 |     mempool_read_handle_factory: MempoolReadHandleFactory,
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_mempool_read_handle_factory`
+
+warning: unused variable: `address`
+   --> crates/node/src/runtime/mod.rs:392:9
+    |
+392 |     let address = Address::new(*miner_public_key).to_string();
+    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_address`
+
+warning: unused variable: `config`
+   --> crates/node/src/runtime/mod.rs:488:5
+    |
+488 |     config: &NodeConfig,
+    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_config`
+
+warning: unused variable: `conn`
+  --> crates/node/src/services/broadcast_controller.rs:54:23
+   |
+54 |                 Some((conn, conn_incoming)) = self.engine.get_incoming_connections().next() => {
+   |                       ^^^^ help: if this is intentional, prefix it with an underscore: `_conn`
+
+warning: unused variable: `backpressure`
+   --> crates/node/src/services/scheduler.rs:125:29
+    |
+125 |                         let backpressure = self.job_scheduler.calculate_back_pressure();
+    |                             ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_backpressure`
+
+warning: variable does not need to be mutable
+   --> crates/node/src/runtime/mod.rs:260:9
+    |
+260 |     let mut event_router = EventRouter::default();
+    |         ----^^^^^^^^^^^^
+    |         |
+    |         help: remove this `mut`
+    |
+    = note: `#[warn(unused_mut)]` on by default
+
+warning: type alias `EventBroadcastReceiver` is never used
+  --> crates/node/src/lib.rs:21:17
+   |
+21 | pub(crate) type EventBroadcastReceiver = tokio::sync::broadcast::Receiver<Event>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: multiple fields are never read
+  --> crates/node/src/node.rs:36:5
+   |
+24 | pub struct Node {
+   |            ---- fields in this struct
+...
+36 |     vm: Option<Cpu>,
+   |     ^^
+37 |     state_handle: Option<JoinHandle<Result<()>>>,
+38 |     mempool_handle: Option<JoinHandle<Result<()>>>,
+   |     ^^^^^^^^^^^^^^
+...
+42 |     dkg_handle: Option<JoinHandle<Result<()>>>,
+   |     ^^^^^^^^^^
+43 |     miner_election_handle: Option<JoinHandle<Result<()>>>,
+   |     ^^^^^^^^^^^^^^^^^^^^^
+44 |     quorum_election_handle: Option<JoinHandle<Result<()>>>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+45 |     farmer_handle: Option<JoinHandle<Result<()>>>,
+   |     ^^^^^^^^^^^^^
+46 |     harvester_handle: Option<JoinHandle<Result<()>>>,
+   |     ^^^^^^^^^^^^^^^^
+47 |     raptor_handle: Option<std::thread::JoinHandle<bool>>,
+   |     ^^^^^^^^^^^^^
+48 |     scheduler_handle: Option<std::thread::JoinHandle<()>>,
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: `Node` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+
+warning: function `setup_event_routing_system` is never used
+   --> crates/node/src/runtime/mod.rs:259:4
+    |
+259 | fn setup_event_routing_system() -> EventRouter {
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: function `setup_reputation_module` is never used
+   --> crates/node/src/runtime/mod.rs:592:4
+    |
+592 | fn setup_reputation_module() -> Result<Option<JoinHandle<Result<()>>>> {
+    |    ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: function `setup_credit_model_module` is never used
+   --> crates/node/src/runtime/mod.rs:596:4
+    |
+596 | fn setup_credit_model_module() -> Result<Option<JoinHandle<Result<()>>>> {
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: fields `events_tx` and `vrrbdb_read_handle` are never read
+  --> crates/node/src/runtime/broadcast_module.rs:44:5
+   |
+41 | pub struct BroadcastModule {
+   |            --------------- fields in this struct
+...
+44 |     events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+   |     ^^^^^^^^^
+45 |     vrrbdb_read_handle: VrrbDbReadHandle,
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: `BroadcastModule` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+
+warning: field `label` is never read
+  --> crates/node/src/runtime/dkg_module.rs:51:5
+   |
+43 | pub struct DkgModule {
+   |            --------- field in this struct
+...
+51 |     label: ActorLabel,
+   |     ^^^^^
+
+warning: fields `election_type` and `label` are never read
+  --> crates/node/src/runtime/election_module.rs:58:5
+   |
+53 | pub struct ElectionModule<E, T>
+   |            -------------- fields in this struct
+...
+58 |     election_type: E,
+   |     ^^^^^^^^^^^^^
+...
+61 |     label: ActorLabel,
+   |     ^^^^^
+   |
+   = note: `ElectionModule` has derived impls for the traits `Debug` and `Clone`, but these are intentionally ignored during dead code analysis
+
+warning: fields `label` and `async_jobs_sender` are never read
+  --> crates/node/src/runtime/farmer_module.rs:57:5
+   |
+50 | pub struct FarmerModule {
+   |            ------------ fields in this struct
+...
+57 |     label: ActorLabel,
+   |     ^^^^^
+...
+62 |     async_jobs_sender: Sender<Job>,
+   |     ^^^^^^^^^^^^^^^^^
+
+warning: fields `label`, `events_rx`, `quorum_threshold` and `async_jobs_sender` are never read
+  --> crates/node/src/runtime/harvester_module.rs:86:5
+   |
+78 | pub struct HarvesterModule {
+   |            --------------- fields in this struct
+...
+86 |     label: ActorLabel,
+   |     ^^^^^
+...
+89 |     events_rx: UnboundedReceiver<DirectedEvent>,
+   |     ^^^^^^^^^
+90 |     quorum_threshold: QuorumThreshold,
+   |     ^^^^^^^^^^^^^^^^
+91 |     sync_jobs_sender: Sender<Job>,
+92 |     async_jobs_sender: Sender<Job>,
+   |     ^^^^^^^^^^^^^^^^^
+
+warning: associated function `process_sync_job_status` is never used
+   --> crates/node/src/runtime/harvester_module.rs:129:8
+    |
+129 |     fn process_sync_job_status(&mut self, sync_jobs_status_receiver: Receiver<JobResult>) {
+    |        ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: field `vrrbdb_read_handle` is never read
+  --> crates/node/src/runtime/mining_module.rs:22:5
+   |
+16 | pub struct MiningModule {
+   |            ------------ field in this struct
+...
+22 |     vrrbdb_read_handle: VrrbDbReadHandle,
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: `MiningModule` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+
+warning: field `label` is never read
+  --> crates/node/src/runtime/state_module.rs:25:5
+   |
+22 | pub struct StateModule {
+   |            ----------- field in this struct
+...
+25 |     label: ActorLabel,
+   |     ^^^^^
+   |
+   = note: `StateModule` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+
+warning: fields `is_bootstrap_node`, `refresh_interval`, `ping_interval`, `label` and `events_tx` are never read
+  --> crates/node/src/runtime/swarm_module.rs:29:5
+   |
+27 | pub struct SwarmModule {
+   |            ----------- fields in this struct
+28 |     pub node: KademliaNode,
+29 |     is_bootstrap_node: bool,
+   |     ^^^^^^^^^^^^^^^^^
+30 |     refresh_interval: Option<u64>,
+   |     ^^^^^^^^^^^^^^^^
+31 |     ping_interval: Option<u64>,
+   |     ^^^^^^^^^^^^^
+32 |     status: ActorState,
+33 |     label: ActorLabel,
+   |     ^^^^^
+34 |     id: ActorId,
+35 |     events_tx: tokio::sync::mpsc::UnboundedSender<DirectedEvent>,
+   |     ^^^^^^^^^
+   |
+   = note: `SwarmModule` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
+
+warning: field `async_jobs_receiver` is never read
+  --> crates/node/src/services/scheduler.rs:51:5
+   |
+47 | pub struct JobSchedulerController {
+   |            ---------------------- field in this struct
+...
+51 |     async_jobs_receiver: Receiver<Job>,
+   |     ^^^^^^^^^^^^^^^^^^^
+
+warning: unused `std::result::Result` that must be used
+   --> crates/node/src/runtime/mod.rs:371:17
+    |
+371 |                 jsonrpc_server_handle.stop();
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: `#[warn(unused_must_use)]` on by default
+    = note: this `Result` may be an `Err` variant, which should be handled
+
+warning: unused implementer of `std::future::Future` that must be used
+   --> crates/node/src/runtime/broadcast_module.rs:200:17
+    |
+200 |                 self.broadcast_engine.add_peer_connection(quic_addresses);
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: futures do nothing unless you `.await` or poll them
+
+warning: unused `std::result::Result` that must be used
+   --> crates/node/src/runtime/harvester_module.rs:291:25
+    |
+291 | /                         self.broadcast_events_tx
+292 | |                             .send(Event::QuorumCertifiedTxns(txn.clone()));
+    | |___________________________________________________________________________^
+    |
+    = note: this `Result` may be an `Err` variant, which should be handled
+
+warning: unused `std::result::Result` that must be used
+  --> crates/node/src/services/broadcast_controller.rs:57:25
+   |
+57 |                         self.handle_network_event(message).await;
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+
+warning: unused `std::result::Result` that must be used
+  --> crates/node/src/services/broadcast_controller.rs:69:21
+   |
+69 |                     self.handle_internal_event(event).await;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+
+warning: unused `std::result::Result` that must be used
+   --> crates/node/src/services/broadcast_controller.rs:118:21
+    |
+118 |                     self.events_tx.send(Event::EmptyPeerSync);
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this `Result` may be an `Err` variant, which should be handled
+
+warning: unused `std::result::Result` that must be used
+   --> crates/node/src/services/broadcast_controller.rs:147:21
+    |
+147 |                     self.events_tx.send(Event::PeerSyncFailed(quic_addresses));
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this `Result` may be an `Err` variant, which should be handled
+
+warning: `node` (lib) generated 164 warnings
+warning: unused import: `time::Duration`
+ --> crates/cli/src/commands/node/run.rs:4:5
+  |
+4 |     time::Duration,
+  |     ^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused import: `Subcommand`
+ --> crates/cli/src/commands/node/run.rs:7:20
+  |
+7 | use clap::{Parser, Subcommand};
+  |                    ^^^^^^^^^^
+
+warning: unused imports: `PublicKey`, `SecretKey`, `serde_impl::SerdeSecret`
+  --> crates/cli/src/commands/node/run.rs:10:21
+   |
+10 | use hbbft::crypto::{serde_impl::SerdeSecret, PublicKey, SecretKey};
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^  ^^^^^^^^^
+
+warning: unused imports: `Secp256k1`, `rand`
+  --> crates/cli/src/commands/node/run.rs:13:17
+   |
+13 | use secp256k1::{rand, Secp256k1};
+   |                 ^^^^  ^^^^^^^^^
+
+warning: unused import: `error`
+  --> crates/cli/src/commands/node/run.rs:15:17
+   |
+15 | use telemetry::{error, info, warn};
+   |                 ^^^^^
+
+warning: unused import: `self`
+  --> crates/cli/src/commands/node/run.rs:18:26
+   |
+18 | use vrrb_core::keypair::{self, read_keypair_file, write_keypair_file, Keypair};
+   |                          ^^^^
+
+warning: unused import: `std::net::SocketAddr`
+ --> crates/cli/src/commands/wallet/get.rs:1:5
+  |
+1 | use std::net::SocketAddr;
+  |     ^^^^^^^^^^^^^^^^^^^^
+
+warning: unused imports: `PublicKey`, `SecretKey`
+ --> crates/cli/src/commands/wallet/get.rs:3:27
+  |
+3 | use primitives::{Address, PublicKey, SecretKey};
+  |                           ^^^^^^^^^  ^^^^^^^^^
+
+warning: unused import: `secp256k1::hashes::serde_impl`
+ --> crates/cli/src/commands/wallet/get.rs:4:5
+  |
+4 | use secp256k1::hashes::serde_impl;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `WalletConfig`
+ --> crates/cli/src/commands/wallet/get.rs:6:26
+  |
+6 | use wallet::v2::{Wallet, WalletConfig};
+  |                          ^^^^^^^^^^^^
+
+warning: unused imports: `IpAddr`, `Ipv4Addr`, `SocketAddr`
+ --> crates/cli/src/commands/wallet/info.rs:1:16
+  |
+1 | use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+  |                ^^^^^^  ^^^^^^^^  ^^^^^^^^^^
+
+warning: unused imports: `PublicKey`, `SecretKey`
+ --> crates/cli/src/commands/wallet/info.rs:3:18
+  |
+3 | use primitives::{PublicKey, SecretKey};
+  |                  ^^^^^^^^^  ^^^^^^^^^
+
+warning: unused imports: `generate_keypair`, `rand`
+ --> crates/cli/src/commands/wallet/info.rs:4:17
+  |
+4 | use secp256k1::{generate_keypair, rand};
+  |                 ^^^^^^^^^^^^^^^^  ^^^^
+
+warning: unused import: `WalletConfig`
+ --> crates/cli/src/commands/wallet/info.rs:5:26
+  |
+5 | use wallet::v2::{Wallet, WalletConfig};
+  |                          ^^^^^^^^^^^^
+
+warning: unused imports: `IpAddr`, `Ipv4Addr`, `SocketAddr`
+ --> crates/cli/src/commands/wallet/new.rs:2:11
+  |
+2 |     net::{IpAddr, Ipv4Addr, SocketAddr},
+  |           ^^^^^^  ^^^^^^^^  ^^^^^^^^^^
+
+warning: unused imports: `Address`, `PublicKey`, `SecretKey`
+ --> crates/cli/src/commands/wallet/new.rs:6:18
+  |
+6 | use primitives::{Address, PublicKey, SecretKey};
+  |                  ^^^^^^^  ^^^^^^^^^  ^^^^^^^^^
+
+warning: unused imports: `Message`, `hashes::sha256`
+ --> crates/cli/src/commands/wallet/new.rs:7:35
+  |
+7 | use secp256k1::{generate_keypair, hashes::sha256, rand, Message};
+  |                                   ^^^^^^^^^^^^^^        ^^^^^^^
+
+warning: unused import: `account::Account`
+ --> crates/cli/src/commands/wallet/new.rs:8:17
+  |
+8 | use vrrb_core::{account::Account, helpers::write_keypair_file};
+  |                 ^^^^^^^^^^^^^^^^
+
+warning: unused import: `WalletConfig`
+ --> crates/cli/src/commands/wallet/new.rs:9:40
+  |
+9 | use wallet::v2::{AddressAlias, Wallet, WalletConfig};
+  |                                        ^^^^^^^^^^^^
+
+warning: unused imports: `IpAddr`, `Ipv4Addr`, `SocketAddr`
+ --> crates/cli/src/commands/wallet/transfer.rs:1:16
+  |
+1 | use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+  |                ^^^^^^  ^^^^^^^^  ^^^^^^^^^^
+
+warning: unused imports: `PublicKey`, `SecretKey`
+ --> crates/cli/src/commands/wallet/transfer.rs:3:18
+  |
+3 | use primitives::{PublicKey, SecretKey};
+  |                  ^^^^^^^^^  ^^^^^^^^^
+
+warning: unused imports: `generate_keypair`, `rand`
+ --> crates/cli/src/commands/wallet/transfer.rs:4:17
+  |
+4 | use secp256k1::{generate_keypair, rand};
+  |                 ^^^^^^^^^^^^^^^^  ^^^^
+
+warning: unused import: `TransactionDigest`
+ --> crates/cli/src/commands/wallet/transfer.rs:5:29
+  |
+5 | use vrrb_core::txn::{Token, TransactionDigest};
+  |                             ^^^^^^^^^^^^^^^^^
+
+warning: unused import: `WalletConfig`
+ --> crates/cli/src/commands/wallet/transfer.rs:7:26
+  |
+7 | use wallet::v2::{Wallet, WalletConfig};
+  |                          ^^^^^^^^^^^^
+
+warning: unused import: `hash::Hash`
+ --> crates/cli/src/commands/wallet/mod.rs:7:33
+  |
+7 | use std::{collections::HashMap, hash::Hash, net::SocketAddr, path::PathBuf, str::FromStr};
+  |                                 ^^^^^^^^^^
+
+warning: unused imports: `generate_keypair`, `rand`
+  --> crates/cli/src/commands/wallet/mod.rs:11:17
+   |
+11 | use secp256k1::{generate_keypair, rand};
+   |                 ^^^^^^^^^^^^^^^^  ^^^^
+
+warning: use of deprecated associated function `commands::node::run::RunOpts::from_file`: prefer global config file
+ --> crates/cli/src/commands/utils.rs:8:32
+  |
+8 |     let node_config = RunOpts::from_file(path_str)
+  |                                ^^^^^^^^^
+  |
+  = note: `#[warn(deprecated)]` on by default
+
+warning: unused import: `Parser`
+ --> crates/cli/src/commands/node/run.rs:7:12
+  |
+7 | use clap::{Parser, Subcommand};
+  |            ^^^^^^
+
+warning: unreachable pattern
+   --> crates/cli/src/commands/wallet/mod.rs:149:9
+    |
+149 |         _ => Err(CliError::InvalidCommand(format!("{:?}", sub_cmd))),
+    |         ^
+    |
+    = note: `#[warn(unreachable_patterns)]` on by default
+
+warning: unused variable: `err`
+   --> crates/cli/src/commands/node/run.rs:290:19
+    |
+290 |         .map_err(|err| CliError::Other(String::from("failed to listen for ctrl+c")))?;
+    |                   ^^^ help: if this is intentional, prefix it with an underscore: `_err`
+    |
+    = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `limit`
+ --> crates/cli/src/commands/wallet/get_mempool.rs:5:5
+  |
+5 |     limit: Option<usize>,
+  |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_limit`
+
+warning: unused variable: `address`
+  --> crates/cli/src/commands/wallet/new.rs:29:10
+   |
+29 |     let (address, account) = wallet
+   |          ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_address`
+
+warning: unused variable: `err`
+  --> crates/cli/src/commands/wallet/new.rs:32:19
+   |
+32 |         .map_err(|err| CliError::Other("unable to create account in state".to_string()))?;
+   |                   ^^^ help: if this is intentional, prefix it with an underscore: `_err`
+
+warning: unused variable: `mempool`
+   --> crates/cli/src/commands/wallet/mod.rs:144:17
+    |
+144 |             let mempool = get_mempool::exec(&mut wallet, limit).await?;
+    |                 ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_mempool`
+
+warning: unused variable: `secret`
+   --> crates/cli/src/commands/wallet/mod.rs:182:14
+    |
+182 |         let (secret, public) = read_or_generate_keypair_file(&path.join("keys"))
+    |              ^^^^^^ help: if this is intentional, prefix it with an underscore: `_secret`
+
+warning: function `read_node_config_from_file` is never used
+ --> crates/cli/src/commands/utils.rs:5:8
+  |
+5 | pub fn read_node_config_from_file(config_file_path: PathBuf) -> crate::result::Result<RunOpts> {
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(dead_code)]` on by default
+
+warning: function `load_account_secret_key` is never used
+   --> crates/cli/src/commands/wallet/mod.rs:194:4
+    |
+194 | fn load_account_secret_key() {
+    |    ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused `std::result::Result` that must be used
+   --> crates/cli/src/commands/node/run.rs:309:5
+    |
+309 | /     node_handle
+310 | |         .await
+311 | |         .map_err(|err| CliError::Other(format!("failed to join node task handle: {err}")))?;
+    | |____________________________________________________________________________________________^
+    |
+    = note: `#[warn(unused_must_use)]` on by default
+    = note: this `Result` may be an `Err` variant, which should be handled
+
+warning: `cli` (lib) generated 38 warnings
+    Finished dev [unoptimized + debuginfo] target(s) in 0.33s

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -283,7 +283,7 @@ pub async fn run(args: RunOpts) -> Result<()> {
 
 #[telemetry::instrument]
 async fn run_blocking(node_config: NodeConfig) -> Result<()> {
-    let (ctrl_tx, mut ctrl_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+    let (ctrl_tx, ctrl_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
 
     let vrrb_node = Node::start(&node_config, ctrl_rx)
         .await

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -6,21 +6,28 @@ use std::{
 };
 
 use async_trait::async_trait;
-use block::{header::BlockHeader, Conflict, ConflictList, RefHash, ResolvedConflicts, invalid::BlockError};
+use block::{
+    header::BlockHeader,
+    invalid::BlockError,
+    Conflict,
+    ConflictList,
+    RefHash,
+    ResolvedConflicts,
+};
 use ethereum_types::U256;
 use events::{ConflictBytes, Event};
 use primitives::NodeId;
+use quorum::{
+    election::Election,
+    quorum::{InvalidQuorum, Quorum},
+};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler, TheaterError};
 use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
 use vrrb_core::claim::Claim;
-use sha2::{Sha256, Digest};
-use quorum::{
-    quorum::{InvalidQuorum, Quorum}, 
-    election::Election
-};
 
 pub type Seed = u64;
 
@@ -140,9 +147,8 @@ impl Handler<Event> for ElectionModule<MinerElection, MinerElectionResult> {
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
             Event::MinerElection(header_bytes) => {
-                let header_result: serde_json::Result<BlockHeader> = serde_json::from_slice(
-                    &header_bytes
-                );
+                let header_result: serde_json::Result<BlockHeader> =
+                    serde_json::from_slice(&header_bytes);
                 if let Ok(header) = header_result {
                     let claims = self.db_read_handle.claim_store_values();
                     let mut election_results: BTreeMap<U256, Claim> =
@@ -188,19 +194,15 @@ impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
     async fn handle(&mut self, event: Event) -> theater::Result<ActorState> {
         match event {
             Event::QuorumElection(header_bytes) => {
-                let header_result: serde_json::Result<BlockHeader> = serde_json::from_slice(
-                    &header_bytes
-                );
+                let header_result: serde_json::Result<BlockHeader> =
+                    serde_json::from_slice(&header_bytes);
 
                 if let Ok(header) = header_result {
                     let claims = self.db_read_handle.claim_store_values();
                     if let Ok(quorum) = elect_quorum(claims, header) {
-                        let _ = self.events_tx.send(
-                            Event::ElectedQuorum(quorum)
-                        );
+                        let _ = self.events_tx.send(Event::ElectedQuorum(quorum));
                     }
                 }
-
             },
             _ => {},
         }
@@ -209,34 +211,25 @@ impl Handler<Event> for ElectionModule<QuorumElection, QuorumElectionResult> {
     }
 }
 
-fn elect_miner(
-    claims: HashMap<NodeId, Claim>, 
-    block_seed: u64
-) -> BTreeMap<U256, Claim> {
+fn elect_miner(claims: HashMap<NodeId, Claim>, block_seed: u64) -> BTreeMap<U256, Claim> {
     claims
         .iter()
         .filter(|(_, claim)| claim.eligible)
-        .map(|(nodeid, claim)| {
-            single_miner_results(claim, block_seed)
-        }).collect()
+        .map(|(nodeid, claim)| single_miner_results(claim, block_seed))
+        .collect()
 }
 
-fn single_miner_results(
-    claim: &Claim, 
-    block_seed: u64
-) -> (U256, Claim) {
-    (claim.get_election_result(block_seed), claim.clone()) 
+fn single_miner_results(claim: &Claim, block_seed: u64) -> (U256, Claim) {
+    (claim.get_election_result(block_seed), claim.clone())
 }
 
-fn get_winner(
-    election_results: &mut BTreeMap<U256, Claim>
-) -> (U256, Claim) {
+fn get_winner(election_results: &mut BTreeMap<U256, Claim>) -> (U256, Claim) {
     let mut iter = election_results.iter();
-    let mut first: (U256, Claim);
+    let first: (U256, Claim);
     loop {
         if let Some((pointer_sum, claim)) = iter.next() {
             first = (pointer_sum.clone(), claim.clone());
-            break
+            break;
         }
     }
 
@@ -250,17 +243,12 @@ fn elect_quorum(
     let last_block_height = header.block_height;
     let seed = header.next_block_seed;
 
-    if let Ok(mut quorum) = Quorum::new(
-        seed, 
-        last_block_height 
-    ) {
-        let claim_vec: Vec<Claim> = claims.values()
-            .cloned()
-            .collect();
+    if let Ok(mut quorum) = Quorum::new(seed, last_block_height) {
+        let claim_vec: Vec<Claim> = claims.values().cloned().collect();
         if let Ok(elected_quorum) = quorum.run_election(claim_vec) {
-            return Ok(elected_quorum.clone())
+            return Ok(elected_quorum.clone());
         }
     }
 
-    return Err(InvalidQuorum::InvalidSeedError())
+    return Err(InvalidQuorum::InvalidSeedError());
 }

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -74,7 +74,7 @@ impl FarmerModule {
         async_jobs_sender: Sender<Job>,
     ) -> Self {
         let lrmpooldb = LeftRightMempool::new();
-        let mut farmer = Self {
+        let farmer = Self {
             sig_provider,
             tx_mempool: lrmpooldb,
             status: ActorState::Stopped,

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -174,7 +174,7 @@ pub async fn setup_runtime_components(
 
     info!("JSON-RPC server address: {}", config.jsonrpc_server_address);
 
-    let mut dag: Arc<RwLock<BullDag<Block, String>>> = Arc::new(RwLock::new(BullDag::new()));
+    let dag: Arc<RwLock<BullDag<Block, String>>> = Arc::new(RwLock::new(BullDag::new()));
 
     let miner_handle = setup_mining_module(
         &config,
@@ -265,7 +265,7 @@ async fn setup_gossip_network(
     config: &NodeConfig,
     events_tx: UnboundedSender<Event>,
     mut network_events_rx: Receiver<Event>,
-    mut controller_events_rx: Receiver<Event>,
+    controller_events_rx: Receiver<Event>,
     vrrbdb_read_handle: VrrbDbReadHandle,
     raptor_sender: Sender<RaptorBroadCastedData>,
 ) -> Result<(
@@ -425,7 +425,7 @@ fn setup_dkg_module(
     events_tx: UnboundedSender<Event>,
     mut dkg_events_rx: Receiver<Event>,
 ) -> Result<Option<JoinHandle<Result<()>>>> {
-    let mut module = dkg_module::DkgModule::new(
+    let module = dkg_module::DkgModule::new(
         0,
         config.node_type,
         config.keypair.validator_kp.0.clone(),
@@ -516,10 +516,10 @@ fn setup_farmer_module(
     config: &NodeConfig,
     sync_jobs_sender: Sender<Job>,
     async_jobs_sender: Sender<Job>,
-    mut events_tx: EventBroadcastSender,
+    events_tx: EventBroadcastSender,
     mut farmer_events_rx: Receiver<Event>,
 ) -> Result<Option<JoinHandle<Result<()>>>> {
-    let mut module = farmer_module::FarmerModule::new(
+    let module = farmer_module::FarmerModule::new(
         None,
         vec![],
         config.keypair.get_peer_id().into_bytes(),
@@ -543,11 +543,11 @@ fn setup_farmer_module(
 fn setup_harvester_module(
     sync_jobs_sender: Sender<Job>,
     async_jobs_sender: Sender<Job>,
-    mut broadcast_events_tx: EventBroadcastSender,
-    mut events_rx: UnboundedReceiver<DirectedEvent>,
+    broadcast_events_tx: EventBroadcastSender,
+    events_rx: UnboundedReceiver<DirectedEvent>,
     mut harvester_events_rx: Receiver<Event>,
 ) -> Result<Option<JoinHandle<Result<()>>>> {
-    let mut module = harvester_module::HarvesterModule::new(
+    let module = harvester_module::HarvesterModule::new(
         Bloom::new(10000),
         None,
         vec![],

--- a/crates/wallet/src/v2/mod.rs
+++ b/crates/wallet/src/v2/mod.rs
@@ -107,7 +107,7 @@ impl Wallet {
             "DO NOT SHARE OR LOSE YOUR SECRET KEY:", &secret_key, &public_key,
         );
 
-        let mut wallet = Wallet {
+        let wallet = Wallet {
             secret_key,
             public_key,
             welcome_message,


### PR DESCRIPTION
## Info

- Removed all muts warned by compiler besides the below

```
warning: variable does not need to be mutable
   --> crates/node/src/runtime/mod.rs:260:9
    |
260 |     let mut event_router = EventRouter::default();
    |         ----^^^^^^^^^^^^
    |         |
    |         help: remove this `mut`
    |
```

when removed throws:

```
error[E0596]: cannot borrow `network_events_rx` as mutable, as it is not declared as mutable
   --> crates/node/src/runtime/mod.rs:310:20
    |
267 |     network_events_rx: Receiver<Event>,
    |     ----------------- help: consider changing this to be mutable: `mut network_events_rx`
...
310 |             .start(&mut network_events_rx)
    |                    ^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
```