### PR TITLE
Update len method on trie to accurately reflect total nodes stored in it.

### DIFF
--- a/crates/storage/lr_trie/Cargo.toml
+++ b/crates/storage/lr_trie/Cargo.toml
@@ -14,6 +14,7 @@ parking_lot = { workspace = true }
 rlp = { workspace = true }
 thiserror = { workspace = true }
 bincode = { workspace = true }
+telemetry = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/storage/lr_trie/src/inner.rs
+++ b/crates/storage/lr_trie/src/inner.rs
@@ -1,6 +1,7 @@
 use left_right::Absorb;
 pub use left_right::ReadHandleFactory;
 use patriecia::{db::Database, inner::InnerTrie, trie::Trie};
+use telemetry::error;
 
 use crate::Operation;
 
@@ -12,21 +13,29 @@ where
         match operation {
             // TODO: report errors via instrumentation
             Operation::Add(key, value) => {
-                self.insert(key, value).unwrap_or_default();
-                self.commit().unwrap_or_default();
+                if let Err(err) = self.insert(key, value) {
+                    error!("failed to insert key: {err}");
+                }
             },
             Operation::Remove(key) => {
-                self.remove(key).unwrap_or_default();
+                if let Err(err) = self.remove(key) {
+                    error!("failed to remove value for key: {err}");
+                }
             },
             Operation::Extend(values) => {
                 //
                 // TODO: temp hack to get this going. Refactor ASAP
                 //
                 for (k, v) in values {
-                    self.insert(k, v).unwrap_or_default();
+                    if let Err(err) = self.insert(k, v) {
+                        error!("failed to insert key: {err}");
+                    }
                 }
-                self.commit().unwrap_or_default();
             },
+        }
+
+        if let Err(err) = self.commit() {
+            error!("failed to commit changes to trie: {err}");
         }
     }
 

--- a/crates/storage/lr_trie/src/inner_wrapper.rs
+++ b/crates/storage/lr_trie/src/inner_wrapper.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    sync::Arc,
+};
 
 use keccak_hash::H256;
 pub use left_right::ReadHandleFactory;
@@ -127,7 +130,7 @@ where
     }
 
     pub fn len(&self) -> usize {
-        self.inner.len()
+        self.iter().count()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -136,5 +139,14 @@ where
 
     pub fn db(&self) -> Arc<D> {
         self.inner.db()
+    }
+}
+
+impl<D> Display for InnerTrieWrapper<D>
+where
+    D: Database,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner)
     }
 }


### PR DESCRIPTION
- Update LeftRightTrie::len method to count using a trie iterator instead of the underlying db
- Implement display on LRTrie
- Instrument LRTrie's LR implementation to catch errors when updating oplog