### PR TITLE
fix: add `Security` framework from `apple_sdk`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,7 @@ pkgs.mkShell {
     rocksdb
     openssl.dev
     libiconv
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
 
   shellHook = ''
     export LIBCLANG_PATH="${pkgs.libclang.lib}/lib";


### PR DESCRIPTION
Adds the `Security` package from the `apple_sdk` to fix problems with `clang` linking on apple machines.

This is tested and working on my M1 MBP, but please test before approving.

Closes #356 