### PR TITLE
chore: Add platform compatibility to `shell.nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -27,6 +27,7 @@ pkgs.mkShell rec {
     # build dependencies
     clang
     libclang.lib
+    libiconv
     rocksdb
     openssl.dev
     pkg-config

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,10 @@
 pkgs.mkShell rec {
   name = "vrrb-dev";
 
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+  ];
+
   buildInputs = with pkgs; [
     # dev tools
     which
@@ -27,12 +31,13 @@ pkgs.mkShell rec {
     # build dependencies
     clang
     libclang.lib
-    libiconv
     rocksdb
     openssl.dev
-    pkg-config
     rustup
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+    darwin.apple_sdk.frameworks.Security
+    ];
 
   RUSTC_VERSION = pkgs.lib.readFile ./rust-toolchain.toml;
 

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@
 
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz") {} }:
 
-pkgs.mkShell rec {
+pkgs.mkShell {
   name = "vrrb-dev";
 
   nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
This update to the nix shell adds support for the following platforms and targets:

| platform | target |
-|-
aarch64-darwin | aarch64-apple-darwin
aarch64-linux | aarch64-unknown-linux-gnu
i686-linux | i686-unknown-linux-gnu
x86_64-darwin | x86_64-apple-darwin
x86_64-linux | x86_64-unknown-linux-gnu
