### PR TITLE
rm crates/block warnings (1)

### DIFF
--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -7,7 +7,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use hex::{decode, FromHexError};
+use hex::FromHexError;
 use primitives::RawSignature;
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;


### PR DESCRIPTION
## What
`block` (lib) generated 1 warning
```
warning: unused import: `decode`
  --> crates/block/src/types.rs:10:11
   |
10 | use hex::{decode, FromHexError};
   |           ^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```

## Why
Somewhat related to #218.

