### PR TITLE
[WIP] Reputation Module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ kademlia-dht = { git = "https://github.com/vrrb-io/kademlia-dht-rs" }
 rendezvous_dht = { git = "https://github.com/vrrb-io/rendezvous_dht" }
 messr = { git = "https://github.com/vrrb-io/messr" }
 decentrust = { git = "https://github.com/vrrb-io/decentrust", branch = "main" }
+buckets = { git = "https://github.com/vrrb-io/buckets", branch = "main" }
 
 secp256k1 = { version = "0.25.0", features = [
     "rand",
@@ -191,6 +192,8 @@ wiremock = "0.5.18"
 url = "2.3.1"
 bs58 = "0.4.0"
 ring = "0.16.20"
+ordered-float = "3.6.0"
+num-traits = "0.2"
 
 [dev-dependencies]
 cuckoofilter.workspace = true

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -35,6 +35,7 @@ cuckoofilter = { workspace = true }
 ethereum-types = { workspace = true }
 quorum = { workspace = true }
 messr = { workspace = true }
+decentrust = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -6,6 +6,7 @@ use primitives::{
     Address,
     FarmerQuorumThreshold,
     HarvesterQuorumThreshold,
+    NodeId,
     QuorumPublicKey,
     QuorumSize,
 };
@@ -115,6 +116,8 @@ pub enum Event {
     CertifiedTxn(JobResult),
     RepUpdate(RepUpdateBytes),
     InitRepUpdate(RepUpdateBytes),
+    GetBuckets,
+    RepBuckets(Vec<(NodeId, usize)>),
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -22,6 +22,7 @@ pub type AccountBytes = Vec<u8>;
 pub type BlockBytes = Vec<u8>;
 pub type HeaderBytes = Vec<u8>;
 pub type ConflictBytes = Vec<u8>;
+pub type RepUpdateBytes = Vec<u8>;
 
 #[derive(Default, Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -112,6 +113,8 @@ pub enum Event {
     FarmerQuorum(QuorumSize, FarmerQuorumThreshold),
     HarvesterQuorum(QuorumSize, HarvesterQuorumThreshold),
     CertifiedTxn(JobResult),
+    RepUpdate(RepUpdateBytes),
+    InitRepUpdate(RepUpdateBytes),
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/events/src/event_data.rs
+++ b/crates/events/src/event_data.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
-use primitives::{ByteVec, FarmerQuorumThreshold, NodeIdx, NodeType, PeerId, RawSignature};
+use decentrust::honest_peer::Update;
+use primitives::{ByteVec, FarmerQuorumThreshold, NodeId, NodeIdx, NodeType, PeerId, RawSignature};
 use serde::{Deserialize, Serialize};
 use vrrb_core::txn::{TransactionDigest, Txn};
 
@@ -85,6 +86,15 @@ impl QuorumCertifiedTxn {
             signature,
         }
     }
+}
+
+/// A type used to encapsulate Reputation Updates
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReputationUpdateEvent {
+    pub sender: Option<NodeId>,
+    pub peer: NodeId,
+    pub delta: f64,
+    pub update: Update,
 }
 
 // `JobResult` is an enum that represents the possible results of a job that is

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -65,6 +65,10 @@ sha2 = { workspace = true }
 bulldag = { workspace = true }
 vrrb_http = { workspace = true }
 messr = { workspace = true }
+decentrust = { workspace = true }
+ordered-float = { workspace = true }
+buckets = { workspace = true }
+num-traits = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/crates/node/src/runtime/broadcast_module.rs
+++ b/crates/node/src/runtime/broadcast_module.rs
@@ -226,7 +226,7 @@ impl Handler<EventMessage> for BroadcastModule {
                     },
                 }
             },
-            /// Broadcasting the Convergence block to the peers.
+            // Broadcasting the Convergence block to the peers.
             Event::BlockConfirmed(block) => {
                 let status = self
                     .broadcast_engine

--- a/crates/node/src/runtime/reputation_module.rs
+++ b/crates/node/src/runtime/reputation_module.rs
@@ -439,6 +439,11 @@ where
                     }
                 }
             },
+            Event::GetBuckets => {
+                let buckets: Vec<(NodeId, usize)> =
+                    { self.bucketize_reputation_raw_global().collect() };
+                let _ = self.events_tx.send(Event::RepBuckets(buckets).into());
+            },
             Event::NoOp => {},
             _ => {},
         }

--- a/crates/node/src/runtime/reputation_module.rs
+++ b/crates/node/src/runtime/reputation_module.rs
@@ -1,1 +1,470 @@
+use std::{
+    collections::HashSet,
+    fmt::Debug,
+    hash::Hash,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, Sub, SubAssign},
+};
 
+use async_trait::async_trait;
+use buckets::bucketize::BucketizeSingle;
+use decentrust::{
+    cms::CountMinSketch,
+    honest_peer::{HonestPeer, Update},
+    probabilistic::LightHonestPeer,
+};
+use events::{Event, EventMessage, EventPublisher};
+use num_traits::Bounded;
+use telemetry::info;
+use theater::{ActorId, ActorImpl, ActorLabel, ActorState, Handler};
+
+/// A configuration struct for the Reputation Module
+/// providing the data necessary to construct a new
+/// reputation module
+///
+/// ```
+/// use std::{
+///     hash::Hash,
+///     fmt::Debug,
+///     ops::{
+///         SubAssign,
+///         AddAssign,
+///         DivAssign,
+///         Add,
+///         Sub,
+///         Mul,
+///         Div
+///     }
+/// };
+///
+/// use buckets::bucketize::BucketizeSingle;
+/// use events::EventPublisher;
+///
+/// pub struct ReputationModuleConfig<K, V, B>
+/// where
+///     K: Hash, Eq, Clone, Debug + ToString
+///     V: AddAssign
+///     + DivAssign
+///     + SubAssign
+///     + Add<Output = V>
+///     + Sub<Output = V>
+///     + Mul<Output = V>
+///     + Div<Output = V>
+///     + Copy
+///     + Default
+///     + Bounded
+///     + Ord
+///     + Hash
+///     + Debug,
+///     + B: BucketizeSingle<V>,
+/// {
+///     
+///    pub reputation_error_bound: f64,
+///    pub reputation_probability: f64,
+///    pub reputation_max_entries: f64,
+///    pub reputation_min: V,
+///    pub reputation_max: V,
+///    pub credit_error_bound: f64,
+///    pub credit_probability: f64,
+///    pub credit_max_entries: f64,
+///    pub credit_min: V,
+///    pub credit_max: V,
+///    pub events_tx: EventPublisher
+///    pub bucketizer: B,
+/// }
+/// ```
+pub struct ReputationModuleConfig<V, B>
+where
+    V: AddAssign
+        + DivAssign
+        + SubAssign
+        + Add<Output = V>
+        + Sub<Output = V>
+        + Mul<Output = V>
+        + Div<Output = V>
+        + Copy
+        + Default
+        + Bounded
+        + Ord
+        + Hash
+        + Debug,
+    B: BucketizeSingle<V> + Clone,
+{
+    pub reputation_error_bound: f64,
+    pub reputation_probability: f64,
+    pub reputation_max_entries: f64,
+    pub reputation_min: V,
+    pub reputation_max: V,
+    pub credit_error_bound: f64,
+    pub credit_probability: f64,
+    pub credit_max_entries: f64,
+    pub credit_min: V,
+    pub credit_max: V,
+    pub events_tx: EventPublisher,
+    pub bucketizer: B,
+}
+
+/// A module for tracking the reputation and message credits of peers
+/// in a decentralized, trustless, peer to peer network.
+///
+/// ```
+/// use std::{
+///     collections::HashSet,
+///     fmt::Debug,
+///     hash::Hash,
+///     ops::{Add, AddAssign, Div, DivAssign, Mul, Sub, SubAssign},
+/// };
+///
+/// use buckets::bucketize::BucketizeSingle;
+/// use decentrust::probabilistic::LightHonestPeer;
+/// use events::EventPublisher;
+/// use num_traits::Bounded;
+/// use theater::{ActorId, ActorImpl, ActorLabel, ActorState, Handler};
+///
+/// pub struct ReputationModule<K, V, B>
+/// where
+///     K: Hash + Eq + Clone + Debug + ToString,
+///     V: AddAssign
+///         + DivAssign
+///         + SubAssign
+///         + Add<Output = V>
+///         + Sub<Output = V>
+///         + Mul<Output = V>
+///         + Div<Output = V>
+///         + Copy
+///         + Default
+///         + Bounded
+///         + Ord
+///         + Hash
+///         + Debug,
+///     B: BucketizeSingle<V>,
+/// {
+///     status: ActorState,
+///     label: ActorLabel,
+///     id: ActorId,
+///     events_tx: EventPublisher,
+///     reputation: LightHonestPeer<K, V>,
+///     credits: LightHonestPeer<K, V>,
+///     bucketizer: B,
+///     peer_set: HashSet<K>,
+/// }
+/// ```
+pub struct ReputationModule<K, V, B>
+where
+    K: Hash + Eq + Clone + Debug + ToString,
+    V: AddAssign
+        + DivAssign
+        + SubAssign
+        + Add<Output = V>
+        + Sub<Output = V>
+        + Mul<Output = V>
+        + Div<Output = V>
+        + Copy
+        + Default
+        + Bounded
+        + Ord
+        + Hash
+        + Debug,
+    B: BucketizeSingle<V>,
+{
+    status: ActorState,
+    label: ActorLabel,
+    id: ActorId,
+    events_tx: EventPublisher,
+    reputation: LightHonestPeer<K, V>,
+    credits: LightHonestPeer<K, V>,
+    bucketizer: B,
+    peer_set: HashSet<K>,
+}
+
+impl<K, V, B> ReputationModule<K, V, B>
+where
+    K: Hash + Eq + Clone + Debug + ToString,
+    V: AddAssign
+        + DivAssign
+        + SubAssign
+        + Add<Output = V>
+        + Sub<Output = V>
+        + Mul<Output = V>
+        + Div<Output = V>
+        + Copy
+        + Default
+        + Bounded
+        + Ord
+        + Hash
+        + Debug,
+    B: BucketizeSingle<V> + Clone,
+{
+    /// Creates a new `ReputationModule` struct with two
+    /// `LightHonestPeer` instances and a Bucketizer,
+    /// as well as all the Actor required objects.
+    /// Also receives an EventPublisher.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use node::runtime::reputation_module::{
+    ///     ReputationModuleConfig,
+    ///     ReputationModule
+    /// };
+    /// use buckets::bucketize::BucketizeSingle;
+    /// use buckets::bucketizers::FixedWidthBucketizer;
+    /// use events::EventPublisher;
+    /// use decentrust::probabilistic::LightHonestPeer;
+    /// use ordered_float::OrderedFloat;
+    /// use num_traits::Bounded;
+    /// use theater::{ActorState, ActorId, ActorLabel, ActorImpl, Handler};
+    /// use tokio::sync::mpsc::channel;
+    ///
+    /// let (tx, rx) = channel();
+    ///
+    /// let bucketizer: FixedWidthBucketizer<OrderedFloat<f64>> = FixedWidthBucketizer::new();
+    ///
+    /// let config = ReputationModuleConfig<OrderedFloat<f64>> {
+    ///     reputation_error_bound: 50.0f64,
+    ///     reputation_probability: 0.001f64,
+    ///     reputation_max_entries: 10_000.0f64,
+    ///     reputation_min: OrderedFloat::from(0.0f64)
+    ///     reputation_max: OrderedFloat::from(1000.0f64)
+    ///     credit_error_bound: 100.0f64,
+    ///     credit_probability: 0.01f64,
+    ///     credit_max_entries: 30_000.0f64,
+    ///     credit_min: OrderedFloat::from(0.0f64),
+    ///     credit_max: OrderedFloat::from(f64::max_value()),
+    ///     events_tx: tx.clone(),
+    ///     bucketizer,
+    /// };
+    ///
+    /// let reputation_module: ReputationModule<
+    ///     &str,
+    ///     OrderedFloat<f64>,
+    ///     FixedWidthBucketizer<
+    ///         OrderedFloat<f64>
+    ///     >
+    /// > = ReputationModule::new(&config);
+    /// ```
+    pub fn new(config: ReputationModuleConfig<V, B>) -> Self {
+        let reputation: LightHonestPeer<K, V> = LightHonestPeer::new_from_bounds(
+            config.reputation_error_bound,
+            config.reputation_probability,
+            config.reputation_max_entries,
+            config.reputation_min,
+            config.reputation_max,
+        );
+
+        let credits: LightHonestPeer<K, V> = LightHonestPeer::new_from_bounds(
+            config.credit_error_bound,
+            config.credit_probability,
+            config.credit_max_entries,
+            config.credit_min,
+            config.credit_max,
+        );
+
+        ReputationModule {
+            id: uuid::Uuid::new_v4().to_string(),
+            label: String::from("Reputation"),
+            status: ActorState::Stopped,
+            events_tx: config.events_tx,
+            reputation,
+            credits,
+            bucketizer: config.bucketizer,
+            peer_set: HashSet::new(),
+        }
+    }
+
+    fn init_local_reputation(&mut self, peer: &K, init_value: V) {
+        self.reputation.init_local(peer, init_value);
+    }
+
+    fn update_local_reputation(&mut self, receiver: &K, value: V, update: Update) {
+        self.reputation.update_local(receiver, value, update);
+    }
+
+    fn get_reputation_raw_local(&self, key: &K) -> Option<V> {
+        self.reputation.get_raw_local(key)
+    }
+
+    fn get_reputation_normalized_local(&self, key: &K) -> Option<V> {
+        self.reputation.get_normalized_local(key)
+    }
+
+    fn get_reputation_raw_local_map(&self) -> CountMinSketch<V> {
+        self.reputation.get_raw_local_map()
+    }
+
+    fn get_reputation_normalized_local_map(&self) -> CountMinSketch<V> {
+        self.reputation.get_normalized_local_map()
+    }
+
+    fn init_global_reputation(&mut self, peer: &K, init_value: V) {
+        self.reputation.init_global(peer, init_value)
+    }
+
+    fn update_global_reputation(&mut self, sender: &K, receiver: &K, value: V, update: Update) {
+        self.reputation
+            .update_global(sender, receiver, value, update);
+    }
+
+    fn get_reputation_raw_global(&self, key: &K) -> Option<V> {
+        self.reputation.get_raw_global(key)
+    }
+
+    fn get_reputation_normalized_global(&self, key: &K) -> Option<V> {
+        self.reputation.get_normalized_global(key)
+    }
+
+    fn get_reputation_global_local_map(&self) -> CountMinSketch<V> {
+        self.reputation.get_raw_global_map()
+    }
+
+    fn get_reputation_normalized_global_map(&self) -> CountMinSketch<V> {
+        self.reputation.get_normalized_global_map()
+    }
+
+    fn bucketize_reputation_raw_local(&self) -> impl Iterator<Item = (K, usize)> + '_ {
+        self.reputation
+            .bucketize_local(self.peer_set.clone().into_iter(), self.bucketizer.clone())
+    }
+
+    fn bucketize_reputation_normalized_local(&self) -> impl Iterator<Item = (K, usize)> + '_ {
+        self.reputation
+            .bucketize_normalized_local(self.peer_set.clone().into_iter(), self.bucketizer.clone())
+    }
+
+    fn bucketize_reputation_raw_global(&self) -> impl Iterator<Item = (K, usize)> + '_ {
+        self.reputation
+            .bucketize_global(self.peer_set.clone().into_iter(), self.bucketizer.clone())
+    }
+
+    fn bucketize_reputation_normalized_global(&self) -> impl Iterator<Item = (K, usize)> + '_ {
+        self.reputation
+            .bucketize_normalized_global(self.peer_set.clone().into_iter(), self.bucketizer.clone())
+    }
+
+    fn init_local_credit(&mut self, peer: &K, init_value: V) {
+        self.credits.init_local(peer, init_value);
+    }
+
+    fn update_local_credit(&mut self, receiver: &K, value: V, update: Update) {
+        self.credits.update_local(receiver, value, update);
+    }
+
+    fn get_credits_raw_local(&self, key: &K) -> Option<V> {
+        self.credits.get_raw_local(key)
+    }
+
+    fn get_credits_normalized_local(&self, key: &K) -> Option<V> {
+        self.credits.get_normalized_local(key)
+    }
+
+    fn get_credits_raw_local_map(&self) -> CountMinSketch<V> {
+        self.credits.get_raw_local_map()
+    }
+
+    fn get_credits_normalized_local_map(&self) -> CountMinSketch<V> {
+        self.credits.get_normalized_local_map()
+    }
+
+    fn init_credits_reputation(&mut self, peer: &K, init_value: V) {
+        self.reputation.init_global(peer, init_value)
+    }
+
+    fn update_credits_reputation(&mut self, sender: &K, receiver: &K, value: V, update: Update) {
+        self.credits.update_global(sender, receiver, value, update);
+    }
+
+    fn get_credits_raw_global(&self, key: &K) -> Option<V> {
+        self.credits.get_raw_global(key)
+    }
+
+    fn get_credits_normalized_global(&self, key: &K) -> Option<V> {
+        self.credits.get_normalized_global(key)
+    }
+
+    fn get_credits_global_local_map(&self) -> CountMinSketch<V> {
+        self.credits.get_raw_global_map()
+    }
+
+    fn get_credits_normalized_global_map(&self) -> CountMinSketch<V> {
+        self.credits.get_normalized_global_map()
+    }
+}
+
+
+#[async_trait]
+impl<K, V, B> Handler<EventMessage> for ReputationModule<K, V, B>
+where
+    K: Hash + Eq + Clone + Debug + ToString,
+    V: AddAssign
+        + DivAssign
+        + SubAssign
+        + Add<Output = V>
+        + Sub<Output = V>
+        + Mul<Output = V>
+        + Div<Output = V>
+        + Copy
+        + Default
+        + Bounded
+        + Ord
+        + Hash
+        + Debug,
+    B: BucketizeSingle<V> + Clone,
+{
+    fn id(&self) -> ActorId {
+        self.id.clone()
+    }
+
+    fn label(&self) -> ActorLabel {
+        self.label.clone()
+    }
+
+    fn status(&self) -> ActorState {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, actor_status: ActorState) {
+        self.status = actor_status;
+    }
+
+    fn on_start(&self) {
+        info!("{}-{} starting", self.label(), self.id(),);
+    }
+
+    fn on_stop(&self) {
+        info!(
+            "{}-{} received stop signal. Stopping",
+            self.label(),
+            self.id(),
+        );
+    }
+
+    async fn handle(&mut self, event: EventMessage) -> theater::Result<ActorState> {
+        match event.into() {
+            Event::Stop => {
+                return Ok(ActorState::Stopped);
+            },
+            Event::NoOp => {},
+            _ => {},
+        }
+        Ok(ActorState::Running)
+    }
+}
+
+unsafe impl<K, V, B> Send for ReputationModule<K, V, B>
+where
+    K: Hash + Eq + Clone + Debug + ToString,
+    V: AddAssign
+        + DivAssign
+        + SubAssign
+        + Add<Output = V>
+        + Sub<Output = V>
+        + Mul<Output = V>
+        + Div<Output = V>
+        + Copy
+        + Default
+        + Bounded
+        + Ord
+        + Hash
+        + Debug,
+    B: BucketizeSingle<V> + Clone,
+{
+}

--- a/crates/node/src/runtime/reputation_module.rs
+++ b/crates/node/src/runtime/reputation_module.rs
@@ -12,7 +12,7 @@ use decentrust::{
     honest_peer::{HonestPeer, Update},
     probabilistic::LightHonestPeer,
 };
-use events::{Event, EventMessage, EventPublisher};
+use events::{Event, EventMessage, EventPublisher, ReputationUpdateEvent};
 use num_traits::Bounded;
 use ordered_float::OrderedFloat;
 use primitives::NodeId;
@@ -20,14 +20,6 @@ use serde::{Deserialize, Serialize};
 use telemetry::info;
 use theater::{ActorId, ActorImpl, ActorLabel, ActorState, Handler};
 
-/// A type used to encapsulate Reputation Updates
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReputationUpdateEvent {
-    pub sender: Option<NodeId>,
-    pub peer: NodeId,
-    pub delta: f64,
-    pub update: Update,
-}
 
 /// A configuration struct for the Reputation Module
 /// providing the data necessary to construct a new


### PR DESCRIPTION
This PR is a WIP to implement the reputation and credit tracking model.

Currently, only 1 of the events relevant are being processed. This PR will touch a significant amount of code, as many of the interactions throughout the network will have some effect on the reputation module. 

Due to that, this will likely need to be implemented over time, and carefully. This is a scaffold of the module currently, there's only the basic methods necessary to _track_ the reputation and credit of nodes, however there is no events being emitted or handled, relevant to reputation or credits. 

### Reputation Updates
- [ ] Increments
    - [ ] Initial Valid "Handshake" of new peer - as part of new peer discovery
    - [x] (Farmers) Successfully validating a transaction (or rejecting) with consensus - as part of tx certification process
    - [ ] (Harvester) Proposing a valid proposal block - as part of convergence block certification process
    - [ ] (Farmers & Harvesters) Actively participating in quorum (for farmers casting a % threshold of votes on txs their quorum saw, for harvesters, proposing a proposal block in a certain % of rounds) - need to count number txs sent and number of tx voted on, can use `CountMinSketch` for lightweight version cache.
    - [ ] (Harvesters) Valid certification of convergence blocks (with consensus) - as part of Convergence Block certification
    - [ ] (Farmers) Consistently reporting backpressure with forwarded transactions - as part event reception
    - [ ] (Harvesters) Accurately reporting a slashing event - as part of slashing event consensus
    - [ ] (Farmers) Accurately voting on a slashing event (with consensus) - as part of slashing event consensus
    - [ ] (Farmers & Harvesters) Consistently forwarding of valid messages - as part of message reception
    - [ ] (Miners) In-turn mining of a valid convergence block - as part of convergence block certification
    - [ ] (All Nodes) Responsiveness to network requests - as part of network request reception or timeout
    - [ ] (All Nodes) Uptime and Longevity (consistent responses to consecutive Ping-Pong) - as part of ping pong
    - [ ] (All Nodes) Sharing of useful resources - as part of message reception
- [ ] Decrements
    - [ ] Invalid "Handshake" of new peer
    - [ ] (Farmers) Invalid transaction validation (against consensus)
    - [ ] (Harvesters) Proposing an invalid proposal block, or one with > 100kb of lost-conflicts
    - [ ] (Farmers & Harvesters) Inconsistent participation in a quorum
    - [ ] (Farmers) Late submission of votes or non-voting 
    - [ ] (Harvesters) Invalid certification of convergence block (against consensus)
    - [ ] (Farmers and Harvesters) Forwarding of invalid or spam messages
    - [ ] (All nodes) Unresponsiveness to network requests
    - [ ] (All nodes) Frequent downtime or disconnections (inconsistent response to Ping Pong)
    - [ ] (Miners) Mining and invalid convergence block
    - [ ] (Miners) Out of turn mining of a convergence block
    - [ ] (Harvesters) False report of malicious activity
    - [ ] (Farmers) Inaccurately voting on reports of malicious activity (against consensus)
    - [ ] (All Nodes) Collusion for malicious purposes
    - [ ] (All Nodes) Attempting to manipulate the reputation system