### PR TITLE
Add IP address update functionality for Claim

### DIFF
--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -81,6 +81,9 @@ pub struct RunOpts {
 
     #[clap(long, value_parser, default_value = DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
     pub rendezvous_server_address: SocketAddr,
+
+    #[clap(long, value_parser, default_value = DEFAULT_OS_ASSIGNED_PORT_ADDRESS)]
+    pub public_ip_address: SocketAddr,
 }
 
 impl From<RunOpts> for NodeConfig {
@@ -125,6 +128,7 @@ impl From<RunOpts> for NodeConfig {
             keypair: default_node_config.keypair,
             disable_networking: opts.disable_networking,
             rendezvous_server_address: opts.rendezvous_server_address,
+            public_ip_address: opts.raptorq_gossip_address,
         }
     }
 }
@@ -153,6 +157,7 @@ impl Default for RunOpts {
             disable_networking: Default::default(),
             rendezvous_local_address: ipv4_localhost_with_random_port,
             rendezvous_server_address: ipv4_localhost_with_random_port,
+            public_ip_address: ipv4_localhost_with_random_port,
         }
     }
 }
@@ -238,6 +243,7 @@ impl RunOpts {
             disable_networking: false,
             rendezvous_local_address: other.rendezvous_local_address,
             rendezvous_server_address: other.rendezvous_server_address,
+            public_ip_address: other.public_ip_address,
         }
     }
 }
@@ -302,7 +308,7 @@ async fn run_blocking(node_config: NodeConfig) -> Result<()> {
         .send(Event::Stop)
         .map_err(|err| CliError::Other(format!("failed to send stop event to node: {err}")))?;
 
-    _ = node_handle
+    let _ = node_handle
         .await
         .map_err(|err| CliError::Other(format!("failed to join node task handle: {err}")))?;
 

--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -6,6 +6,7 @@ mod tests {
     use std::{
         collections::hash_map::DefaultHasher,
         hash::{Hash, Hasher},
+        net::SocketAddr,
     };
 
     use primitives::Address;
@@ -28,7 +29,15 @@ mod tests {
         (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key().clone();
-            let claim: Claim = Claim::new(public_key, Address::new(public_key));
+            let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+            let signature = Claim::signature_for_valid_claim(
+                public_key.clone(),
+                ip_address,
+                keypair.get_miner_secret_key().secret_bytes().to_vec(),
+            )
+            .unwrap();
+            let claim: Claim =
+                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
 
             //let claim_box = Box::new(claim);
             dummy_claims.push(claim);
@@ -61,7 +70,16 @@ mod tests {
         (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key().clone();
-            let claim: Claim = Claim::new(public_key, Address::new(public_key));
+            let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+            let signature = Claim::signature_for_valid_claim(
+                public_key.clone(),
+                ip_address,
+                keypair.get_miner_secret_key().secret_bytes().to_vec(),
+            )
+            .unwrap();
+            let claim: Claim =
+                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -88,7 +106,15 @@ mod tests {
         (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key().clone();
-            let claim: Claim = Claim::new(public_key, Address::new(public_key));
+            let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+            let signature = Claim::signature_for_valid_claim(
+                public_key.clone(),
+                ip_address,
+                keypair.get_miner_secret_key().secret_bytes().to_vec(),
+            )
+            .unwrap();
+            let claim: Claim =
+                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -113,7 +139,15 @@ mod tests {
         (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key().clone();
-            let claim: Claim = Claim::new(public_key, Address::new(public_key));
+            let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+            let signature = Claim::signature_for_valid_claim(
+                public_key.clone(),
+                ip_address,
+                keypair.get_miner_secret_key().secret_bytes().to_vec(),
+            )
+            .unwrap();
+            let claim: Claim =
+                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -142,7 +176,15 @@ mod tests {
         (0..20).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key().clone();
-            let claim: Claim = Claim::new(public_key, Address::new(public_key));
+            let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+            let signature = Claim::signature_for_valid_claim(
+                public_key.clone(),
+                ip_address,
+                keypair.get_miner_secret_key().secret_bytes().to_vec(),
+            )
+            .unwrap();
+            let claim: Claim =
+                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
             dummy_claims.push(claim);
         });
 
@@ -172,7 +214,15 @@ mod tests {
         (0..25).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key().clone();
-            let claim: Claim = Claim::new(public_key, Address::new(public_key));
+            let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+            let signature = Claim::signature_for_valid_claim(
+                public_key.clone(),
+                ip_address,
+                keypair.get_miner_secret_key().secret_bytes().to_vec(),
+            )
+            .unwrap();
+            let claim: Claim =
+                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -205,7 +255,15 @@ mod tests {
         (0..3).for_each(|_| {
             let keypair = KeyPair::random();
             let public_key = keypair.get_miner_public_key().clone();
-            let claim: Claim = Claim::new(public_key, Address::new(public_key));
+            let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+            let signature = Claim::signature_for_valid_claim(
+                public_key.clone(),
+                ip_address,
+                keypair.get_miner_secret_key().secret_bytes().to_vec(),
+            )
+            .unwrap();
+            let claim: Claim =
+                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
             //let boxed_claim = Box::new(claim);
             dummy_claims1.push(claim.clone());
             dummy_claims2.push(claim.clone());

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -19,7 +19,7 @@ pub mod v2 {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{net::SocketAddr, sync::Arc};
 
     use block::{Block, ProposalBlock};
     use bulldag::vertex::Vertex;
@@ -49,7 +49,20 @@ mod tests {
     fn test_create_miner() {
         let kp = Keypair::random();
         let address = Address::new(kp.miner_kp.1.clone());
-        let claim = Claim::new(kp.miner_kp.1.clone(), address.clone());
+        let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+        let signature = Claim::signature_for_valid_claim(
+            kp.miner_kp.1.clone(),
+            ip_address.clone(),
+            kp.get_miner_secret_key().secret_bytes().to_vec(),
+        )
+        .unwrap();
+        let claim = Claim::new(
+            kp.miner_kp.1.clone(),
+            address.clone(),
+            ip_address,
+            signature,
+        )
+        .unwrap();
         let miner = create_miner_from_keypair(&kp);
 
         assert_eq!(miner.claim, claim);

--- a/crates/miner/src/result.rs
+++ b/crates/miner/src/result.rs
@@ -4,7 +4,10 @@
 pub enum MinerError {
     #[error("no lowest pointer: {0}")]
     NoLowestPointerError(String),
-
+    #[error("Invalid signature during miner's claim verification")]
+    InvalidSignature,
+    #[error("Invalid public of miner encountered ")]
+    InvalidPublicKey,
     #[error("{0}")]
     Other(String),
 }

--- a/crates/node/src/runtime/dag_module.rs
+++ b/crates/node/src/runtime/dag_module.rs
@@ -348,6 +348,10 @@ impl Handler<EventMessage> for DagModule {
                         let err_note = format!("Encountered GraphError: {:?}", e);
                         return Err(theater::TheaterError::Other(err_note));
                     }
+                    //
+
+                    //      self.events_tx.send(EventMessage::new(None,
+                    // Event::MineProposalBlock(block.hash,block.)))
                 },
             },
             Event::HarvesterPublicKey(pubkey_bytes) => {

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -9,7 +9,7 @@ use bulldag::graph::BullDag;
 use crossbeam_channel::{unbounded, Sender};
 use events::{Event, EventMessage, EventPublisher, EventRouter, EventSubscriber, DEFAULT_BUFFER};
 use mempool::{LeftRightMempool, MempoolReadHandleFactory};
-use miner::MinerConfig;
+use miner::{result::MinerError, MinerConfig};
 use network::{network::BroadcastEngine, packet::RaptorBroadCastedData};
 use primitives::{Address, NodeType, QuorumType::Farmer};
 use storage::vrrbdb::{VrrbDbConfig, VrrbDbReadHandle};
@@ -18,7 +18,10 @@ use theater::{Actor, ActorImpl};
 use tokio::task::JoinHandle;
 use validator::validator_core_manager::ValidatorCoreManager;
 use vrrb_config::NodeConfig;
-use vrrb_core::{bloom::Bloom, claim::Claim};
+use vrrb_core::{
+    bloom::Bloom,
+    claim::{Claim, ClaimError},
+};
 use vrrb_rpc::rpc::{JsonRpcServer, JsonRpcServerConfig};
 
 use self::{
@@ -63,6 +66,25 @@ pub mod swarm_module;
 pub type RuntimeHandle = Option<JoinHandle<Result<()>>>;
 pub type RaptorHandle = Option<thread::JoinHandle<bool>>;
 pub type SchedulerHandle = Option<std::thread::JoinHandle<()>>;
+
+impl From<MinerError> for NodeError {
+    fn from(error: MinerError) -> Self {
+        match error {
+            _ => NodeError::Other(String::from(
+                "Error occurred while creating instance of miner ",
+            )),
+        }
+    }
+}
+impl From<ClaimError> for NodeError {
+    fn from(error: ClaimError) -> Self {
+        match error {
+            _ => NodeError::Other(String::from(
+                "Error occurred while creating claim for the node",
+            )),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct RuntimeComponents {
@@ -196,8 +218,24 @@ pub async fn setup_runtime_components(
     )?;
 
     let dkg_handle = setup_dkg_module(&config, events_tx.clone(), dkg_events_rx)?;
-
-    let claim: Claim = config.keypair.clone().into();
+    let public_key = config.keypair.get_miner_public_key().clone();
+    let signature = Claim::signature_for_valid_claim(
+        public_key.clone(),
+        config.public_ip_address.clone(),
+        config
+            .keypair
+            .get_miner_secret_key()
+            .secret_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    let claim = Claim::new(
+        public_key,
+        Address::new(public_key),
+        config.public_ip_address,
+        signature,
+    )
+    .map_err(|err| NodeError::from(err))?;
     let miner_election_handle = setup_miner_election_module(
         events_tx.clone(),
         miner_election_events_rx,
@@ -417,6 +455,7 @@ async fn setup_rpc_api_server(
     Ok((jsonrpc_server_handle, resolved_jsonrpc_server_addr))
 }
 
+
 fn setup_mining_module(
     config: &NodeConfig,
     events_tx: EventPublisher,
@@ -432,11 +471,11 @@ fn setup_mining_module(
     let miner_config = MinerConfig {
         secret_key: *miner_secret_key,
         public_key: *miner_public_key,
+        ip_address: config.public_ip_address,
         dag: dag.clone(),
     };
 
-    let miner = miner::Miner::new(miner_config);
-
+    let miner = miner::Miner::new(miner_config).map_err(|e| NodeError::from(e))?;
     let module_config = MiningModuleConfig {
         miner,
         events_tx,

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -24,6 +24,7 @@ pub fn create_mock_full_node_config() -> NodeConfig {
     let raptorq_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let rendezvous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let rendezvous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let public_ip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
 
     let main_bootstrap_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 10)), 0);
     let bootstrap_node_addresses = vec![main_bootstrap_addr];
@@ -46,6 +47,7 @@ pub fn create_mock_full_node_config() -> NodeConfig {
         .keypair(Keypair::random())
         .rendezvous_local_address(rendezvous_local_address)
         .rendezvous_server_address(rendezvous_server_address)
+        .public_ip_address(public_ip_address)
         .disable_networking(false)
         .build()
         .unwrap()

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use primitives::{Address, NodeId, SecretKey};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secp256k1::{Message, Secp256k1};
@@ -71,6 +73,19 @@ pub fn generate_random_valid_transaction() -> Txn {
 
 pub fn generate_random_claim() -> Claim {
     let keypair = Keypair::random();
-
-    Claim::new(keypair.miner_kp.1.clone(), Address::new(keypair.miner_kp.1))
+    let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+    let public_key = keypair.get_miner_public_key().clone();
+    let signature = Claim::signature_for_valid_claim(
+        public_key,
+        ip_address,
+        keypair.get_miner_secret_key().secret_bytes().to_vec(),
+    )
+    .unwrap();
+    Claim::new(
+        public_key,
+        Address::new(public_key),
+        ip_address.clone(),
+        signature,
+    )
+    .unwrap()
 }

--- a/crates/vrrb_config/src/lib.rs
+++ b/crates/vrrb_config/src/lib.rs
@@ -33,6 +33,7 @@ mod tests {
             .bootstrap_node_addresses(vec![addr])
             .rendezvous_local_address(addr)
             .rendezvous_server_address(addr)
+            .public_ip_address(addr)
             .keypair(keypair)
             .bootstrap_config(None)
             .build()

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -25,6 +25,13 @@ pub struct NodeConfig {
 
     pub db_path: PathBuf,
 
+    /// `pub public_ip_address: SocketAddr` is defining a public IP address for
+    /// the node. This is the IP address that other nodes in the network
+    /// will use to connect to this node. `SocketAddr` is a struct that
+    /// represents a socket address, which includes both an IP address and a
+    /// port number.
+    pub public_ip_address: SocketAddr,
+
     /// Address the node listens for network events through RaptorQ
     pub raptorq_gossip_address: SocketAddr,
 
@@ -130,6 +137,7 @@ impl Default for NodeConfig {
             db_path: PathBuf::from(DEFAULT_VRRB_DATA_DIR_PATH)
                 .join("node")
                 .join("db"),
+            public_ip_address: ipv4_localhost_with_random_port,
             raptorq_gossip_address: ipv4_localhost_with_random_port,
             udp_gossip_address: ipv4_localhost_with_random_port,
             rendezvous_local_address: ipv4_localhost_with_random_port,

--- a/crates/vrrb_core/src/ownable.rs
+++ b/crates/vrrb_core/src/ownable.rs
@@ -2,5 +2,7 @@
 /// wallet i.e. Token, Claim, (Program?)
 pub trait Ownable {
     type Pubkey;
-    fn get_pubkey(&self) -> Self::Pubkey;
+    type SocketAddr;
+    fn get_public_key(&self) -> Self::Pubkey;
+    fn get_socket_addr(&self) -> Self::SocketAddr;
 }

--- a/crates/vrrb_core/src/staking.rs
+++ b/crates/vrrb_core/src/staking.rs
@@ -13,6 +13,8 @@ pub const MIN_STAKE_FARMER: u128 = 10_000;
 pub const MIN_STAKE_VALIDATOR: u128 = 50_000;
 
 
+pub type Result<T> = std::result::Result<T, StakeError>;
+
 #[derive(Debug, Error, PartialEq, Clone, Serialize, Deserialize, Eq)]
 pub enum StakeError {
     #[error("StakeError: The payload was not able to be converted into a valid message")]
@@ -212,7 +214,7 @@ impl Stake {
     }
 
     /// Adds a certificate to the instance.
-    pub fn certify(&mut self, certificate: Certificate) -> Result<(), StakeError> {
+    pub fn certify(&mut self, certificate: Certificate) -> Result<()> {
         if certificate.0.len() != 96 {
             return Err(StakeError::InvalidCertificate);
         }
@@ -223,7 +225,7 @@ impl Stake {
     }
 
     /// Verifies the signature of the StakeTransaction
-    pub fn verify(&self) -> Result<(), StakeError> {
+    pub fn verify(&self) -> Result<()> {
         let payload = self.get_payload();
         if let Ok(message) = Message::from_slice(&payload) {
             self.signature


### PR DESCRIPTION
This commit adds the ability to update the IP address associated with a Claim. The update can only be performed if the node passing the Claim provides the correct signature.