### PR TITLE
Implement Block Signature Verification Methods in the DagModule

### DIFF
--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -28,3 +28,4 @@ sha2 = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
 ethereum-types = { workspace = true }
+hbbft = { workspace = true } 

--- a/crates/block/src/header.rs
+++ b/crates/block/src/header.rs
@@ -46,7 +46,6 @@ impl BlockHeader {
         secret_key: SecretKey,
         claim_list_hash: String,
     ) -> BlockHeader {
-        //TODO: Replace rand::thread_rng() with VPRNG
         //TODO: Determine data fields to be used as message in VPRNG, must be
         // known/revealed within block but cannot be predictable or gameable.
         // Leading candidates are some combination of last_hash and last_block_seed

--- a/crates/block/src/lib.rs
+++ b/crates/block/src/lib.rs
@@ -16,3 +16,85 @@ pub use crate::{
     types::*,
     vesting::*,
 };
+
+pub mod valid {
+    use primitives::{ByteVec, RawSignature, SignatureType};
+    use serde::{Serialize, Deserialize};
+
+    use crate::{GenesisBlock, ProposalBlock, ConvergenceBlock};
+
+    pub trait Valid {
+        type ValidationData;
+        fn get_validation_data(&self) -> Self::ValidationData; 
+        fn get_signature_type(&self) -> SignatureType;
+        fn get_payload_hash(&self) -> ByteVec {
+            vec![]
+        }
+        fn get_raw_signature(&self) -> RawSignature {
+            vec![]
+        }
+        fn get_node_idx(&self) -> Option<u16> {
+            None
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct BlockValidationData {
+        pub node_idx: Option<u16>,
+        pub payload_hash: ByteVec,
+        pub signature: RawSignature,
+        pub signature_type: SignatureType
+    }
+
+    impl Valid for GenesisBlock {
+        type ValidationData = BlockValidationData;
+
+        fn get_validation_data(&self) -> Self::ValidationData {
+            BlockValidationData {
+                node_idx: self.get_node_idx(),
+                payload_hash: self.get_payload_hash(),
+                signature: self.get_raw_signature(),
+                signature_type: self.get_signature_type()
+            }
+        }
+
+        fn get_signature_type(&self) -> SignatureType {
+            SignatureType::ThresholdSignature
+        }
+
+    }
+
+    impl Valid for ProposalBlock {
+        type ValidationData = BlockValidationData;
+
+        fn get_validation_data(&self) -> Self::ValidationData {
+            BlockValidationData {
+                node_idx: self.get_node_idx(),
+                payload_hash: self.get_payload_hash(),
+                signature: self.get_raw_signature(),
+                signature_type: self.get_signature_type()
+            }
+        }
+
+        fn get_signature_type(&self) -> SignatureType {
+            SignatureType::PartialSignature
+        }
+    }
+
+    impl Valid for ConvergenceBlock {
+        type ValidationData = BlockValidationData;
+
+        fn get_validation_data(&self) -> Self::ValidationData {
+            BlockValidationData {
+                node_idx: self.get_node_idx(),
+                payload_hash: self.get_payload_hash(),
+                signature: self.get_raw_signature(),
+                signature_type: self.get_signature_type(),
+            }
+        }
+
+        fn get_signature_type(&self) -> SignatureType {
+            SignatureType::ThresholdSignature
+        }
+    }
+}

--- a/crates/block/src/lib.rs
+++ b/crates/block/src/lib.rs
@@ -21,17 +21,20 @@ pub mod valid {
     use primitives::{ByteVec, RawSignature, SignatureType};
     use serde::{Serialize, Deserialize};
 
+    use utils::hash_data;
     use crate::{GenesisBlock, ProposalBlock, ConvergenceBlock};
 
     pub trait Valid {
         type ValidationData;
-        fn get_validation_data(&self) -> Self::ValidationData; 
+        type DecodeError: std::error::Error;
+
+        fn get_validation_data(&self) -> Result<Self::ValidationData, Self::DecodeError>; 
         fn get_signature_type(&self) -> SignatureType;
         fn get_payload_hash(&self) -> ByteVec {
             vec![]
         }
-        fn get_raw_signature(&self) -> RawSignature {
-            vec![]
+        fn get_raw_signature(&self) -> Result<RawSignature, Self::DecodeError> {
+            Ok(vec![])
         }
         fn get_node_idx(&self) -> Option<u16> {
             None
@@ -48,53 +51,101 @@ pub mod valid {
 
     impl Valid for GenesisBlock {
         type ValidationData = BlockValidationData;
+        type DecodeError = hex::FromHexError;
 
-        fn get_validation_data(&self) -> Self::ValidationData {
-            BlockValidationData {
+        fn get_validation_data(&self) -> Result<Self::ValidationData, Self::DecodeError> {
+            let signature = self.get_raw_signature()?;
+            Ok(BlockValidationData {
                 node_idx: self.get_node_idx(),
                 payload_hash: self.get_payload_hash(),
-                signature: self.get_raw_signature(),
+                signature,
                 signature_type: self.get_signature_type()
-            }
+            })
         }
 
         fn get_signature_type(&self) -> SignatureType {
             SignatureType::ThresholdSignature
+        }
+
+        fn get_payload_hash(&self) -> ByteVec {
+            vec![]
+        }
+
+        fn get_raw_signature(&self) -> Result<RawSignature, Self::DecodeError> {
+            if let Some(cert) = self.certificate.clone() {
+                let signature = cert.decode_signature()?;
+                return Ok(signature)
+            } else {
+                return Err(hex::FromHexError::InvalidStringLength)
+            }
+        }
+
+        fn get_node_idx(&self) -> Option<u16> {
+            None
         }
 
     }
 
     impl Valid for ProposalBlock {
         type ValidationData = BlockValidationData;
+        type DecodeError = hex::FromHexError;
 
-        fn get_validation_data(&self) -> Self::ValidationData {
-            BlockValidationData {
+        fn get_validation_data(&self) -> Result<Self::ValidationData, Self::DecodeError> {
+            let signature = self.get_raw_signature()?;
+            Ok(BlockValidationData {
                 node_idx: self.get_node_idx(),
                 payload_hash: self.get_payload_hash(),
-                signature: self.get_raw_signature(),
+                signature,
                 signature_type: self.get_signature_type()
-            }
+            })
         }
 
         fn get_signature_type(&self) -> SignatureType {
             SignatureType::PartialSignature
         }
+
+        fn get_payload_hash(&self) -> ByteVec {
+            let hashable_txns = self.get_hashable_txns(); 
+            hash_data!(
+                self.round, 
+                self.epoch, 
+                hashable_txns, 
+                self.claims, 
+                self.from
+            ).to_vec()
+        }
+
+        fn get_raw_signature(&self) -> Result<RawSignature, Self::DecodeError> {
+           let signature = self.decode_signature_share()?;
+           Ok(signature.to_vec())
+        }
     }
 
     impl Valid for ConvergenceBlock {
         type ValidationData = BlockValidationData;
+        type DecodeError = hex::FromHexError;
 
-        fn get_validation_data(&self) -> Self::ValidationData {
-            BlockValidationData {
+        fn get_validation_data(&self) -> Result<Self::ValidationData, Self::DecodeError> {
+            let signature = self.get_raw_signature()?;
+            Ok(BlockValidationData {
                 node_idx: self.get_node_idx(),
                 payload_hash: self.get_payload_hash(),
-                signature: self.get_raw_signature(),
+                signature,
                 signature_type: self.get_signature_type(),
-            }
+            })
         }
 
         fn get_signature_type(&self) -> SignatureType {
             SignatureType::ThresholdSignature
+        }
+
+        fn get_raw_signature(&self) -> Result<RawSignature, Self::DecodeError> {
+            if let Some(cert) = self.certificate.clone() {
+                let signature = cert.decode_signature()?;
+                return Ok(signature)
+            } else {
+                return Err(hex::FromHexError::InvalidStringLength)
+            }
         }
     }
 }

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -15,6 +15,8 @@ use vrrb_core::{
     claim::Claim,
     txn::{Txn, TransactionDigest},
 };
+use primitives::RawSignature;
+use hex::{decode, FromHexError};
 use tokio::task::JoinHandle;
 
 #[cfg(mainnet)]
@@ -79,5 +81,12 @@ impl Hash for Conflict {
         }
 
         self.winner.hash(state);
+    }
+}
+
+impl Certificate {
+    pub(crate) fn decode_signature(&self) -> Result<RawSignature, FromHexError> {
+        let signature = hex::decode(self.signature.clone())?;
+        Ok(signature)
     }
 }

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, net::SocketAddr};
 
 use block::{Block, Conflict};
 use ethereum_types::U256;
+use hbbft::crypto::PublicKeySet;
 use primitives::{
     Address,
     ByteVec,

--- a/crates/miner/Cargo.toml
+++ b/crates/miner/Cargo.toml
@@ -23,3 +23,4 @@ thiserror = { workspace = true }
 utils = { workspace = true }
 sha2 = { workspace = true }
 ethereum-types = { workspace = true }
+hbbft = { workspace = true }

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -26,6 +26,7 @@ mod tests {
     use ritelinked::LinkedHashMap;
     use vrrb_core::{keypair::Keypair, claim::Claim, txn::{TransactionDigest, Txn}};
     use block::{Block, ProposalBlock};
+    use hbbft::crypto::SecretKeyShare;
 
     use crate::test_helpers::{
         mine_genesis, 
@@ -104,7 +105,7 @@ mod tests {
                 LinkedHashMap::new(),
                 LinkedHashMap::new(),
                 other_miner.claim.clone(),
-                keypair.miner_kp.0.clone()
+                SecretKeyShare::default(), 
             );
             let pblock = Block::Proposal { block: prop1.clone() };
             let pvtx: Vertex<Block, String> = pblock.into(); 
@@ -151,7 +152,7 @@ mod tests {
                 0,
                 0,
                 miner.claim.clone(),
-                m1kp.miner_kp.0.clone()
+                SecretKeyShare::default(),
             );
             let prop2 = build_single_proposal_block(
                 genesis.hash.clone(),
@@ -160,7 +161,7 @@ mod tests {
                 0,
                 0,
                 other_miner.claim.clone(),
-                m2kp.miner_kp.0.clone()
+                SecretKeyShare::default(),
             );
 
             let pblock1 = Block::Proposal { block: prop1.clone() };

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -10,6 +10,7 @@ use block::{
 };
 use bulldag::{graph::BullDag, vertex::Vertex};
 use primitives::{Address, PublicKey, SecretKey, Signature};
+use hbbft::crypto::SecretKeyShare;
 use ritelinked::LinkedHashMap;
 use secp256k1::Message;
 use sha2::Digest;
@@ -254,7 +255,7 @@ pub(crate) fn build_single_proposal_block(
     round: u128,
     epoch: u128,
     from: Claim,
-    sk: SecretKey,
+    sk: SecretKeyShare,
 ) -> ProposalBlock {
     let txns = create_txns(n_txns).collect();
     let claims = create_claims(n_claims).collect();
@@ -292,7 +293,7 @@ pub(crate) fn build_multiple_proposal_blocks_single_round(
             round, 
             epoch, 
             claim, 
-            keypair.miner_kp.0.clone()
+            SecretKeyShare::default()
         );
         prop
     }).collect()
@@ -399,7 +400,7 @@ pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
             LinkedHashMap::new(),
             LinkedHashMap::new(),
             miner.claim.clone(),
-            keypair.miner_kp.0.clone()
+            SecretKeyShare::default(),
         );
         let pblock = Block::Proposal { block: prop1.clone() };
         let pvtx: Vertex<Block, String> = pblock.into(); 
@@ -512,7 +513,7 @@ pub(crate) fn build_single_proposal_block_from_txns(
         round, 
         epoch, 
         miner.claim, 
-        kp.miner_kp.0
+        SecretKeyShare::default(),
     );
 
     prop.txns.extend(txns);

--- a/crates/node/src/runtime/dag_module.rs
+++ b/crates/node/src/runtime/dag_module.rs
@@ -202,23 +202,35 @@ impl DagModule {
     }
 
     fn check_valid_genesis(&self, block: &GenesisBlock) -> bool {
-        match self.verify_signature(block.get_validation_data()) {
-            Ok(true) => true,
-            _ => false
+        if let Ok(validation_data) = block.get_validation_data() {
+            match self.verify_signature(validation_data) {
+                Ok(true) => return true,
+                _ => return false
+            }
+        } else {
+            return false
         }
     }
 
     fn check_valid_proposal(&self, block: &ProposalBlock) -> bool {
-        match self.verify_signature(block.get_validation_data()) {
-            Ok(true) => true,
-            _ => false
+        if let Ok(validation_data) = block.get_validation_data() {
+            match self.verify_signature(validation_data) {
+                Ok(true) => return true,
+                _ => return false
+            }
+        } else {
+            return false
         }
     }
 
     fn check_valid_convergence(&self, block: &ConvergenceBlock) -> bool {
-        match self.verify_signature(block.get_validation_data()) {
-            Ok(true) => true,
-            _ => false
+        if let Ok(validation_data) = block.get_validation_data() {
+            match self.verify_signature(validation_data) {
+                Ok(true) => return true,
+                _ => return false
+            }
+        } else {
+            return false
         }
     }
 


### PR DESCRIPTION
add signature verification methods to the DagModule to be able to verify block signatures, TODO: integrate signature verification into either  method, or into the relevant  methods.

The verification methods are implemented, and the type(s) needed in the `DagModule` struct are added, however, they aren't being used currently. Need to integrate them with either the `handle` method OR with the various `write` methods.

Also in #263 we need to discuss the `GenesisBlock` this will obviously be different than every other block.

We also need to discuss the "Chicken vs Egg" scenario I mentioned in the 4/12/2023 Stand-Up wrt needing harvester quorum to certify `ConvergenceBlock`... 