### PR TITLE
Refactor Instantiation of Swarm Module and Add Peer Fetching Events

### DIFF
--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -46,7 +46,8 @@ pub enum Event {
     #[default]
     NoOp,
     Stop,
-
+    FetchPeers(usize),
+    DHTStoreRequest(String, String),
     /// New txn came from network, requires validation
     NewTxnCreated(Txn),
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the Swarm module. The main focus is on refactoring the instantiation process to improve the overall efficiency and readability of the codebase. Additionally, two new events have been added to enhance the functionality of the Swarm:

Event 1: Fetch Peers from Swarm
  Implemented a mechanism to fetch peers from the Swarm network.
  Ensured that the event retrieves and provides accurate information about available peers.

Event 2: Store and Put Value within the DHT
  Node can store and fetch values from the Distributed Hash Table (DHT).
  Ensured that the event handles value storage securely and efficiently.