### PR TITLE
rm crates/miner warnings (1)

### DIFF
--- a/crates/consensus/dkg_engine/src/dkg.rs
+++ b/crates/consensus/dkg_engine/src/dkg.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use hbbft::sync_key_gen::{Error, PartOutcome, SyncKeyGen};
+use hbbft::sync_key_gen::{PartOutcome, SyncKeyGen};
 use primitives::NodeType;
 use rand::rngs::OsRng;
 

--- a/crates/consensus/dkg_engine/src/types/mod.rs
+++ b/crates/consensus/dkg_engine/src/types/mod.rs
@@ -5,7 +5,7 @@ use hbbft::{
     crypto::{PublicKey, PublicKeySet, SecretKey, SecretKeyShare},
     sync_key_gen::{Ack, Part, SyncKeyGen},
 };
-use primitives::{NodeIdx, NodeType, QuorumType};
+use primitives::{NodeIdx, NodeType};
 use rand::rngs::OsRng;
 use thiserror::Error;
 

--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -102,7 +102,7 @@ mod tests {
 
         let hash = digest(digest(&*pub_key_bytes).as_bytes());
 
-        let payload1 = (10, hash);
+        let payload1 = (0, hash);
 
         assert!(Quorum::generate_seed(payload1, keypair).is_err());
     }
@@ -145,6 +145,7 @@ mod tests {
             let claim: Claim = Claim::new(public_key, Address::new(public_key));
             dummy_claims.push(claim);
         });
+
         let keypair = KeyPair::random();
         let public_key = keypair.get_miner_public_key();
         let mut hasher = DefaultHasher::new();
@@ -159,9 +160,10 @@ mod tests {
         let payload1 = (10, hash);
 
         if let Ok(seed) = Quorum::generate_seed(payload1, keypair.clone()) {
-            assert!(Quorum::new(seed, 11).is_err());
+            assert!(Quorum::new(seed, 0).is_err());
         }
     }
+
 
     #[test]
     #[ignore = "temporarily disabled while the crate is refactored"]
@@ -205,7 +207,6 @@ mod tests {
             let public_key = keypair.get_miner_public_key().clone();
             let claim: Claim = Claim::new(public_key, Address::new(public_key));
             //let boxed_claim = Box::new(claim);
-
             dummy_claims1.push(claim.clone());
             dummy_claims2.push(claim.clone());
         });

--- a/crates/consensus/quorum/src/quorum.rs
+++ b/crates/consensus/quorum/src/quorum.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use ethereum_types::U256;
-use primitives::PublicKey;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vrrb_core::{claim::Claim, keypair::KeyPair};
@@ -171,7 +170,7 @@ impl Quorum {
         Ok(self)
     }
 
-    pub fn get_trusted_peers(&mut self, claims: Vec<Claim>) -> Self {
+    pub fn get_trusted_peers(&mut self, _claims: Vec<Claim>) -> Self {
         //get the weighted value hashmap
         //calcualte all the t values
 

--- a/crates/consensus/quorum/src/quorum.rs
+++ b/crates/consensus/quorum/src/quorum.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeMap;
 use ethereum_types::U256;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use vrrb_core::{claim::Claim, keypair::KeyPair};
+use vrrb_core::{
+    claim::{Claim, Eligibility},
+    keypair::KeyPair,
+};
 use vrrb_vrf::{vrng::VRNG, vvrf::VVRF};
 
 use crate::election::Election;
@@ -124,7 +127,10 @@ impl Quorum {
         let mut eligible_claims = Vec::<Claim>::new();
         claims
             .into_iter()
-            .filter(|claim| claim.eligible)
+            .filter(|claim| {
+                (claim.eligibility == Eligibility::Harvester
+                    && claim.eligibility == Eligibility::Farmer)
+            })
             .for_each(|claim| {
                 eligible_claims.push(claim);
             });

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -8,12 +8,10 @@ use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
 use left_right::{Absorb, ReadHandle, ReadHandleFactory, WriteHandle};
 use serde::{Deserialize, Serialize};
-use telemetry::{error, info, warn};
-use tokio;
 use vrrb_core::txn::{TransactionDigest, TxTimestamp, Txn};
 
 use super::error::MempoolError;
-use crate::create_tx_indexer;
+
 
 pub type Result<T> = StdResult<T, MempoolError>;
 

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -49,12 +49,6 @@ pub const MICRO: u128 = NANO * 1000;
 pub const MILLI: u128 = MICRO * 1000;
 pub const SECOND: u128 = MILLI * 1000;
 
-// TODO: Consider moving that to genesis_config.yaml
-const GENESIS_ALLOWED_MINERS: [&str; 2] = [
-    "82104DeE06aa223eC9574a8b2De4fB440630c300",
-    "F4ccb23f9A2b10b165965e2a4555EC25615c29BE",
-];
-
 /// A basic enum to inform the system whether the current
 /// status of the local mining unit.
 /// ```

--- a/crates/network/src/network.rs
+++ b/crates/network/src/network.rs
@@ -12,11 +12,9 @@ use crossbeam_channel::{unbounded, Sender};
 use futures::{stream::FuturesUnordered, StreamExt};
 use primitives::{
     DEFAULT_CONNECTION_TIMEOUT_IN_SECS,
-    NUMBER_OF_NETWORK_PACKETS,
     RAPTOR_DECODER_CACHE_LIMIT,
     RAPTOR_DECODER_CACHE_TTL_IN_SECS,
 };
-use qp2p::ConnectionError;
 pub use qp2p::{
     Config,
     Connection,
@@ -28,7 +26,7 @@ pub use qp2p::{
 use raptorq::Decoder;
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
-use tokio::{net::UdpSocket, time::error::Elapsed};
+use tokio::net::UdpSocket;
 use vrrb_core::cache::Cache;
 
 use crate::{
@@ -428,21 +426,13 @@ impl BroadcastEngine {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::{Ipv6Addr, SocketAddr},
-        thread,
-        time::Duration,
-    };
+    use std::net::{Ipv6Addr, SocketAddr};
 
-    use block::{header::BlockHeader, Block, ConvergenceBlock};
     use bytes::Bytes;
-    use crossbeam_channel::unbounded;
-    use vrrb_core::{claim::Claim, txn::Txn};
 
     use crate::{
         message::{Message, MessageBody},
         network::{BroadcastEngine, Timeout},
-        packet::RaptorBroadCastedData,
     };
 
     #[tokio::test]

--- a/crates/network/src/packet.rs
+++ b/crates/network/src/packet.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     convert::TryInto,
     error::Error,
     fs,
@@ -20,7 +20,7 @@ use raptorq::{Decoder, Encoder, EncodingPacket, ObjectTransmissionInformation};
 use serde::{Deserialize, Serialize};
 use telemetry::error;
 use tokio::net::UdpSocket;
-use vrrb_core::{cache::Cache, txn::Txn};
+use vrrb_core::cache::Cache;
 
 /// Maximum over-the-wire size of a Transaction
 ///   1280 is IPv6 minimum MTU

--- a/crates/network/src/types/message.rs
+++ b/crates/network/src/types/message.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use events::{Event, PeerData, Vote};
-use primitives::{FarmerQuorumThreshold, NodeType, QuorumType};
+use primitives::{FarmerQuorumThreshold, NodeType};
 use serde::{Deserialize, Serialize};
 use udp2p::node::peer_id::PeerId;
 use uuid::Uuid;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -8,7 +8,7 @@ mod runtime_module;
 pub mod services;
 pub mod test_utils;
 
-use events::Event;
+
 pub use node_type::*;
 pub use result::*;
 pub use runtime::*;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,10 +1,9 @@
 use std::net::SocketAddr;
 
 use events::{Event, EventMessage, EventPublisher, EventRouter, Topic};
-use jsonrpsee::server::ServerHandle;
 use telemetry::info;
 use tokio::{
-    sync::mpsc::{channel, Sender, UnboundedReceiver},
+    sync::mpsc::{channel, UnboundedReceiver},
     task::JoinHandle,
 };
 use trecho::vm::Cpu;
@@ -12,7 +11,6 @@ use vrrb_config::NodeConfig;
 use vrrb_core::keypair::KeyPair;
 
 use crate::{
-    farmer_module::QuorumMember,
     result::{NodeError, Result},
     runtime::{setup_runtime_components, RuntimeHandle},
     NodeType,

--- a/crates/node/src/runtime/broadcast_module.rs
+++ b/crates/node/src/runtime/broadcast_module.rs
@@ -1,8 +1,6 @@
-use std::{collections::HashSet, net::SocketAddr, result::Result as StdResult, time::Duration};
+use std::{net::SocketAddr, time::Duration};
 
 use async_trait::async_trait;
-use block::Block;
-use bytes::Bytes;
 use events::{Event, EventMessage, EventPublisher};
 use network::{
     message::{Message, MessageBody},
@@ -12,20 +10,9 @@ use primitives::{NodeType, PeerId};
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::{error, info, instrument};
 use theater::{ActorLabel, ActorState, Handler};
-use tokio::{
-    sync::{
-        broadcast::{
-            error::{RecvError, TryRecvError},
-            Receiver,
-        },
-        mpsc::{channel, Receiver as MpscReceiver, Sender},
-    },
-    task::JoinHandle,
-    time::timeout,
-};
 use uuid::Uuid;
 
-use crate::{NodeError, Result, RuntimeModuleState};
+use crate::{NodeError, Result};
 
 pub struct BroadcastModuleConfig {
     pub events_tx: EventPublisher,
@@ -109,8 +96,8 @@ impl BroadcastModule {
                                 MessageBody::RemovePeer { .. } => {},
                                 MessageBody::AddPeer { .. } => {},
                                 MessageBody::DKGPartCommitment {
-                                    part_commitment,
-                                    sender_id,
+                                    part_commitment: _,
+                                    sender_id: _,
                                 } => {},
                                 MessageBody::DKGPartAcknowledgement { .. } => {},
                                 MessageBody::Vote { .. } => {},

--- a/crates/node/src/runtime/broadcast_module.rs
+++ b/crates/node/src/runtime/broadcast_module.rs
@@ -300,11 +300,18 @@ mod tests {
         };
 
         events_tx
-            .send(Event::SyncPeers(vec![peer_data]).into())
+            .send(Event::SyncPeers(vec![peer_data.clone()]).into())
             .unwrap();
+
         events_tx.send(Event::Stop.into()).unwrap();
 
-        let evt = internal_events_rx.recv().await.unwrap();
+        match internal_events_rx.recv().await {
+            Some(value) => assert_eq!(value, Event::SyncPeers(vec![peer_data]).into()),
+            None => println!(
+                "no
+value"
+            ),
+        }
 
         handle.await.unwrap();
     }

--- a/crates/node/src/runtime/dag_module.rs
+++ b/crates/node/src/runtime/dag_module.rs
@@ -23,7 +23,7 @@ use theater::{ActorId, ActorLabel, ActorState, Handler};
 pub type Edge = (Vertex<Block, String>, Vertex<Block, String>);
 pub type Edges = Vec<Edge>;
 pub type GraphResult<T> = Result<T, GraphError>;
-
+///
 /// The runtime module that manages the DAG, both exposing
 /// data within and appending blocks to it.
 ///
@@ -32,8 +32,8 @@ pub type GraphResult<T> = Result<T, GraphError>;
 ///
 /// use block::Block;
 /// use bulldag::graph::BullDag;
+/// use events::EventPublisher;
 /// use hbbft::crypto::PublicKeySet;
-/// use node::EventBroadcastSender;
 /// use theater::{ActorId, ActorLabel, ActorState, Handler};
 ///
 /// pub struct DagModule {

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -1,4 +1,9 @@
-use std::{net::SocketAddr, thread, thread::sleep, time::Duration};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    thread,
+    thread::sleep,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use crossbeam_channel::{select, unbounded, Sender};

--- a/crates/node/src/runtime/dkg_module.rs
+++ b/crates/node/src/runtime/dkg_module.rs
@@ -1,9 +1,4 @@
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    thread,
-    thread::sleep,
-    time::Duration,
-};
+use std::{net::SocketAddr, thread, thread::sleep, time::Duration};
 
 use async_trait::async_trait;
 use crossbeam_channel::{select, unbounded, Sender};
@@ -458,7 +453,7 @@ impl Handler<EventMessage> for DkgModule {
                                 }
                             }
                         },
-                        Err(e) => {
+                        Err(_e) => {
                             error!("Error occured while generating synchronized keygen instance for node {:?}", self.dkg_engine.node_idx);
                         },
                     }

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -18,7 +18,7 @@ use sha2::Digest;
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler};
-use vrrb_core::claim::Claim;
+use vrrb_core::claim::{Claim, Eligibility};
 
 pub type Seed = u64;
 
@@ -214,7 +214,7 @@ impl Handler<EventMessage> for ElectionModule<QuorumElection, QuorumElectionResu
 fn elect_miner(claims: HashMap<NodeId, Claim>, block_seed: u64) -> BTreeMap<U256, Claim> {
     claims
         .iter()
-        .filter(|(_, claim)| claim.eligible)
+        .filter(|(_, claim)| claim.eligibility == Eligibility::Miner)
         .map(|(_nodeid, claim)| single_miner_results(claim, block_seed))
         .collect()
 }

--- a/crates/node/src/runtime/election_module.rs
+++ b/crates/node/src/runtime/election_module.rs
@@ -1,32 +1,23 @@
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, HashMap},
-    error::Error,
+    collections::{BTreeMap, HashMap},
     fmt::Debug,
-    hash::{Hash, Hasher},
+    hash::Hasher,
 };
 
 use async_trait::async_trait;
-use block::{
-    header::BlockHeader,
-    invalid::BlockError,
-    Conflict,
-    ConflictList,
-    RefHash,
-    ResolvedConflicts,
-};
+use block::header::BlockHeader;
 use ethereum_types::U256;
-use events::{ConflictBytes, Event, EventMessage, EventPublisher};
+use events::{Event, EventMessage, EventPublisher};
 use primitives::NodeId;
 use quorum::{
     election::Election,
     quorum::{InvalidQuorum, Quorum},
 };
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use sha2::Digest;
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::info;
-use theater::{ActorId, ActorLabel, ActorState, Handler, TheaterError};
-use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
+use theater::{ActorId, ActorLabel, ActorState, Handler};
 use vrrb_core::claim::Claim;
 
 pub type Seed = u64;
@@ -224,7 +215,7 @@ fn elect_miner(claims: HashMap<NodeId, Claim>, block_seed: u64) -> BTreeMap<U256
     claims
         .iter()
         .filter(|(_, claim)| claim.eligible)
-        .map(|(nodeid, claim)| single_miner_results(claim, block_seed))
+        .map(|(_nodeid, claim)| single_miner_results(claim, block_seed))
         .collect()
 }
 

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -6,7 +6,6 @@ use primitives::{GroupPublicKey, NodeIdx, PeerId, QuorumThreshold};
 use signer::signer::SignatureProvider;
 use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler};
-use tokio::sync::mpsc::UnboundedSender;
 use vrrb_core::txn::{TransactionDigest, Txn};
 
 use crate::scheduler::Job;

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -360,10 +360,12 @@ mod tests {
         let txn_amount: u128 = 1010101;
 
         for n in 1..101 {
-            let sig = keypair
-                .miner_kp
-                .0
-                .sign_ecdsa(Message::from_hashed_data::<secp256k1::hashes::sha256::Hash>(b"vrrb"));
+            let sig = keypair.miner_kp.0.sign_ecdsa(Message::from_hashed_data::<
+                secp256k1::hashes::sha256::Hash,
+            >(
+                b"
+    vrrb",
+            ));
 
             let txn = Txn::new(NewTxnArgs {
                 timestamp: 0,

--- a/crates/node/src/runtime/harvester_module.rs
+++ b/crates/node/src/runtime/harvester_module.rs
@@ -1,5 +1,3 @@
-use std::thread;
-
 use async_trait::async_trait;
 use crossbeam_channel::Sender;
 use dashmap::DashMap;
@@ -7,7 +5,6 @@ use events::{
     Event,
     EventMessage,
     EventPublisher,
-    EventSubscriber,
     JobResult,
     QuorumCertifiedTxn,
     Vote,
@@ -17,14 +14,10 @@ use primitives::{GroupPublicKey, HarvesterQuorumThreshold, QuorumThreshold};
 use signer::signer::SignatureProvider;
 use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler};
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::error;
-use vrrb_core::{
-    bloom::Bloom,
-    txn::{TransactionDigest, Txn},
-};
+use vrrb_core::{bloom::Bloom, txn::TransactionDigest};
 
-use crate::{farmer_module::PULL_TXN_BATCH_SIZE, result::Result, scheduler::Job, NodeError};
+use crate::{farmer_module::PULL_TXN_BATCH_SIZE, scheduler::Job};
 
 /// `CERTIFIED_TXNS_FILTER_SIZE` is a constant that defines the size of the
 /// bloom filter used by the `HarvesterModule` to store the certified
@@ -240,7 +233,7 @@ impl Handler<EventMessage> for HarvesterModule {
                         .send(Event::QuorumCertifiedTxns(txn.clone()).into());
                     let _ = self.certified_txns_filter.push(&txn.txn.id.to_string());
                 });
-                let txns = txns.collect::<Vec<&QuorumCertifiedTxn>>();
+                let _txns = txns.collect::<Vec<&QuorumCertifiedTxn>>();
                 //TODO: Build Proposal Blocks here
             },
             Event::NoOp => {},

--- a/crates/node/src/runtime/indexer_module.rs
+++ b/crates/node/src/runtime/indexer_module.rs
@@ -97,7 +97,10 @@ impl Handler<EventMessage> for IndexerModule {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use events::DEFAULT_BUFFER;
+    use mempool::LeftRightMempool;
     use serial_test::serial;
     use theater::ActorImpl;
 

--- a/crates/node/src/runtime/indexer_module.rs
+++ b/crates/node/src/runtime/indexer_module.rs
@@ -1,18 +1,11 @@
-use std::{hash::Hash, path::PathBuf, sync::Arc};
-
 use async_trait::async_trait;
 use events::{Event, EventMessage};
-use lr_trie::ReadHandleFactory;
-use mempool::{LeftRightMempool, MempoolReadHandleFactory};
-use patriecia::{db::MemoryDB, inner::InnerTrie};
-use storage::vrrbdb::{VrrbDb, VrrbDbReadHandle};
+use mempool::MempoolReadHandleFactory;
 use telemetry::{info, warn};
-use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
-use tokio::{runtime::Runtime, sync::broadcast::error::TryRecvError};
-use vrrb_core::txn::{TransactionDigest, Txn};
+use theater::{Actor, ActorId, ActorLabel, ActorState, Handler};
 use vrrb_http::indexer::{IndexerClient, IndexerClientConfig};
 
-use crate::{result::Result, NodeError, RuntimeModule, MEMPOOL_THRESHOLD_SIZE};
+use crate::RuntimeModule;
 
 pub struct IndexerModuleConfig {
     pub mempool_read_handle_factory: MempoolReadHandleFactory,

--- a/crates/node/src/runtime/mempool_module.rs
+++ b/crates/node/src/runtime/mempool_module.rs
@@ -1,17 +1,11 @@
-use std::{hash::Hash, path::PathBuf};
-
 use async_trait::async_trait;
 use events::{Event, EventMessage, EventPublisher};
-use lr_trie::ReadHandleFactory;
 use mempool::LeftRightMempool;
-use patriecia::{db::MemoryDB, inner::InnerTrie};
-use storage::vrrbdb::{VrrbDb, VrrbDbReadHandle};
 use telemetry::info;
-use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
-use tokio::sync::broadcast::error::TryRecvError;
-use vrrb_core::txn::{TransactionDigest, Txn};
+use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, TheaterError};
+use vrrb_core::txn::TransactionDigest;
 
-use crate::{result::Result, NodeError, RuntimeModule, MEMPOOL_THRESHOLD_SIZE};
+use crate::{RuntimeModule, MEMPOOL_THRESHOLD_SIZE};
 
 pub struct MempoolModuleConfig {
     pub mempool: LeftRightMempool,
@@ -82,7 +76,7 @@ impl Handler<EventMessage> for MempoolModule {
 
                 let txn_hash = txn.id();
 
-                let mempool_size = self
+                let _mempool_size = self
                     .mempool
                     .insert(txn)
                     .map_err(|err| TheaterError::Other(err.to_string()))?;

--- a/crates/node/src/runtime/mining_module.rs
+++ b/crates/node/src/runtime/mining_module.rs
@@ -1,12 +1,10 @@
 use async_trait::async_trait;
-use block::{convergence_block, Block};
 use events::{Event, EventMessage, EventPublisher};
 use mempool::MempoolReadHandleFactory;
 use miner::Miner;
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler};
-use tokio::sync::broadcast::{error::TryRecvError, Receiver};
 use vrrb_core::txn::Txn;
 
 #[derive(Debug)]
@@ -49,7 +47,7 @@ impl MiningModule {
         // TODO: drain mempool instead then commit changes
         handle
             .drain(..cutoff_idx)
-            .map(|(id, record)| record.txn)
+            .map(|(_id, record)| record.txn)
             .collect()
     }
 
@@ -94,7 +92,7 @@ impl Handler<EventMessage> for MiningModule {
             Event::Stop => {
                 return Ok(ActorState::Stopped);
             },
-            Event::ElectedMiner((winner_claim_hash, winner_claim)) => {
+            Event::ElectedMiner((_winner_claim_hash, winner_claim)) => {
                 if self.miner.check_claim(winner_claim.hash) {
                     let mining_result = self.miner.try_mine();
 

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     net::SocketAddr,
-    sync::{mpsc, Arc, RwLock},
+    sync::{Arc, RwLock},
     thread,
 };
 
@@ -8,7 +8,6 @@ use block::Block;
 use bulldag::graph::BullDag;
 use crossbeam_channel::{unbounded, Sender};
 use events::{Event, EventMessage, EventPublisher, EventRouter, EventSubscriber, DEFAULT_BUFFER};
-use jsonrpsee::server::ServerHandle;
 use mempool::{LeftRightMempool, MempoolReadHandleFactory};
 use miner::MinerConfig;
 use network::{network::BroadcastEngine, packet::RaptorBroadCastedData};
@@ -16,13 +15,7 @@ use primitives::{Address, NodeType, QuorumType::Farmer};
 use storage::vrrbdb::{VrrbDbConfig, VrrbDbReadHandle};
 use telemetry::info;
 use theater::{Actor, ActorImpl};
-use tokio::{
-    sync::{
-        broadcast::Receiver,
-        mpsc::{UnboundedReceiver, UnboundedSender},
-    },
-    task::JoinHandle,
-};
+use tokio::task::JoinHandle;
 use validator::validator_core_manager::ValidatorCoreManager;
 use vrrb_config::NodeConfig;
 use vrrb_core::{bloom::Bloom, claim::Claim};
@@ -45,11 +38,7 @@ use self::{
     state_module::StateModule,
 };
 use crate::{
-    broadcast_controller::{
-        BroadcastEngineController,
-        BroadcastEngineControllerConfig,
-        BROADCAST_CONTROLLER_BUFFER_SIZE,
-    },
+    broadcast_controller::{BroadcastEngineController, BroadcastEngineControllerConfig},
     dkg_module::DkgModuleConfig,
     farmer_module::PULL_TXN_BATCH_SIZE,
     scheduler::{Job, JobSchedulerController},
@@ -288,7 +277,7 @@ pub async fn setup_runtime_components(
 }
 
 fn setup_event_routing_system() -> EventRouter {
-    let mut event_router = EventRouter::default();
+    let event_router = EventRouter::default();
 
     event_router
 }
@@ -296,7 +285,7 @@ async fn setup_gossip_network(
     config: &NodeConfig,
     events_tx: EventPublisher,
     mut network_events_rx: EventSubscriber,
-    mut controller_events_rx: EventSubscriber,
+    controller_events_rx: EventSubscriber,
     vrrbdb_read_handle: VrrbDbReadHandle,
     raptor_sender: Sender<RaptorBroadCastedData>,
 ) -> Result<(
@@ -359,7 +348,7 @@ async fn setup_state_store(
     config: &NodeConfig,
     events_tx: EventPublisher,
     mut state_events_rx: EventSubscriber,
-    mempool_read_handle_factory: MempoolReadHandleFactory,
+    _mempool_read_handle_factory: MempoolReadHandleFactory,
 ) -> Result<(VrrbDbReadHandle, Option<JoinHandle<Result<()>>>)> {
     let mut vrrbdb_config = VrrbDbConfig::default();
 
@@ -439,7 +428,7 @@ fn setup_mining_module(
     let (_, miner_secret_key) = config.keypair.get_secret_keys();
     let (_, miner_public_key) = config.keypair.get_public_keys();
 
-    let address = Address::new(*miner_public_key).to_string();
+    let _address = Address::new(*miner_public_key).to_string();
     let miner_config = MinerConfig {
         secret_key: *miner_secret_key,
         public_key: *miner_public_key,
@@ -535,7 +524,7 @@ fn setup_miner_election_module(
 }
 
 fn setup_quorum_election_module(
-    config: &NodeConfig,
+    _config: &NodeConfig,
     events_tx: EventPublisher,
     mut quorum_election_events_rx: EventSubscriber,
     db_read_handle: VrrbDbReadHandle,
@@ -638,7 +627,7 @@ fn setup_dag_module(
 }
 
 fn setup_indexer_module(
-    config: &NodeConfig,
+    _config: &NodeConfig,
     mut indexer_events_rx: EventSubscriber,
     mempool_read_handle_factory: MempoolReadHandleFactory,
 ) -> Result<Option<JoinHandle<Result<()>>>> {
@@ -646,7 +635,7 @@ fn setup_indexer_module(
         mempool_read_handle_factory,
     };
 
-    let mut module = indexer_module::IndexerModule::new(config);
+    let module = indexer_module::IndexerModule::new(config);
 
     let mut indexer_module_actor = ActorImpl::new(module);
 

--- a/crates/node/src/runtime/swarm_module.rs
+++ b/crates/node/src/runtime/swarm_module.rs
@@ -1,14 +1,10 @@
-use std::{hash::Hash, net::SocketAddr, path::PathBuf};
+use std::net::SocketAddr;
 
 use async_trait::async_trait;
 use events::{Event, EventMessage, EventPublisher};
 use kademlia_dht::{Key, Node as KademliaNode, NodeData};
-use lr_trie::ReadHandleFactory;
-use patriecia::{db::MemoryDB, inner::InnerTrie};
 use telemetry::info;
-use theater::{Actor, ActorId, ActorLabel, ActorState, Handler, Message, TheaterError};
-use tokio::sync::broadcast::error::TryRecvError;
-use tracing::error;
+use theater::{Actor, ActorId, ActorLabel, ActorState, Handler};
 
 use crate::{result::Result, NodeError};
 

--- a/crates/node/src/services/broadcast_controller.rs
+++ b/crates/node/src/services/broadcast_controller.rs
@@ -1,6 +1,5 @@
 use std::net::SocketAddr;
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use events::{Event, EventPublisher, EventSubscriber};
 use network::{
@@ -8,18 +7,6 @@ use network::{
     network::{BroadcastEngine, ConnectionIncoming},
 };
 use telemetry::{error, info, warn};
-use theater::{ActorLabel, ActorState, Handler};
-use tokio::{
-    sync::{
-        broadcast::{
-            error::{RecvError, TryRecvError},
-            Receiver,
-        },
-        mpsc::Sender,
-    },
-    task::JoinHandle,
-};
-use uuid::Uuid;
 
 use crate::{NodeError, Result};
 
@@ -62,7 +49,7 @@ impl BroadcastEngineController {
     pub async fn listen(&mut self, mut events_rx: EventSubscriber) -> Result<()> {
         loop {
             tokio::select! {
-                Some((conn, conn_incoming)) = self.engine.get_incoming_connections().next() => {
+                Some((_conn, conn_incoming)) = self.engine.get_incoming_connections().next() => {
                 match self.map_network_conn_to_message(conn_incoming).await {
                     Ok(message) => {
                         self.handle_network_event(message).await;

--- a/crates/node/src/services/scheduler.rs
+++ b/crates/node/src/services/scheduler.rs
@@ -1,16 +1,13 @@
 use std::collections::BTreeMap;
 
-use crossbeam_channel::{unbounded, Receiver, Sender};
-use dashmap::DashMap;
-use events::{Event, EventPublisher, JobResult, QuorumCertifiedTxn, Vote, VoteReceipt};
-use indexmap::IndexMap;
+use crossbeam_channel::Receiver;
+use events::{Event, EventPublisher, JobResult, Vote};
 use job_scheduler::JobScheduler;
 use mempool::TxnRecord;
 use primitives::{base::PeerId as PeerID, ByteVec, FarmerQuorumThreshold};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use signer::signer::{SignatureProvider, Signer};
 use storage::vrrbdb::VrrbDbReadHandle;
-use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
 use validator::validator_core_manager::ValidatorCoreManager;
 use vrrb_core::txn::{TransactionDigest, Txn};
@@ -121,7 +118,7 @@ impl JobSchedulerController {
                         // MagLev Hashing over( Quorum Keys) to identify whether current farmer
                         // quorum is supposed to vote on txn Txn is intended
                         // to be validated by current validator
-                        let backpressure = self.job_scheduler.calculate_back_pressure();
+                        let _backpressure = self.job_scheduler.calculate_back_pressure();
                         //Delegation Principle need to be done
                         let votes_result = self
                             .job_scheduler

--- a/crates/node/tests/state_sync.rs
+++ b/crates/node/tests/state_sync.rs
@@ -14,6 +14,7 @@ use vrrb_core::txn::NewTxnArgs;
 use vrrb_rpc::rpc::{api::RpcApiClient, client::create_client};
 
 #[tokio::test]
+#[ignore = "state sync is not implemented yet"]
 async fn nodes_can_synchronize_state() {
     // NOTE: two instances of a config are required because the node will create a
     // data directory for the database which cannot be the same for both nodes
@@ -50,7 +51,6 @@ async fn nodes_can_synchronize_state() {
 
         let signature =
             sk.sign_ecdsa(Message::from_hashed_data::<secp256k1::hashes::sha256::Hash>(b"vrrb"));
-
         client_1
             .create_txn(NewTxnArgs {
                 timestamp: 0,

--- a/crates/storage/vrrbdb/src/claim_store/mod.rs
+++ b/crates/storage/vrrbdb/src/claim_store/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use lr_trie::{LeftRightTrie, H256};
 use primitives::{NodeId, NodeIdentifier};

--- a/crates/storage/vrrbdb/src/rocksdb_adapter.rs
+++ b/crates/storage/vrrbdb/src/rocksdb_adapter.rs
@@ -104,16 +104,21 @@ impl Default for RocksDbAdapter {
         options.create_if_missing(true);
         options.create_missing_column_families(true);
 
-        let db = new_db_instance(
+        let db_result = new_db_instance(
             options,
             DEFAULT_VRRB_DB_PATH.into(),
             DEFAULT_COLUMN_FAMILY_NAME,
-        )
-        .unwrap();
+        );
 
-        Self {
-            db,
-            column: DEFAULT_COLUMN_FAMILY_NAME.to_string(),
+        match db_result {
+            Ok(db) => Self {
+                db,
+                column: DEFAULT_COLUMN_FAMILY_NAME.to_string(),
+            },
+            Err(e) => {
+                error!("Failed to create database: {}", e);
+                Self::default()
+            },
         }
     }
 }

--- a/crates/storage/vrrbdb/src/rocksdb_adapter.rs
+++ b/crates/storage/vrrbdb/src/rocksdb_adapter.rs
@@ -1,5 +1,5 @@
 use patriecia::db::Database;
-use primitives::{base, get_vrrb_environment, Environment, DEFAULT_VRRB_DB_PATH};
+use primitives::{get_vrrb_environment, Environment, DEFAULT_VRRB_DB_PATH};
 use rocksdb::{DB, DEFAULT_COLUMN_FAMILY_NAME};
 use storage_utils::{get_node_data_dir, StorageError};
 use telemetry::error;

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use storage_utils::{Result, StorageError};
 use vrrb_core::{
     account::{Account, UpdateArgs},
-    claim::{self, Claim},
+    claim::Claim,
     txn::Txn,
 };
 

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 telemetry = { workspace = true }
 rayon = { workspace = true }
+hbbft = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/validator/src/claim_validator.rs
+++ b/crates/validator/src/claim_validator.rs
@@ -1,0 +1,147 @@
+use std::result::Result as StdResult;
+
+use hbbft::crypto::{PublicKey, Signature};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use vrrb_core::{
+    claim::{Claim, Eligibility},
+    staking::{Stake, StakeUpdate, MIN_STAKE_FARMER, MIN_STAKE_VALIDATOR},
+};
+
+pub type Result<T> = StdResult<T, ClaimValidatorError>;
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq, Hash)]
+pub enum ClaimValidatorError {
+    #[error("Non eligible claim")]
+    NotEligibleClaim,
+
+    #[error("Non enough stake for {0}")]
+    NotEnoughStake(String),
+
+    #[error("Invalid Stake Txn")]
+    InvalidStakeTxn,
+
+    #[error("Non Certified Stake ")]
+    NonCertifiedStake,
+
+    #[error("timestamp {0} is outside of the permitted date range [0, {1}]")]
+    OutOfBoundsTimestamp(i64, i64),
+
+    #[error("value {0} is outside of the permitted range [{1}, {2}]")]
+    OutOfBounds(String, String, String),
+
+    #[error("Quorum Key missing")]
+    QuorumKeyMissing,
+
+    #[error("Invalid Quorum Key ")]
+    InvalidQuorumKey,
+
+    #[error("One of the stake of claim has invalid Certificate")]
+    InvalidStakeCertificate,
+
+    #[error("Temporary Jailed, Node needs to put stake to get unjailed")]
+    Jailed,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClaimValidator;
+
+impl ClaimValidator {
+    /// The function validates a claim by checking if it is eligible, has enough
+    /// stake, and verifying the stake transactions and certificates.
+    ///
+    /// Arguments:
+    ///
+    /// * `claim`: The `claim` parameter is a reference to a `Claim` object that
+    ///   needs to be validated.
+    ///
+    /// Returns:
+    ///
+    /// a `Result<()>` type, which is an empty tuple `()` wrapped in a `Result`
+    /// enum. If the validation is successful, it returns an `Ok(())`
+    /// variant, and if there is an error, it returns an `Err` variant with
+    /// a `ClaimValidatorError` enum as the error type.
+    pub fn validate(&self, claim: &Claim) -> Result<()> {
+        if claim.eligibility == Eligibility::None {
+            return Err(ClaimValidatorError::NotEligibleClaim);
+        }
+        match claim.eligibility {
+            Eligibility::Harvester => {
+                if claim.get_stake() < MIN_STAKE_VALIDATOR {
+                    return Err(ClaimValidatorError::NotEnoughStake(
+                        claim.eligibility.to_string(),
+                    ));
+                }
+            },
+            Eligibility::Miner => {},
+            Eligibility::Farmer => {
+                if claim.get_stake() < MIN_STAKE_FARMER {
+                    return Err(ClaimValidatorError::NotEnoughStake(
+                        claim.eligibility.to_string(),
+                    ));
+                }
+            },
+            Eligibility::None => {},
+        }
+
+        let stakes = claim.get_stake_txns();
+        if let Some(last_stake) = stakes.last() {
+            match last_stake.get_amount() {
+                StakeUpdate::Slash(amount) => {
+                    if amount > 0 {
+                        return Err(ClaimValidatorError::Jailed);
+                    }
+                },
+                _ => {},
+            }
+        }
+
+        stakes
+            .par_iter()
+            .try_for_each(|stake: &Stake| -> Result<()> {
+                stake
+                    .verify()
+                    .map_err(|_| ClaimValidatorError::InvalidStakeTxn)?;
+                self.validate_timestamp(&stake)?;
+                match stake.get_certificate() {
+                    None => return Err(ClaimValidatorError::NonCertifiedStake),
+                    Some(certificate) => {
+                        if stake.get_quorum_key().is_empty() {
+                            return Err(ClaimValidatorError::QuorumKeyMissing);
+                        }
+                        let public_key_arr = TryInto::<[u8; 48]>::try_into(stake.get_quorum_key())
+                            .map_err(|_| ClaimValidatorError::InvalidQuorumKey)?;
+                        let public_key = PublicKey::from_bytes(&public_key_arr)
+                            .map_err(|_| ClaimValidatorError::InvalidQuorumKey)?;
+
+                        let signature_arr = TryInto::<[u8; 96]>::try_into(certificate.0.as_slice())
+                            .map_err(|_| ClaimValidatorError::InvalidStakeCertificate)?;
+
+                        let signature = Signature::from_bytes(signature_arr)
+                            .map_err(|_| ClaimValidatorError::InvalidStakeCertificate)?;
+
+                        let status = public_key.verify(&signature, certificate.1.clone());
+                        if !status {
+                            return Err(ClaimValidatorError::InvalidStakeCertificate);
+                        }
+                    },
+                }
+
+                Ok(())
+            })?;
+
+        Ok(())
+    }
+
+    pub fn validate_timestamp(&self, stake: &Stake) -> Result<()> {
+        let timestamp = chrono::offset::Utc::now().timestamp();
+        let stake_timestamp = stake.get_timestamp();
+        if stake_timestamp > 0 && stake_timestamp < timestamp {
+            return Ok(());
+        } else {
+            Err(ClaimValidatorError::OutOfBoundsTimestamp(
+                stake_timestamp,
+                timestamp,
+            ))
+        }
+    }
+}

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -1,4 +1,5 @@
 // pub mod mempool_processor;
+pub mod claim_validator;
 pub mod result;
 pub mod txn_validator;
 pub mod validator_core;

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -66,11 +66,7 @@ mod tests {
             .iter()
             .cloned()
             .map(|txn| {
-                let account = txn.sender_address.clone();
-                let err = Err(crate::txn_validator::TxnValidatorError::AccountNotFound(
-                    account,
-                ));
-
+                let err = Err(crate::txn_validator::TxnValidatorError::SenderAddressIncorrect);
                 (txn, err)
             })
             .collect();

--- a/crates/validator/src/validator_core.rs
+++ b/crates/validator/src/validator_core.rs
@@ -3,7 +3,6 @@ use std::{
     sync::mpsc::RecvError,
 };
 
-use left_right::{ReadHandle, ReadHandleFactory};
 use primitives::Address;
 use vrrb_core::{account::Account, txn::*};
 

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -29,10 +29,31 @@ pub struct Claim {
     pub public_key: PublicKey,
     pub address: Address,
     pub hash: U256,
-    pub eligible: bool,
+    pub eligibility: Eligibility,
     stake: u128,
     stake_txns: Vec<Stake>,
 }
+
+///Node has privileges to be Miner/Validator,Farmer or None
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum Eligibility {
+    Harvester,
+    Miner,
+    Farmer,
+    None,
+}
+
+impl std::fmt::Display for Eligibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Eligibility::Harvester => write!(f, "Harvester"),
+            Eligibility::Farmer => write!(f, "Farmer"),
+            Eligibility::Miner => write!(f, "Miner"),
+            Eligibility::None => write!(f, "None"),
+        }
+    }
+}
+
 
 impl Claim {
     /// Creates a new claim from a public key, address and nonce.
@@ -45,7 +66,7 @@ impl Claim {
             public_key,
             address,
             hash,
-            eligible: true,
+            eligibility: Eligibility::None,
             stake: 0,
             stake_txns: vec![],
         }
@@ -240,7 +261,7 @@ mod tests {
             public_key: public_key.clone(),
             address: address.clone(),
             hash,
-            eligible: true,
+            eligibility: Eligibility::None,
             stake: 0,
             stake_txns: vec![],
         };
@@ -337,7 +358,8 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 10_000u128);
@@ -361,7 +383,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake_txns().len(), 1);
@@ -385,7 +407,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 10_000u128);
@@ -401,7 +423,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 5_000u128);
@@ -425,7 +447,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 0u128);
@@ -450,7 +472,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 10_000u128);
@@ -466,7 +488,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 7_500u128);
@@ -490,7 +512,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 0u128);
@@ -515,7 +537,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 10_000u128);
@@ -531,7 +553,7 @@ mod tests {
         )
         .unwrap();
 
-        stake.certify(vec![0; 96]).unwrap();
+        stake.certify((vec![0; 96], vec![0; 96])).unwrap();
 
         assert!(claim.update_stake(stake).is_ok());
         assert_eq!(claim.get_stake(), 90_000u128);

--- a/crates/vrrb_http/src/indexer.rs
+++ b/crates/vrrb_http/src/indexer.rs
@@ -1,5 +1,3 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
 use http::{HttpClient, HttpClientBuilder};
 use mempool::TxnRecord;
 use reqwest::StatusCode;
@@ -34,7 +32,7 @@ impl IndexerClient {
         Ok(Self { client })
     }
 
-    pub async fn post_tx(mut self, txn_record: &TxnRecord) -> Result<StatusCode> {
+    pub async fn post_tx(self, txn_record: &TxnRecord) -> Result<StatusCode> {
         let req_json = serde_json::to_string(txn_record).map_err(|e| Error::SerdeJson(e));
 
         let response = self

--- a/crates/vrrb_rpc/src/http/router.rs
+++ b/crates/vrrb_rpc/src/http/router.rs
@@ -1,5 +1,4 @@
 use axum::{routing::get, Router};
-use events::Event;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 
@@ -8,7 +7,7 @@ use crate::http::{
     HttpApiRouterConfig,
 };
 
-pub fn create_router(config: &HttpApiRouterConfig) -> Router {
+pub fn create_router(_config: &HttpApiRouterConfig) -> Router {
     Router::new()
         .route("/", get(|| async { "index" }))
         .route("/health", get(health::health_check))

--- a/crates/vrrb_rpc/src/http/routes/accounts.rs
+++ b/crates/vrrb_rpc/src/http/routes/accounts.rs
@@ -1,5 +1,5 @@
 use axum::{
-    routing::{get, post, put, Route},
+    routing::{get, post, put},
     Extension,
     Json,
     Router,

--- a/crates/vrrb_rpc/src/http/server.rs
+++ b/crates/vrrb_rpc/src/http/server.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Debug,
-    net::{SocketAddr, TcpListener, TcpStream},
+    net::{SocketAddr, TcpListener},
     time::Duration,
 };
 

--- a/crates/vrrb_rpc/src/rpc/api.rs
+++ b/crates/vrrb_rpc/src/rpc/api.rs
@@ -1,8 +1,7 @@
-use std::{collections::HashMap, net::SocketAddr};
+use std::collections::HashMap;
 
-use async_trait::async_trait;
-use jsonrpsee::{core::Error, proc_macros::rpc, types::SubscriptionResult};
-use primitives::{Address, NodeType, SerializedPublicKey};
+use jsonrpsee::{core::Error, proc_macros::rpc};
+use primitives::{Address, NodeType};
 use serde::{Deserialize, Serialize};
 use vrrb_core::{
     account::Account,

--- a/crates/vrrb_rpc/src/rpc/server.rs
+++ b/crates/vrrb_rpc/src/rpc/server.rs
@@ -1,17 +1,11 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use async_trait::async_trait;
-use events::{Event, EventPublisher, DEFAULT_BUFFER};
-use jsonrpsee::{
-    core::Error,
-    server::{ServerBuilder, ServerHandle, SubscriptionSink},
-    types::SubscriptionResult,
-};
-use mempool::{LeftRightMempool, Mempool, MempoolReadHandleFactory};
+use events::{EventPublisher, DEFAULT_BUFFER};
+use jsonrpsee::server::{ServerBuilder, ServerHandle};
+use mempool::{LeftRightMempool, MempoolReadHandleFactory};
 use primitives::NodeType;
 use storage::vrrbdb::{VrrbDb, VrrbDbConfig, VrrbDbReadHandle};
 use tokio::sync::mpsc::channel;
-use vrrb_core::{account::Account, txn::NewTxnArgs};
 
 use crate::rpc::{api::RpcApiServer, server_impl::RpcServerImpl};
 

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::SocketAddr, str::FromStr};
+use std::{collections::HashMap, str::FromStr};
 
 use async_trait::async_trait;
 use events::{Event, EventPublisher};
@@ -9,7 +9,6 @@ use secp256k1::{Message, SecretKey};
 use sha2::{Digest, Sha256};
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::{debug, error};
-use tokio::sync::mpsc::UnboundedSender;
 use vrrb_core::{
     account::Account,
     serde_helpers::encode_to_binary,
@@ -116,7 +115,7 @@ impl RpcApiServer for RpcServerImpl {
 
         let parsed_digest = transaction_digest
             .parse::<TransactionDigest>()
-            .map_err(|err| Error::Custom("unable to parse transaction digest".to_string()))?;
+            .map_err(|_err| Error::Custom("unable to parse transaction digest".to_string()))?;
 
         let values = self.vrrbdb_read_handle.transaction_store_values();
         let value = values.get(&parsed_digest);

--- a/crates/vrrb_rpc/tests/rpc.rs
+++ b/crates/vrrb_rpc/tests/rpc.rs
@@ -78,7 +78,9 @@ async fn server_can_publish_transactions_to_be_created() {
     let mock_receiver_address =
         "028b0d9b8a79ef99e2d2c030123aef543ffa7e8583e480f229ae7fccd89c8ddbfa".to_string();
 
-    let mock_signature= "30440220029d8f55b771933f5bcea06771cda9fa793478317a5633407366d3f2186ac994022012f5bdc5217f192a34a62e9856c6efd9a0803e7a93bfaefb95783da29c52c3df".to_string();
+    let mock_signature=
+"30440220029d8f55b771933f5bcea06771cda9fa793478317a5633407366d3f2186ac994022012f5bdc5217f192a34a62e9856c6efd9a0803e7a93bfaefb95783da29c52c3df"
+.to_string();
 
     let mock_record = RpcTransactionRecord {
         id: mock_digest,

--- a/crates/wallet/src/v2/mod.rs
+++ b/crates/wallet/src/v2/mod.rs
@@ -9,14 +9,9 @@ use primitives::Address;
 use secp256k1::{ecdsa::Signature, Message, PublicKey, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use telemetry::{debug, error};
+use telemetry::error;
 use thiserror::Error;
-use vrrb_core::{
-    account::Account,
-    helpers::write_keypair_file,
-    keypair::KeyPairError,
-    txn::{Token, TransactionDigest, Txn},
-};
+use vrrb_core::{account::Account, txn::Token};
 use vrrb_rpc::rpc::{
     api::{RpcApiClient, RpcTransactionDigest, RpcTransactionRecord},
     client::create_client,
@@ -314,7 +309,7 @@ impl Wallet {
         let account = Account::new(public_key);
         let address = Address::new(public_key);
 
-        let result = self
+        let _result = self
             .client
             .create_account(address.clone(), account.clone())
             .await


### PR DESCRIPTION
## What
`miner` (lib) generated 1 warning:
```
warning: constant `GENESIS_ALLOWED_MINERS` is never used
  --> crates/miner/src/miner.rs:53:7
   |
53 | const GENESIS_ALLOWED_MINERS: [&str; 2] = [
   |       ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

## Why
Somewhat related to #218 
