### PR TITLE
Docs mods

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -25,7 +25,7 @@ Clone the repository with the following command:
 
 ```
 # Clone the Repository
-git clone git@github.com:vrrb-io/vrrb.git vrrb
+git clone https://github.com/vrrb-io/vrrb.git vrrb
 
 # Change into the working directory
 cd vrrb

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -14,7 +14,8 @@ In order to run the VRRB node, you will need to have the following installed on 
 
 - GIT (https://git-scm.com/downloads)
 - Rust & Cargo (https://www.rust-lang.org/tools/install)
-- CMake (https://www.gnu.org/software/make/)
+- GNU Make (https://www.gnu.org/software/make/)
+- CLang (https://clang.llvm.org/)
 
 # Clone the Github Repository
 


### PR DESCRIPTION
In trying to build, it seems like we need GNU Make instead of CMake, plus CLang's libs are needed to build. Also, using the ssh URL will likely not work for folks outside our git org due to permissions issues, so changed the URL to the HTTP one.