### PR TITLE
Add dyswarm to manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ kademlia-dht = { git = "https://github.com/vrrb-io/kademlia-dht-rs" }
 rendezvous_dht = { git = "https://github.com/vrrb-io/rendezvous_dht" }
 messr = { git = "https://github.com/vrrb-io/messr" }
 decentrust = { git = "https://github.com/vrrb-io/decentrust", branch = "main" }
+dyswarm = { git = "https://github.com/vrrb-io/dyswarm" }
 
 secp256k1 = { version = "0.25.0", features = [
     "rand",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -67,7 +67,8 @@ vrrb_http = { workspace = true }
 vrrb_grpc = { workspace = true }
 messr = { workspace = true }
 utils = { workspace = true }
-maglev =  { workspace = true }
+maglev = { workspace = true }
+dyswarm = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true }


### PR DESCRIPTION
Simply adds dyswarm as a dependency where it's going to be used to make it available early on.