### PR TITLE
Provides significant updates to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ items that are less than 50% complete are marked as :x:, all items marked with
 | Block Indexer | Indexes, sequences and stores blocks for display in UIs that need access to block and transaction data | :construction: | :signal_strength: | | Block Explorer | Provides a web based user interface for scanning blocks, tracking transactions, etc. | :construction: | :signal_strength: | 
 | Node Metrics | Tracks the performance of a given node, cluster of nodes, and/or all nodes in the network | :x: | :signal_strength: | 
 | Wallet GUI | Provides a user interface for interacting with VRRB network | :x: | :computer: | 
-| Unikernel Compute Runtime | Enables programming language agnoostic compute in the VRRB network | :x: | :computer: | 
+| Unikernel Compute Runtime | Enables programming language agnostic compute in the VRRB network | :x: | :computer: | 
 
 ### Starting a Node
     In order to start a node, run `cargo run`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![vrrb-logo dark-mode](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png#gh-dark-mode-only)
-![vrrb-logo light-mode](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only)
+![vrrb-logo](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png#gh-dark-mode-only)
+![vrrb-logo](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only)
 
 
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [//]: # (![vrrb-logo]&#40;https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only&#41;)
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png">
-  <img alt="Shows an illustrated sun in light color mode and a moon with stars in dark color mode." src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
+    <img alt="vrrb logo" src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
 </picture>
 
 VRRB is a fast, scalable Layer 1 blockchain truly designed for mass adoption. 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,8 @@
-[//]: # (![vrrb-logo]&#40;https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png#gh-dark-mode-only&#41;)
-[//]: # (![vrrb-logo]&#40;https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only&#41;)
-
-<img src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png" alt="Logo" title="Logo" id="logo" style="max-width: 100%;">
-<script>
-  function setLogoSrc() {
-    const isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const logo = document.getElementById('logo');
-    if (isDarkMode) {
-      logo.src = "https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png"
-    } else {
-      logo.src = "https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png";
-    }
-  }
-  setLogoSrc();
-  if (window.matchMedia) {
-    window.matchMedia('(prefers-color-scheme: dark)').addListener(setLogoSrc);
-    window.matchMedia('(prefers-color-scheme: light)').addListener(setLogoSrc);
-  }
-</script>
-
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset=https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png"
+  <img alt="VRRB Logo" src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png">
+</picture>
 
 VRRB is a fast, scalable Layer 1 blockchain truly designed for mass adoption. 
 VRRB is powered by a novel consensus mechanism called Proof-of-Claim, which 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 VRRB is a fast, scalable Layer 1 blockchain truly designed for mass adoption. 
 VRRB is powered by a novel consensus mechanism called Proof-of-Claim, which 
-feature dual-scalability for record-breaking TPS and fast time to finality. 
-VRRB offers a flexible, composable, safe programming language agnostic 
+features dual-scalability for record-breaking TPS and fast time to finality. 
+VRRB offers a flexible, composable and safe, (programming) language agnostic 
 compute platform powered by unikernel containers. The VRRB compute platform 
 takes web3 beyond the paradigm of ownership, tokenization and event 
 triggered transfers, offering a decentralized general execution environment 
@@ -30,6 +30,11 @@ _Items that are more than 50% complete are marked with :construction: while
 items that are less than 50% complete are marked as :x:, all items marked with
 :white_check_mark: are complete, tested, and integrated into the node runtime_
 
+:link: : Alphanet
+:signal_strength: Betanet
+:computer: Devnet
+:satellite: Mainnet
+
 | __Epic__   | _Description_ | State | Network |
 |------------|---------------|-------|---------|
 | Network | P2P Network enabling communication between network participants | :white_check_mark: | :link: |   
@@ -44,12 +49,15 @@ items that are less than 50% complete are marked as :x:, all items marked with
 | Miner Unit | Protocol for consolidating proposal blocks produced by miners into a single point of reference signifying the end of a round and finality of transactions (once certified)| :white_check_mark: | :link: | 
 | Scheduler | Decentralized task buffer and allocator to maximize efficiency of Farmer Quorum nodes | :white_check_mark: | :link: | 
 | Block Production | Enables harvesters to produce conflict minimized, extractable value maximized proposal blocks to be appended to the DAG | :white_check_mark: | :link: |
+| Token Emission Protocol | Ensures that proper number of tokens each block and epoch are produced | :white_check_mark: | :signal_strength: |
+| Fee & Rent Model | Provides economic incentives to operators beyond emission subsidy, provides token burning to limit inflation, and economic incentives to maintain speed at scale. Also provides economic incentives to developers to build small, composable applications | :x: | :signal_strength: |
 | Node CLI | Provides an interface for operators to spin up a VRRB node | :construction: | :link: | 
 | Wallet CLI | Provides an interface for users to interact with the VRRB network| :construction: | :link: | 
 | Reputation Tracking | Tracks the reputation of nodes, and the message credits, to align incentives, reduce malicious behavior and allow for dynamic stake calculation to prevent accumulation and centralization of staking nodes| :construction: | :signal_strength: | 
 | Dynamic Stake Calculator | Protocol to calculate minimum required stake of nodes in the network in order for the given nodes to become eligible as validators| :x: | :signal_strength: | 
 | Whistleblower Protocol | Protocol for reporting malicious behavior, and initiating a stake slashing vote | :x: | :computer: | 
-| Block Indexer | Indexes, sequences and stores blocks for display in UIs that need access to block and transaction data | :construction: | :signal_strength: | | Block Explorer | Provides a web based user interface for scanning blocks, tracking transactions, etc. | :construction: | :signal_strength: | 
+| Block Indexer | Indexes, sequences and stores blocks for display in UIs that need access to block and transaction data | :construction: | :signal_strength: | 
+| Block Explorer | Provides a web based user interface for scanning blocks, tracking transactions, etc. | :construction: | :signal_strength: | 
 | Node Metrics | Tracks the performance of a given node, cluster of nodes, and/or all nodes in the network | :x: | :signal_strength: | 
 | Wallet GUI | Provides a user interface for interacting with VRRB network | :x: | :computer: | 
 | Unikernel Compute Runtime | Enables programming language agnostic compute in the VRRB network | :x: | :computer: | 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,71 @@
-# VRRB
-## Versatile Ranged Reward Blockchain
+![vrrb-logo](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png)
 
-VRRB is a Web-Scale Blockchain with an innovative low energy consumption consensus algorithm called Proof of Claim 
-and a commodity production inspired monetary policy.
 
-VRRB is currently a WIP scheduled to begin alpha testing on the MVP by end of year. If you are interested in contributing to the
-project please reach out to the owners.
+VRRB is a fast, scalable Layer 1 blockchain truly designed for mass adoption. 
+VRRB is powered by a novel consensus mechanism called Proof-of-Claim, which 
+feature dual-scalability for record-breaking TPS and fast time to finality. 
+VRRB offers a flexible, composable, safe programming language agnostic 
+compute platform powered by unikernel containers. The VRRB compute platform 
+takes web3 beyond the paradigm of ownership, tokenization and event 
+triggered transfers, offering a decentralized general execution environment 
+that can deliver on the promise of a decentralized internet and financial 
+system.
 
-Node Requirements
-    A minimum of 10,000 staked VRRB coins are required for Masternode eligibility, though this minimum may be higher depending on a node's reputation score.
-    
+<hr>
+
+Scroll to the bottom for information on how to start a node.
+
+### High Level Roadmap
+
+This is extremely high level, for each __Epic__ there are multiple features
+and under each feature there are many stories and tasks
+
+_Items that are more than 50% complete are marked with :construction: while 
+items that are less than 50% complete are marked as :x:, all items marked with
+:white_check_mark: are complete, tested, and integrated into the node runtime_
+
+| __Epic__   | _Description_ | State | Network |
+|------------|---------------|-------|---------|
+| Network | P2P Network enabling communication between network participants | :white_check_mark: | :link: |   
+| Election | Proof of Claim Algorithm Implementation and Integration | :white_check_mark: | :link: |
+| Genesis Quorum Protocol | Formation of the first quorums at Genesis event | :construction: | :link: |
+| Key Generator | Protocol to generate Dealerless Distributed Keypairs for validator nodes, and ECDSA keypairs for all nodes | :white_check_mark: | :link: |
+| State Store | Left-Right Wrapped Accounts Database and State Trie | :construction: | :link: |  
+| Mempool | Left-Right Wrapped Pending Transaction Store | :white_check_mark: | :link: | 
+| Validator Unit | Left-Right enabled transaction validation protocol | :white_check_mark: | :link: | 
+| Farmer-Harvester | Farmer-Havester Quorum model for secure parallel execution and validation of transactions | :construction: | :link: |
+| DAG | Rounds based Directed Acyclic Graph to append blocks to | :white_check_mark: | :link: | 
+| Miner Unit | Protocol for consolidating proposal blocks produced by miners into a single point of reference signifying the end of a round and finality of transactions (once certified)| :white_check_mark: | :link: | 
+| Scheduler | Decentralized task buffer and allocator to maximize efficiency of Farmer Quorum nodes | :white_check_mark: | :link: | 
+| Block Production | Enables harvesters to produce conflict minimized, extractable value maximized proposal blocks to be appended to the DAG | :white_check_mark: | :link: |
+| Node CLI | Provides an interface for operators to spin up a VRRB node | :construction: | :link: | 
+| Wallet CLI | Provides an interface for users to interact with the VRRB network| :construction: | :link: | 
+| Reputation Tracking | Tracks the reputation of nodes, and the message credits, to align incentives, reduce malicious behavior and allow for dynamic stake calculation to prevent accumulation and centralization of staking nodes| :construction: | :signal_strength: | 
+| Dynamic Stake Calculator | Protocol to calculate minimum required stake of nodes in the network in order for the given nodes to become eligible as validators| :x: | :signal_strength: | 
+| Whistleblower Protocol | Protocol for reporting malicious behavior, and initiating a stake slashing vote | :x: | :computer: | 
+| Block Indexer | Indexes, sequences and stores blocks for display in UIs that need access to block and transaction data | :construction: | :signal_strength: | | Block Explorer | Provides a web based user interface for scanning blocks, tracking transactions, etc. | :construction: | :signal_strength: | 
+| Node Metrics | Tracks the performance of a given node, cluster of nodes, and/or all nodes in the network | :x: | :signal_strength: | 
+| Wallet GUI | Provides a user interface for interacting with VRRB network | :x: | :computer: | 
+| Unikernel Compute Runtime | Enables programming language agnoostic compute in the VRRB network | :x: | :computer: | 
 
 ### Starting a Node
     In order to start a node, run `cargo run`
     Running `cargo run -- -help` will display available cli flags for node configuration and management.
+
+__The above builds and runs a VRRB node in `debug` mode__ to run in optimized
+release mode you must first build the release target using the following command:
+```
+git clone https://github.com/vrrb-io/vrrb
+cd /path/to/cloned/repo
+cargo build --release 
+```
+
+This will produce a target file (and directory if this is your first time 
+running `cargo run` or `cargo build` in this repo.
+
+Then, to display the available CLI flags, you can run:
+
+```
+cd target/release
+./vrrb -help
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset=https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png"
-  <img alt="VRRB Logo" src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png">
+  <source media="(prefers-color-scheme: dark)" srcset=https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png?raw=true">
+  <img alt="VRRB Logo" src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png?raw=true">
 </picture>
 
 VRRB is a fast, scalable Layer 1 blockchain truly designed for mass adoption. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![vrrb-logo](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png)
+![vrrb-logo dark-mode](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png#gh-dark-mode-only)
+![vrrb-logo light-mode](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only)
+
 
 
 VRRB is a fast, scalable Layer 1 blockchain truly designed for mass adoption. 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [//]: # (![vrrb-logo]&#40;https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only&#41;)
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png">
   <img alt="Shows an illustrated sun in light color mode and a moon with stars in dark color mode." src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-![vrrb-logo](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png#gh-dark-mode-only)
-![vrrb-logo](https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only)
+[//]: # (![vrrb-logo]&#40;https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png#gh-dark-mode-only&#41;)
+[//]: # (![vrrb-logo]&#40;https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only&#41;)
 
-
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png">
+  <img alt="Shows an illustrated sun in light color mode and a moon with stars in dark color mode." src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
+</picture>
 
 VRRB is a fast, scalable Layer 1 blockchain truly designed for mass adoption. 
 VRRB is powered by a novel consensus mechanism called Proof-of-Claim, which 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 [//]: # (![vrrb-logo]&#40;https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png#gh-dark-mode-only&#41;)
 [//]: # (![vrrb-logo]&#40;https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png#gh-light-mode-only&#41;)
 
-<picture>
-    <source media="(prefers-color-scheme: light)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png">
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
-    <img alt="vrrb logo" src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png">
-</picture>
+<img src="https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png" alt="Logo" title="Logo" id="logo" style="max-width: 100%;">
+<script>
+  function setLogoSrc() {
+    const isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const logo = document.getElementById('logo');
+    if (isDarkMode) {
+      logo.src = "https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final2.png"
+    } else {
+      logo.src = "https://github.com/vrrb-io/brand-assets/raw/main/logo/vrrb-logo-final1.png";
+    }
+  }
+  setLogoSrc();
+  if (window.matchMedia) {
+    window.matchMedia('(prefers-color-scheme: dark)').addListener(setLogoSrc);
+    window.matchMedia('(prefers-color-scheme: light)').addListener(setLogoSrc);
+  }
+</script>
+
 
 VRRB is a fast, scalable Layer 1 blockchain truly designed for mass adoption. 
 VRRB is powered by a novel consensus mechanism called Proof-of-Claim, which 
@@ -14,9 +27,31 @@ VRRB offers a flexible, composable and safe, (programming) language agnostic
 compute platform powered by unikernel containers. The VRRB compute platform 
 takes web3 beyond the paradigm of ownership, tokenization and event 
 triggered transfers, offering a decentralized general execution environment 
-that can deliver on the promise of a decentralized internet and financial 
-system.
+that can deliver on the promise of a decentralized internet and financial
 
+VRRB provides the most flexible developer experience available on any 
+smart contract platform, allowing developers to build in any language they 
+choose. Beyond language agnosticism, VRRB programs are secure by design,
+allowing developers to spend more time thinking about building core 
+business logic and design. This provides developers with shorter roadmaps,
+lower audit costs, leads to fewer bugs, less maintenance, and ultimately,
+will lead to better end user experiences.
+<br>
+<hr>
+<br>
+
+<div align="center">
+  <img src="https://drive.google.com/uc?export=view&id=1Nx-DUr8e9ueRrgJ80dickT9S_XSztoAV" alt="nowthatsflexible.gif">
+</div>
+<br>
+<hr>
+<br>
+
+VRRB is a permissionless network, be they operators, developers, users or 
+some combination thereof, VRRB is decentralized, censorship resistant and 
+accessible to anyone with an internet connection.
+
+<br>
 <hr>
 
 Scroll to the bottom for information on how to start a node.
@@ -33,7 +68,6 @@ items that are less than 50% complete are marked as :x:, all items marked with
 :link: : Alphanet
 :signal_strength: Betanet
 :computer: Devnet
-:satellite: Mainnet
 
 | __Epic__   | _Description_ | State | Network |
 |------------|---------------|-------|---------|
@@ -49,16 +83,17 @@ items that are less than 50% complete are marked as :x:, all items marked with
 | Miner Unit | Protocol for consolidating proposal blocks produced by miners into a single point of reference signifying the end of a round and finality of transactions (once certified)| :white_check_mark: | :link: | 
 | Scheduler | Decentralized task buffer and allocator to maximize efficiency of Farmer Quorum nodes | :white_check_mark: | :link: | 
 | Block Production | Enables harvesters to produce conflict minimized, extractable value maximized proposal blocks to be appended to the DAG | :white_check_mark: | :link: |
-| Token Emission Protocol | Ensures that proper number of tokens each block and epoch are produced | :white_check_mark: | :signal_strength: |
-| Fee & Rent Model | Provides economic incentives to operators beyond emission subsidy, provides token burning to limit inflation, and economic incentives to maintain speed at scale. Also provides economic incentives to developers to build small, composable applications | :x: | :signal_strength: |
 | Node CLI | Provides an interface for operators to spin up a VRRB node | :construction: | :link: | 
 | Wallet CLI | Provides an interface for users to interact with the VRRB network| :construction: | :link: | 
+| Token Emission Protocol | Ensures that proper number of tokens each block and epoch are produced | :white_check_mark: | :signal_strength: |
+| Fee Model | Provides economic incentives to operators beyond emission subsidy, provides token burning to limit inflation, and economic incentives to maintain speed at scale | :x: | :signal_strength: |
 | Reputation Tracking | Tracks the reputation of nodes, and the message credits, to align incentives, reduce malicious behavior and allow for dynamic stake calculation to prevent accumulation and centralization of staking nodes| :construction: | :signal_strength: | 
 | Dynamic Stake Calculator | Protocol to calculate minimum required stake of nodes in the network in order for the given nodes to become eligible as validators| :x: | :signal_strength: | 
-| Whistleblower Protocol | Protocol for reporting malicious behavior, and initiating a stake slashing vote | :x: | :computer: | 
 | Block Indexer | Indexes, sequences and stores blocks for display in UIs that need access to block and transaction data | :construction: | :signal_strength: | 
 | Block Explorer | Provides a web based user interface for scanning blocks, tracking transactions, etc. | :construction: | :signal_strength: | 
 | Node Metrics | Tracks the performance of a given node, cluster of nodes, and/or all nodes in the network | :x: | :signal_strength: | 
+| Rent Model | Provides economic incentives to developers to build small, modular programs that do one thing well, and link them together by returning commands to the orchestration network. | :x: | :computer: |
+| Whistleblower Protocol | Protocol for reporting malicious behavior, and initiating a stake slashing vote | :x: | :computer: | 
 | Wallet GUI | Provides a user interface for interacting with VRRB network | :x: | :computer: | 
 | Unikernel Compute Runtime | Enables programming language agnostic compute in the VRRB network | :x: | :computer: | 
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ items that are less than 50% complete are marked as :x:, all items marked with
 | Unikernel Compute Runtime | Enables programming language agnostic compute in the VRRB network | :x: | :computer: | 
 
 ### Starting a Node
-    In order to start a node, run `cargo run`
-    Running `cargo run -- -help` will display available cli flags for node configuration and management.
+
+In order to start a node, run `cargo run`
+Running `cargo run -- -help` will display available cli flags for node configuration and management.
 
 __The above builds and runs a VRRB node in `debug` mode__ to run in optimized
 release mode you must first build the release target using the following command:


### PR DESCRIPTION
There is very likely more Epics we want to add, or to break this down into features, but I tried to keep it very high level, and really base it off of the various modules currently in the node runtime, or those that will be added to the node runtime in the future. Need to provide a legend for the network emojis, but :link: is alphanet, :signal_strength:  is betanet and :computer:  is devnet. I left mainnet out, as devnet and mainnet are the same high level requirements, though there may be optimizations, and will certainly be bug squashing, etc. There is also other things that we can add to this that are actually, specifically required for mainnet but not for devnet, and we can use :satellite:  for mainnet.