### PR TITLE
rm crates/network warnings (6)

### DIFF
--- a/crates/network/src/network.rs
+++ b/crates/network/src/network.rs
@@ -12,11 +12,9 @@ use crossbeam_channel::{unbounded, Sender};
 use futures::{stream::FuturesUnordered, StreamExt};
 use primitives::{
     DEFAULT_CONNECTION_TIMEOUT_IN_SECS,
-    NUMBER_OF_NETWORK_PACKETS,
     RAPTOR_DECODER_CACHE_LIMIT,
     RAPTOR_DECODER_CACHE_TTL_IN_SECS,
 };
-use qp2p::ConnectionError;
 pub use qp2p::{
     Config,
     Connection,
@@ -28,7 +26,7 @@ pub use qp2p::{
 use raptorq::Decoder;
 use serde::{Deserialize, Serialize};
 use telemetry::{error, info};
-use tokio::{net::UdpSocket, time::error::Elapsed};
+use tokio::net::UdpSocket;
 use vrrb_core::cache::Cache;
 
 use crate::{
@@ -428,21 +426,13 @@ impl BroadcastEngine {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::{Ipv6Addr, SocketAddr},
-        thread,
-        time::Duration,
-    };
+    use std::net::{Ipv6Addr, SocketAddr};
 
-    use block::{header::BlockHeader, Block, ConvergenceBlock};
     use bytes::Bytes;
-    use crossbeam_channel::unbounded;
-    use vrrb_core::{claim::Claim, txn::Txn};
 
     use crate::{
         message::{Message, MessageBody},
         network::{BroadcastEngine, Timeout},
-        packet::RaptorBroadCastedData,
     };
 
     #[tokio::test]

--- a/crates/network/src/packet.rs
+++ b/crates/network/src/packet.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     convert::TryInto,
     error::Error,
     fs,
@@ -20,7 +20,7 @@ use raptorq::{Decoder, Encoder, EncodingPacket, ObjectTransmissionInformation};
 use serde::{Deserialize, Serialize};
 use telemetry::error;
 use tokio::net::UdpSocket;
-use vrrb_core::{cache::Cache, txn::Txn};
+use vrrb_core::cache::Cache;
 
 /// Maximum over-the-wire size of a Transaction
 ///   1280 is IPv6 minimum MTU

--- a/crates/network/src/types/message.rs
+++ b/crates/network/src/types/message.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use events::{Event, PeerData, Vote};
-use primitives::{FarmerQuorumThreshold, NodeType, QuorumType};
+use primitives::{FarmerQuorumThreshold, NodeType};
 use serde::{Deserialize, Serialize};
 use udp2p::node::peer_id::PeerId;
 use uuid::Uuid;


### PR DESCRIPTION
## What
`network` (lib) generated 6 warnings

```
warning: unused import: `NUMBER_OF_NETWORK_PACKETS`
  --> crates/network/src/network.rs:15:5
   |
15 |     NUMBER_OF_NETWORK_PACKETS,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `qp2p::ConnectionError`
  --> crates/network/src/network.rs:19:5
   |
19 | use qp2p::ConnectionError;
   |     ^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `time::error::Elapsed`
  --> crates/network/src/network.rs:31:29
   |
31 | use tokio::{net::UdpSocket, time::error::Elapsed};
   |                             ^^^^^^^^^^^^^^^^^^^^

warning: unused import: `HashMap`
 --> crates/network/src/packet.rs:2:19
  |
2 |     collections::{HashMap, HashSet},
  |                   ^^^^^^^

warning: unused import: `txn::Txn`
  --> crates/network/src/packet.rs:23:31
   |
23 | use vrrb_core::{cache::Cache, txn::Txn};
   |                               ^^^^^^^^

warning: unused import: `QuorumType`
 --> crates/network/src/types/message.rs:4:51
  |
4 | use primitives::{FarmerQuorumThreshold, NodeType, QuorumType};
  |                                                   ^^^^^^^^^^
```

## Why
Somewhat related to #218 