### PR TITLE
fix: add `pkg-config` & `clang` to `nativeBuildInputs` in `shell.nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,8 @@ pkgs.mkShell {
   nativeBuildInputs = [
     # rust toolchain
     (fenix.fromToolchainFile { dir = ./.; })
+    pkgs.pkg-config
+    pkgs.clang
   ];
 
   buildInputs = with pkgs; [


### PR DESCRIPTION
Closes #357 

As described in the issue, `rocksdb` & `openssl` cannot link without `pkg-config` & `clang` as build inputs.