### PR TITLE
Integrate `DagModule` into `Node` runtime

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -44,6 +44,7 @@ pub struct Node {
     quorum_election_handle: Option<JoinHandle<Result<()>>>,
     farmer_handle: Option<JoinHandle<Result<()>>>,
     indexer_handle: Option<JoinHandle<Result<()>>>,
+    dag_handle: Option<JoinHandle<Result<()>>>,
 }
 
 impl Node {
@@ -69,6 +70,7 @@ impl Node {
         let miner_election_events_rx = event_router.subscribe();
         let quorum_election_events_rx = event_router.subscribe();
         let indexer_events_rx = event_router.subscribe();
+        let dag_events_rx = event_router.subscribe();
 
         let (
             updated_config,
@@ -82,6 +84,7 @@ impl Node {
             quorum_election_handle,
             farmer_handle,
             indexer_handle,
+            dag_handle,
         ) = setup_runtime_components(
             &config,
             events_tx.clone(),
@@ -96,6 +99,7 @@ impl Node {
             quorum_election_events_rx,
             farmer_events_rx,
             indexer_events_rx,
+            dag_events_rx
         )
         .await?;
 
@@ -123,6 +127,7 @@ impl Node {
             quorum_election_handle,
             farmer_handle,
             indexer_handle,
+            dag_handle
         })
     }
 

--- a/crates/node/src/runtime/dag_module.rs
+++ b/crates/node/src/runtime/dag_module.rs
@@ -13,6 +13,26 @@ pub type Edge = (Vertex<Block, String>, Vertex<Block, String>);
 pub type Edges = Vec<Edge>;
 pub type GraphResult<T> = Result<T, GraphError>;
 
+
+/// The runtime module that manages the DAG, both exposing 
+/// data within and appending blocks to it.
+///
+/// ```
+/// use std::sync::{Arc, RwLock};
+///
+/// use block::Block;
+/// use bulldag::graph::BullDag;
+/// use node::EventBroadcastSender;
+/// use theater::{ActorState, ActorLabel, ActorId, Handler};
+///
+/// pub struct DagModule {
+///     status: ActorState,
+///     label: ActorLabel,
+///     id: ActorId,
+///     events_tx: EventBroadcastSender,
+///     dag: Arc<RwLock<BullDag<Block, String>>>,
+/// }
+///
 pub struct DagModule {
     status: ActorState,
     label: ActorLabel,


### PR DESCRIPTION
This PR adds a function called `setup_dag_module` which starts dag module handle and returns it 

It then calls that function inside of `setup_runtime_components` function, and adds a type to the parameters for the `dag_module_events_rx` to pass into the `setup_dag_module` function.

Adds the params needed into the call to `setup_runtime_components` function in the `Node::start()` method and incorporates dag module handle into the Node struct, and call function to create/start dag module handle in the setup_runtime_components function, and return the dag module handle inside the Node start method.