### PR TITLE
rm warnings - crates/events (23)

### DIFF
--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -7,7 +7,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use hex::{decode, FromHexError};
+use hex::FromHexError;
 use primitives::RawSignature;
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,24 +1,16 @@
-use std::{collections::HashMap, net::SocketAddr};
+use std::net::SocketAddr;
 
 use block::{Block, Conflict};
 use ethereum_types::U256;
-use messr::router::Router;
 use primitives::{
     Address,
-    ByteVec,
     FarmerQuorumThreshold,
     HarvesterQuorumThreshold,
-    NodeIdx,
-    NodeType,
-    PeerId,
     QuorumPublicKey,
     QuorumSize,
-    QuorumType,
-    RawSignature,
 };
 use quorum::quorum::Quorum;
 use serde::{Deserialize, Serialize};
-use telemetry::{error, info};
 use vrrb_core::{
     claim::Claim,
     txn::{TransactionDigest, Txn},

--- a/crates/events/src/event_data.rs
+++ b/crates/events/src/event_data.rs
@@ -1,30 +1,8 @@
-use std::{collections::HashMap, net::SocketAddr};
+use std::net::SocketAddr;
 
-use block::{Block, Conflict};
-use ethereum_types::U256;
-use messr::router::Router;
-use primitives::{
-    Address,
-    ByteVec,
-    FarmerQuorumThreshold,
-    NodeIdx,
-    NodeType,
-    PeerId,
-    QuorumPublicKey,
-    QuorumType,
-    RawSignature,
-};
-use quorum::quorum::Quorum;
+use primitives::{ByteVec, FarmerQuorumThreshold, NodeIdx, NodeType, PeerId, RawSignature};
 use serde::{Deserialize, Serialize};
-use telemetry::{error, info};
-use tokio::sync::{
-    broadcast::{self, Receiver, Sender},
-    mpsc::{UnboundedReceiver, UnboundedSender},
-};
-use vrrb_core::{
-    claim::Claim,
-    txn::{TransactionDigest, Txn},
-};
+use vrrb_core::txn::{TransactionDigest, Txn};
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerData {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,37 +1,10 @@
-use std::{collections::HashMap, net::SocketAddr};
-
-use block::{Block, Conflict};
-use ethereum_types::U256;
-use hbbft::crypto::PublicKeySet;
 use messr::Router;
-use primitives::{
-    Address,
-    ByteVec,
-    FarmerQuorumThreshold,
-    HarvesterQuorumThreshold,
-    NodeIdx,
-    NodeType,
-    PeerId,
-    QuorumPublicKey,
-    QuorumSize,
-    QuorumType,
-    RawSignature,
-};
-use quorum::quorum::Quorum;
-use serde::{Deserialize, Serialize};
-use telemetry::{error, info};
-use tokio::sync::{
-    broadcast::{self, Receiver},
-    mpsc::{Sender, UnboundedReceiver, UnboundedSender},
-};
-use vrrb_core::{
-    claim::Claim,
-    txn::{TransactionDigest, Txn},
-};
+use tokio::sync::{broadcast::Receiver, mpsc::Sender};
+
+pub use crate::{event::*, event_data::*};
 
 mod event;
 mod event_data;
-pub use crate::{event::*, event_data::*};
 
 pub const DEFAULT_BUFFER: usize = 1000;
 


### PR DESCRIPTION
## What
`events` (lib) generated 23 warnings

```
warning: unused imports: `collections::HashMap`, `net::SocketAddr`
 --> crates/events/src/lib.rs:1:11
  |
1 | use std::{collections::HashMap, net::SocketAddr};
  |           ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `Block`, `Conflict`
 --> crates/events/src/lib.rs:3:13
  |
3 | use block::{Block, Conflict};
  |             ^^^^^  ^^^^^^^^

warning: unused import: `ethereum_types::U256`
 --> crates/events/src/lib.rs:4:5
  |
4 | use ethereum_types::U256;
  |     ^^^^^^^^^^^^^^^^^^^^

warning: unused import: `hbbft::crypto::PublicKeySet`
 --> crates/events/src/lib.rs:5:5
  |
5 | use hbbft::crypto::PublicKeySet;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `Address`, `ByteVec`, `FarmerQuorumThreshold`, `HarvesterQuorumThreshold`, `NodeIdx`, `NodeType`, `PeerId`, `QuorumPublicKey`, `QuorumSize`, `QuorumType`, `RawSignature`
  --> crates/events/src/lib.rs:8:5
   |
8  |     Address,
   |     ^^^^^^^
9  |     ByteVec,
   |     ^^^^^^^
10 |     FarmerQuorumThreshold,
   |     ^^^^^^^^^^^^^^^^^^^^^
11 |     HarvesterQuorumThreshold,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
12 |     NodeIdx,
   |     ^^^^^^^
13 |     NodeType,
   |     ^^^^^^^^
14 |     PeerId,
   |     ^^^^^^
15 |     QuorumPublicKey,
   |     ^^^^^^^^^^^^^^^
16 |     QuorumSize,
   |     ^^^^^^^^^^
17 |     QuorumType,
   |     ^^^^^^^^^^
18 |     RawSignature,
   |     ^^^^^^^^^^^^

warning: unused import: `quorum::quorum::Quorum`
  --> crates/events/src/lib.rs:20:5
   |
20 | use quorum::quorum::Quorum;
   |     ^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `Deserialize`, `Serialize`
  --> crates/events/src/lib.rs:21:13
   |
21 | use serde::{Deserialize, Serialize};
   |             ^^^^^^^^^^^  ^^^^^^^^^

warning: unused imports: `error`, `info`
  --> crates/events/src/lib.rs:22:17
   |
22 | use telemetry::{error, info};
   |                 ^^^^^  ^^^^

warning: unused imports: `UnboundedReceiver`, `UnboundedSender`, `self`
  --> crates/events/src/lib.rs:24:17
   |
24 |     broadcast::{self, Receiver},
   |                 ^^^^
25 |     mpsc::{Sender, UnboundedReceiver, UnboundedSender},
   |                    ^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^

warning: unused imports: `TransactionDigest`, `Txn`, `claim::Claim`
  --> crates/events/src/lib.rs:28:5
   |
28 |     claim::Claim,
   |     ^^^^^^^^^^^^
29 |     txn::{TransactionDigest, Txn},
   |           ^^^^^^^^^^^^^^^^^  ^^^

warning: unused import: `collections::HashMap`
 --> crates/events/src/event.rs:1:11
  |
1 | use std::{collections::HashMap, net::SocketAddr};
  |           ^^^^^^^^^^^^^^^^^^^^

warning: unused import: `messr::router::Router`
 --> crates/events/src/event.rs:5:5
  |
5 | use messr::router::Router;
  |     ^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `ByteVec`, `NodeIdx`, `NodeType`, `PeerId`, `QuorumType`, `RawSignature`
  --> crates/events/src/event.rs:8:5
   |
8  |     ByteVec,
   |     ^^^^^^^
...
11 |     NodeIdx,
   |     ^^^^^^^
12 |     NodeType,
   |     ^^^^^^^^
13 |     PeerId,
   |     ^^^^^^
...
16 |     QuorumType,
   |     ^^^^^^^^^^
17 |     RawSignature,
   |     ^^^^^^^^^^^^

warning: unused imports: `error`, `info`
  --> crates/events/src/event.rs:21:17
   |
21 | use telemetry::{error, info};
   |                 ^^^^^  ^^^^

warning: unused import: `collections::HashMap`
 --> crates/events/src/event_data.rs:1:11
  |
1 | use std::{collections::HashMap, net::SocketAddr};
  |           ^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `Block`, `Conflict`
 --> crates/events/src/event_data.rs:3:13
  |
3 | use block::{Block, Conflict};
  |             ^^^^^  ^^^^^^^^

warning: unused import: `ethereum_types::U256`
 --> crates/events/src/event_data.rs:4:5
  |
4 | use ethereum_types::U256;
  |     ^^^^^^^^^^^^^^^^^^^^

warning: unused import: `messr::router::Router`
 --> crates/events/src/event_data.rs:5:5
  |
5 | use messr::router::Router;
  |     ^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `Address`, `QuorumPublicKey`, `QuorumType`
  --> crates/events/src/event_data.rs:7:5
   |
7  |     Address,
   |     ^^^^^^^
...
13 |     QuorumPublicKey,
   |     ^^^^^^^^^^^^^^^
14 |     QuorumType,
   |     ^^^^^^^^^^

warning: unused import: `quorum::quorum::Quorum`
  --> crates/events/src/event_data.rs:17:5
   |
17 | use quorum::quorum::Quorum;
   |     ^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `error`, `info`
  --> crates/events/src/event_data.rs:19:17
   |
19 | use telemetry::{error, info};
   |                 ^^^^^  ^^^^

warning: unused imports: `Receiver`, `Sender`, `UnboundedReceiver`, `UnboundedSender`, `self`
  --> crates/events/src/event_data.rs:21:17
   |
21 |     broadcast::{self, Receiver, Sender},
   |                 ^^^^  ^^^^^^^^  ^^^^^^
22 |     mpsc::{UnboundedReceiver, UnboundedSender},
   |            ^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^

warning: unused import: `claim::Claim`
  --> crates/events/src/event_data.rs:25:5
   |
25 |     claim::Claim,
   |     ^^^^^^^^^^^^

```

## Why
Somewhat related to #218.
