### PR TITLE
move node gui initialization from node crate to runtime crate

### DIFF
--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -78,7 +78,7 @@ pub struct RunOpts {
 
     /// Enables the UI for the node
     #[clap(long, action, default_value = "false")]
-    pub enable_ui: bool,
+    pub gui: bool,
 
     /// Disables networking capabilities of the node
     #[clap(long, action, default_value = "false")]
@@ -136,7 +136,7 @@ impl From<RunOpts> for NodeConfig {
             // a hack, but it works for now.
             keypair: default_node_config.keypair,
             disable_networking: opts.disable_networking,
-            enable_ui: opts.enable_ui,
+            gui: opts.gui,
             rendezvous_server_address: opts.rendezvous_server_address,
             public_ip_address: opts.raptorq_gossip_address,
         }
@@ -165,7 +165,7 @@ impl Default for RunOpts {
             bootstrap_node_addresses: Default::default(),
             http_api_title: Default::default(),
             http_api_version: Default::default(),
-            enable_ui: Default::default(),
+            gui: Default::default(),
             disable_networking: Default::default(),
             rendezvous_local_address: ipv4_localhost_with_random_port,
             rendezvous_server_address: ipv4_localhost_with_random_port,
@@ -253,7 +253,7 @@ impl RunOpts {
             http_api_address: other.http_api_address,
             http_api_title,
             http_api_version,
-            enable_ui: false,
+            gui: false,
             disable_networking: false,
             rendezvous_local_address: other.rendezvous_local_address,
             rendezvous_server_address: other.rendezvous_server_address,

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -2,7 +2,9 @@ use std::{
     net::SocketAddr,
     sync::{Arc, RwLock},
     thread,
+    process::Command,
 };
+
 
 use block::Block;
 use bulldag::graph::BullDag;
@@ -18,6 +20,7 @@ use theater::{Actor, ActorImpl};
 use tokio::task::JoinHandle;
 use validator::validator_core_manager::ValidatorCoreManager;
 use vrrb_config::NodeConfig;
+use node::Node;
 use vrrb_core::{
     bloom::Bloom,
     claim::{Claim, ClaimError},
@@ -42,14 +45,7 @@ use self::{
     mining_module::{MiningModule, MiningModuleConfig},
     state_module::StateModule,
 };
-use crate::{
-    broadcast_controller::{BroadcastEngineController, BroadcastEngineControllerConfig},
-    dkg_module::DkgModuleConfig,
-    farmer_module::PULL_TXN_BATCH_SIZE,
-    scheduler::{Job, JobSchedulerController},
-    NodeError,
-    Result,
-};
+use crate::{broadcast_controller::{BroadcastEngineController, BroadcastEngineControllerConfig}, dkg_module::DkgModuleConfig, farmer_module::PULL_TXN_BATCH_SIZE, scheduler::{Job, JobSchedulerController}, NodeError, Result, node};
 
 pub mod broadcast_module;
 pub mod credit_model_module;
@@ -102,6 +98,7 @@ pub struct RuntimeComponents {
     pub raptor_handle: RaptorHandle,
     pub scheduler_handle: SchedulerHandle,
     pub grpc_server_handle: RuntimeHandle,
+    pub node_gui_handle: RuntimeHandle
 }
 
 pub async fn setup_runtime_components(
@@ -313,6 +310,13 @@ pub async fn setup_runtime_components(
     let dag_handle =
         setup_dag_module(dag.clone(), events_tx.clone(), dag_events_rx, claim.clone())?;
 
+
+    let (node_gui_handle) = setup_node_gui(
+        &config,
+    ).await?;
+
+    info!("node gui has started");
+
     let runtime_components = RuntimeComponents {
         node_config: config,
         mempool_handle,
@@ -330,6 +334,7 @@ pub async fn setup_runtime_components(
         raptor_handle: Some(raptor_handle),
         scheduler_handle: Some(scheduler_handle),
         grpc_server_handle,
+        node_gui_handle,
     };
 
     Ok(runtime_components)
@@ -769,4 +774,67 @@ fn setup_reputation_module() -> Result<Option<JoinHandle<Result<()>>>> {
 
 fn setup_credit_model_module() -> Result<Option<JoinHandle<Result<()>>>> {
     Ok(None)
+}
+
+async fn setup_node_gui(
+    config: &NodeConfig,
+) -> Result<Option<JoinHandle<Result<()>>>> {
+    if config.gui {
+        info!("Configuring Node {}", &config.id);
+        info!("Ensuring environment has required dependencies");
+
+        match Command::new("npm").args(&["version"]).status() {
+            Ok(_) => info!("NodeJS is installed"),
+            Err(e) => {
+                return Err(NodeError::Other(format!("NodeJS is not installed: {}", e)).into());
+            }
+        }
+
+        info!("Ensuring yarn is installed");
+        match Command::new("yarn").args(&["--version"]).status() {
+            Ok(_) => info!("Yarn is installed"),
+            Err(e) => {
+                let install_yarn = Command::new("npm")
+                    .args(&["install", "-g", "yarn"])
+                    .current_dir("infra/ui")
+                    .output();
+
+                match install_yarn {
+                    Ok(_) => (),
+                    Err(_) => {
+                        return Err(NodeError::Other(format!("Failed to install yarn: {}", e)).into());
+                    }
+                }
+            }
+        }
+
+        info!("Installing dependencies");
+        match Command::new("yarn")
+            .args(&["install"])
+            .current_dir("infra/ui")
+            .status()
+        {
+            Ok(_) => info!("Dependencies installed successfully"),
+            Err(e) => {
+                return Err(NodeError::Other(format!("Failed to install dependencies: {}", e)).into());
+            }
+        }
+
+        info!("Spawning UI");
+
+        let node_gui_handle = tokio::spawn(async move {
+           Command::new("yarn")
+                .args(&["dev"])
+                .current_dir("infra/ui")
+                .spawn();
+
+            Ok(())
+        });
+
+        info!("Finished spawning UI");
+        Ok(Some(node_gui_handle))
+    } else {
+        info!("GUI not enabled");
+        Ok(None)
+    }
 }

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -85,7 +85,7 @@ pub struct NodeConfig {
     pub keypair: Keypair,
 
     #[builder(default = "false")]
-    pub enable_ui: bool,
+    pub gui: bool,
 
     #[builder(default = "false")]
     pub disable_networking: bool,
@@ -159,7 +159,7 @@ impl Default for NodeConfig {
             preload_mock_state: false,
             bootstrap_config: None,
             keypair: Keypair::random(),
-            enable_ui: false,
+            gui: false,
             disable_networking: false,
         }
     }


### PR DESCRIPTION
## info
initial pass at moving the node gui initialization to a runtime managed by tokio

- move node gui initialization from node crate to runtime crate
- change flag for CLI to --gui