### PR TITLE
fix: resolve use of `Future`s in `scheduler::execute_sync_jobs()`

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -127,7 +127,7 @@ impl Node {
         }
 
         if let Some(handle) = scheduler_handle {
-            if let Err(err) = handle.await? {
+            if let Err(err) = handle.await {
                 error!("Scheduler handle is not shutdown: {err:?}");
             }
         }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -127,7 +127,7 @@ impl Node {
         }
 
         if let Some(handle) = scheduler_handle {
-            if let Err(err) = handle.await {
+            if let Err(err) = handle.join() {
                 error!("Scheduler handle is not shutdown: {err:?}");
             }
         }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -127,7 +127,7 @@ impl Node {
         }
 
         if let Some(handle) = scheduler_handle {
-            if let Err(err) = handle.join() {
+            if let Err(err) = handle.await? {
                 error!("Scheduler handle is not shutdown: {err:?}");
             }
         }

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -281,7 +281,6 @@ pub type QuorumPubkey = String;
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
-        thread,
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -373,9 +372,7 @@ mod tests {
             ValidatorCoreManager::new(8).unwrap(),
             vrrbdb_read_handle,
         );
-        thread::spawn(move || {
-            job_scheduler.execute_sync_jobs();
-        });
+        tokio::spawn(async move { job_scheduler.execute_sync_jobs().await });
         let mut dkg_engines = test_utils::generate_dkg_engine_with_states().await;
         let dkg_engine = dkg_engines.pop().unwrap();
         let group_public_key = dkg_engine

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -281,6 +281,7 @@ pub type QuorumPubkey = String;
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
+        thread,
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -372,7 +373,7 @@ mod tests {
             ValidatorCoreManager::new(8).unwrap(),
             vrrbdb_read_handle,
         );
-        tokio::spawn(async move { job_scheduler.execute_sync_jobs() });
+        thread::spawn(move || job_scheduler.execute_sync_jobs());
         let mut dkg_engines = test_utils::generate_dkg_engine_with_states().await;
         let dkg_engine = dkg_engines.pop().unwrap();
         let group_public_key = dkg_engine

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -372,7 +372,7 @@ mod tests {
             ValidatorCoreManager::new(8).unwrap(),
             vrrbdb_read_handle,
         );
-        tokio::spawn(async move { job_scheduler.execute_sync_jobs().await });
+        tokio::spawn(async move { job_scheduler.execute_sync_jobs() });
         let mut dkg_engines = test_utils::generate_dkg_engine_with_states().await;
         let dkg_engine = dkg_engines.pop().unwrap();
         let group_public_key = dkg_engine

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -67,7 +67,7 @@ pub mod swarm_module;
 
 pub type RuntimeHandle = Option<JoinHandle<Result<()>>>;
 pub type RaptorHandle = Option<thread::JoinHandle<bool>>;
-pub type SchedulerHandle = Option<JoinHandle<Result<()>>>;
+pub type SchedulerHandle = Option<thread::JoinHandle<Result<()>>>;
 
 impl From<MinerError> for NodeError {
     fn from(_error: MinerError) -> Self {
@@ -302,7 +302,7 @@ pub async fn setup_runtime_components(
         events_tx.clone(),
         state_read_handle.clone(),
     );
-    let scheduler_handle = tokio::spawn(async move { scheduler.execute_sync_jobs() });
+    let scheduler_handle = thread::spawn(move || scheduler.execute_sync_jobs());
     let indexer_handle =
         setup_indexer_module(&config, indexer_events_rx, mempool_read_handle_factory)?;
 

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -67,7 +67,7 @@ pub mod swarm_module;
 
 pub type RuntimeHandle = Option<JoinHandle<Result<()>>>;
 pub type RaptorHandle = Option<thread::JoinHandle<bool>>;
-pub type SchedulerHandle = Option<std::thread::JoinHandle<()>>;
+pub type SchedulerHandle = Option<JoinHandle<Result<()>>>;
 
 impl From<MinerError> for NodeError {
     fn from(_error: MinerError) -> Self {
@@ -302,9 +302,7 @@ pub async fn setup_runtime_components(
         events_tx.clone(),
         state_read_handle.clone(),
     );
-    let scheduler_handle = thread::spawn(move || {
-        scheduler.execute_sync_jobs();
-    });
+    let scheduler_handle = tokio::spawn(async move { scheduler.execute_sync_jobs().await });
     let indexer_handle =
         setup_indexer_module(&config, indexer_events_rx, mempool_read_handle_factory)?;
 

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -302,7 +302,7 @@ pub async fn setup_runtime_components(
         events_tx.clone(),
         state_read_handle.clone(),
     );
-    let scheduler_handle = tokio::spawn(async move { scheduler.execute_sync_jobs().await });
+    let scheduler_handle = tokio::spawn(async move { scheduler.execute_sync_jobs() });
     let indexer_handle =
         setup_indexer_module(&config, indexer_events_rx, mempool_read_handle_factory)?;
 

--- a/crates/node/src/services/scheduler.rs
+++ b/crates/node/src/services/scheduler.rs
@@ -100,188 +100,205 @@ impl JobSchedulerController {
         }
     }
 
-    pub async fn execute_sync_jobs(&mut self) -> Result<(), NodeError> {
-        loop {
-            if let Ok(job) = self.sync_jobs_receiver.try_recv() {
-                match job {
-                    Job::Farm((
-                        txns,
-                        receiver_farmer_id,
-                        farmer_node_id,
-                        quorum_public_key,
-                        sig_provider,
-                        farmer_quorum_threshold,
-                    )) => {
-                        let transactions: Vec<Txn> = txns.iter().map(|x| x.1.txn.clone()).collect();
-                        let validated_txns: Vec<_> = self
-                            .validator_core_manager
-                            .validate(&self.vrrbdb_read_handle.state_store_values(), transactions)
-                            .into_iter()
-                            .collect();
-
-                        //TODO  Add Delegation logic + Handling Double Spend by checking whether
-                        // MagLev Hashing over( Quorum Keys) to identify whether current farmer
-                        // quorum is supposed to vote on txn Txn is intended
-                        // to be validated by current validator
-                        let _backpressure = self.job_scheduler.calculate_back_pressure();
-                        //Delegation Principle need to be done
-                        let votes_result = self
-                            .job_scheduler
-                            .get_local_pool()
-                            .run_sync_job(move || {
-                                let votes = validated_txns
-                                    .par_iter()
-                                    .map_with(
-                                        receiver_farmer_id,
-                                        |receiver_farmer_id: &mut Vec<u8>, txn| {
-                                            let mut vote = None;
-                                            let new_txn = txn.0.clone();
-                                            if let Ok(txn_bytes) = bincode::serialize(&new_txn) {
-                                                if let Ok(signature) = sig_provider
-                                                    .generate_partial_signature(txn_bytes)
-                                                {
-                                                    vote = Some(Vote {
-                                                        farmer_id: receiver_farmer_id.clone(),
-                                                        farmer_node_id,
-                                                        signature,
-                                                        txn: new_txn,
-                                                        quorum_public_key: quorum_public_key
-                                                            .clone(),
-                                                        quorum_threshold: farmer_quorum_threshold,
-                                                        execution_result: None,
-                                                        is_txn_valid: txn.1.is_err(),
-                                                    });
-                                                }
-                                            }
-                                            vote
-                                        },
-                                    )
-                                    .collect::<Vec<Option<Vote>>>();
-                                votes
-                            })
-                            .join();
-                        if let Ok(votes) = votes_result {
-                            self.events_tx
-                                .send(
-                                    Event::ProcessedVotes(JobResult::Votes((
-                                        votes,
-                                        farmer_quorum_threshold,
-                                    )))
-                                    .into(),
+    pub fn execute_sync_jobs(&mut self) -> Result<(), NodeError> {
+        let rt_result = tokio::runtime::Runtime::new();
+        if let Ok(rt) = rt_result {
+            loop {
+                if let Ok(job) = self.sync_jobs_receiver.try_recv() {
+                    match job {
+                        Job::Farm((
+                            txns,
+                            receiver_farmer_id,
+                            farmer_node_id,
+                            quorum_public_key,
+                            sig_provider,
+                            farmer_quorum_threshold,
+                        )) => {
+                            let transactions: Vec<Txn> =
+                                txns.iter().map(|x| x.1.txn.clone()).collect();
+                            let validated_txns: Vec<_> = self
+                                .validator_core_manager
+                                .validate(
+                                    &self.vrrbdb_read_handle.state_store_values(),
+                                    transactions,
                                 )
-                                .await
-                                .map_err(|err| {
-                                    NodeError::Other(format!(
-                                        "failed to send processed votes: {err}"
-                                    ))
-                                })?
-                        }
-                    },
-                    Job::CertifyTxn((
-                        sig_provider,
-                        votes,
-                        txn_id,
-                        farmer_quorum_key,
-                        farmer_id,
-                        txn,
-                        farmer_quorum_threshold,
-                    )) => {
-                        let mut vote_shares: HashMap<bool, BTreeMap<NodeIdx, Vec<u8>>> =
-                            HashMap::new();
-                        for v in votes.iter() {
-                            if let Some(votes) = vote_shares.get_mut(&v.is_txn_valid) {
-                                votes.insert(v.farmer_node_id, v.signature.clone());
-                            } else {
-                                let sig_shares_map: BTreeMap<NodeIdx, Vec<u8>> =
-                                    vec![(v.farmer_node_id, v.signature.clone())]
-                                        .into_iter()
-                                        .collect();
-                                vote_shares.insert(v.is_txn_valid, sig_shares_map);
-                            }
-                        }
-                        let validated_txns: Vec<_> = self
-                            .validator_core_manager
-                            .validate(
-                                &self.vrrbdb_read_handle.state_store_values(),
-                                vec![txn.clone()],
-                            )
-                            .into_iter()
-                            .collect();
-                        let validated = validated_txns.par_iter().any(|x| x.0.id() == txn.id());
-                        let most_votes_share = vote_shares
-                            .iter()
-                            .max_by_key(|(_, votes_map)| votes_map.len())
-                            .map(|(key, votes_map)| (*key, votes_map.clone()));
-                        if validated {
-                            if let Some((is_txn_valid, votes_map)) = most_votes_share {
-                                let result = sig_provider.generate_quorum_signature(
-                                    farmer_quorum_threshold as u16,
-                                    votes_map.clone(),
-                                );
-                                if let Ok(threshold_signature) = result {
+                                .into_iter()
+                                .collect();
+
+                            //TODO  Add Delegation logic + Handling Double Spend by checking
+                            // whether MagLev Hashing over( Quorum Keys)
+                            // to identify whether current farmer quorum
+                            // is supposed to vote on txn Txn is intended
+                            // to be validated by current validator
+                            let _backpressure = self.job_scheduler.calculate_back_pressure();
+                            //Delegation Principle need to be done
+                            let votes_result = self
+                                .job_scheduler
+                                .get_local_pool()
+                                .run_sync_job(move || {
+                                    let votes = validated_txns
+                                        .par_iter()
+                                        .map_with(
+                                            receiver_farmer_id,
+                                            |receiver_farmer_id: &mut Vec<u8>, txn| {
+                                                let mut vote = None;
+                                                let new_txn = txn.0.clone();
+                                                if let Ok(txn_bytes) = bincode::serialize(&new_txn)
+                                                {
+                                                    if let Ok(signature) = sig_provider
+                                                        .generate_partial_signature(txn_bytes)
+                                                    {
+                                                        vote = Some(Vote {
+                                                            farmer_id: receiver_farmer_id.clone(),
+                                                            farmer_node_id,
+                                                            signature,
+                                                            txn: new_txn,
+                                                            quorum_public_key: quorum_public_key
+                                                                .clone(),
+                                                            quorum_threshold:
+                                                                farmer_quorum_threshold,
+                                                            execution_result: None,
+                                                            is_txn_valid: txn.1.is_err(),
+                                                        });
+                                                    }
+                                                }
+                                                vote
+                                            },
+                                        )
+                                        .collect::<Vec<Option<Vote>>>();
+                                    votes
+                                })
+                                .join();
+                            if let Ok(votes) = votes_result {
+                                rt.block_on(async {
                                     self.events_tx
                                         .send(
-                                            Event::CertifiedTxn(JobResult::CertifiedTxn(
-                                                votes.clone(),
-                                                threshold_signature,
-                                                txn_id.clone(),
-                                                farmer_quorum_key.clone(),
-                                                farmer_id.clone(),
-                                                Box::new(txn.clone()),
-                                                is_txn_valid,
-                                            ))
+                                            Event::ProcessedVotes(JobResult::Votes((
+                                                votes,
+                                                farmer_quorum_threshold,
+                                            )))
                                             .into(),
                                         )
                                         .await
                                         .map_err(|err| {
                                             NodeError::Other(format!(
-                                                "failed to send certified txn: {err}"
+                                                "failed to send processed votes: {err}"
                                             ))
-                                        })?
+                                        })
+                                })?;
+                            }
+                        },
+                        Job::CertifyTxn((
+                            sig_provider,
+                            votes,
+                            txn_id,
+                            farmer_quorum_key,
+                            farmer_id,
+                            txn,
+                            farmer_quorum_threshold,
+                        )) => {
+                            let mut vote_shares: HashMap<bool, BTreeMap<NodeIdx, Vec<u8>>> =
+                                HashMap::new();
+                            for v in votes.iter() {
+                                if let Some(votes) = vote_shares.get_mut(&v.is_txn_valid) {
+                                    votes.insert(v.farmer_node_id, v.signature.clone());
                                 } else {
-                                    error!("Quorum signature generation failed");
+                                    let sig_shares_map: BTreeMap<NodeIdx, Vec<u8>> =
+                                        vec![(v.farmer_node_id, v.signature.clone())]
+                                            .into_iter()
+                                            .collect();
+                                    vote_shares.insert(v.is_txn_valid, sig_shares_map);
                                 }
                             }
-                        } else {
-                            error!("Penalize Farmer for wrong votes by sending Wrong Vote event to CR Quorum");
-                        }
-                    },
-                    // Job `SignConvergenceBlock` signs the  block hash and
-                    // generates a partial signature for the block
-                    Job::SignConvergenceBlock(sig_provider, block) => {
-                        if let Ok(block_hash_bytes) = hex::decode(block.hash.clone()) {
-                            if let Ok(signature) =
-                                sig_provider.generate_partial_signature(block_hash_bytes)
-                            {
-                                let secret_share_opt = sig_provider
+                            let validated_txns: Vec<_> = self
+                                .validator_core_manager
+                                .validate(
+                                    &self.vrrbdb_read_handle.state_store_values(),
+                                    vec![txn.clone()],
+                                )
+                                .into_iter()
+                                .collect();
+                            let validated = validated_txns.par_iter().any(|x| x.0.id() == txn.id());
+                            let most_votes_share = vote_shares
+                                .iter()
+                                .max_by_key(|(_, votes_map)| votes_map.len())
+                                .map(|(key, votes_map)| (*key, votes_map.clone()));
+                            if validated {
+                                if let Some((is_txn_valid, votes_map)) = most_votes_share {
+                                    let result = sig_provider.generate_quorum_signature(
+                                        farmer_quorum_threshold as u16,
+                                        votes_map.clone(),
+                                    );
+                                    if let Ok(threshold_signature) = result {
+                                        rt.block_on(async {
+                                            self.events_tx
+                                                .send(
+                                                    Event::CertifiedTxn(JobResult::CertifiedTxn(
+                                                        votes.clone(),
+                                                        threshold_signature,
+                                                        txn_id.clone(),
+                                                        farmer_quorum_key.clone(),
+                                                        farmer_id.clone(),
+                                                        Box::new(txn.clone()),
+                                                        is_txn_valid,
+                                                    ))
+                                                    .into(),
+                                                )
+                                                .await
+                                                .map_err(|err| {
+                                                    NodeError::Other(format!(
+                                                        "failed to send certified txn: {err}"
+                                                    ))
+                                                })
+                                        })?;
+                                    } else {
+                                        error!("Quorum signature generation failed");
+                                    }
+                                }
+                            } else {
+                                error!("Penalize Farmer for wrong votes by sending Wrong Vote event to CR Quorum");
+                            }
+                        },
+                        // Job `SignConvergenceBlock` signs the  block hash and
+                        // generates a partial signature for the block
+                        Job::SignConvergenceBlock(sig_provider, block) => {
+                            if let Ok(block_hash_bytes) = hex::decode(block.hash.clone()) {
+                                if let Ok(signature) =
+                                    sig_provider.generate_partial_signature(block_hash_bytes)
+                                {
+                                    let secret_share_opt = sig_provider
                                     .dkg_state
                                     .read()
                                     .map(|dkg_state| dkg_state.secret_key_share.clone())
                                     .map_err(|err| NodeError::Other(format!("dkg_state lock was returned in a poisoned state: {err}")))?;
-                                if let Some(secret_share) = secret_share_opt {
-                                    self.events_tx
-                                        .send(
-                                            Event::ConvergenceBlockPartialSign(
-                                                JobResult::ConvergenceBlockPartialSign(
-                                                    block.hash.clone(),
-                                                    secret_share.public_key_share(),
-                                                    signature.clone(),
-                                                ),
-                                            )
-                                            .into(),
-                                        )
-                                        .await
-                                        .map_err(|err| {
-                                            NodeError::Other(format!(
-                                            "failed to send convergence block partial sign: {err}"
-                                        ))
-                                        })?
+                                    if let Some(secret_share) = secret_share_opt {
+                                        rt.block_on(async {
+                                            self.events_tx
+                                                .send(
+                                                    Event::ConvergenceBlockPartialSign(
+                                                        JobResult::ConvergenceBlockPartialSign(
+                                                            block.hash.clone(),
+                                                            secret_share.public_key_share(),
+                                                            signature.clone(),
+                                                        ),
+                                                    )
+                                                    .into(),
+                                                )
+                                                .await
+                                                .map_err(|err| {
+                                                    NodeError::Other(format!(
+                                                        "failed to send convergence block partial sign: {err}"
+                                                    ))
+                                                })
+                                        })?;
+                                    }
                                 }
                             }
-                        }
-                    },
+                        },
+                    }
                 }
             }
         }
+        Ok(())
     }
 }

--- a/crates/node/src/services/scheduler.rs
+++ b/crates/node/src/services/scheduler.rs
@@ -101,178 +101,171 @@ impl JobSchedulerController {
     }
 
     pub fn execute_sync_jobs(&mut self) -> Result<(), NodeError> {
-        let rt_result = tokio::runtime::Runtime::new();
-        if let Ok(rt) = rt_result {
-            loop {
-                if let Ok(job) = self.sync_jobs_receiver.try_recv() {
-                    match job {
-                        Job::Farm((
-                            txns,
-                            receiver_farmer_id,
-                            farmer_node_id,
-                            quorum_public_key,
-                            sig_provider,
-                            farmer_quorum_threshold,
-                        )) => {
-                            let transactions: Vec<Txn> =
-                                txns.iter().map(|x| x.1.txn.clone()).collect();
-                            let validated_txns: Vec<_> = self
-                                .validator_core_manager
-                                .validate(
-                                    &self.vrrbdb_read_handle.state_store_values(),
-                                    transactions,
-                                )
-                                .into_iter()
-                                .collect();
+        let rt = tokio::runtime::Runtime::new()?;
+        loop {
+            if let Ok(job) = self.sync_jobs_receiver.try_recv() {
+                match job {
+                    Job::Farm((
+                        txns,
+                        receiver_farmer_id,
+                        farmer_node_id,
+                        quorum_public_key,
+                        sig_provider,
+                        farmer_quorum_threshold,
+                    )) => {
+                        let transactions: Vec<Txn> = txns.iter().map(|x| x.1.txn.clone()).collect();
+                        let validated_txns: Vec<_> = self
+                            .validator_core_manager
+                            .validate(&self.vrrbdb_read_handle.state_store_values(), transactions)
+                            .into_iter()
+                            .collect();
 
-                            //TODO  Add Delegation logic + Handling Double Spend by checking
-                            // whether MagLev Hashing over( Quorum Keys)
-                            // to identify whether current farmer quorum
-                            // is supposed to vote on txn Txn is intended
-                            // to be validated by current validator
-                            let _backpressure = self.job_scheduler.calculate_back_pressure();
-                            //Delegation Principle need to be done
-                            let votes_result = self
-                                .job_scheduler
-                                .get_local_pool()
-                                .run_sync_job(move || {
-                                    let votes = validated_txns
-                                        .par_iter()
-                                        .map_with(
-                                            receiver_farmer_id,
-                                            |receiver_farmer_id: &mut Vec<u8>, txn| {
-                                                let mut vote = None;
-                                                let new_txn = txn.0.clone();
-                                                if let Ok(txn_bytes) = bincode::serialize(&new_txn)
+                        //TODO  Add Delegation logic + Handling Double Spend by checking
+                        // whether MagLev Hashing over( Quorum Keys)
+                        // to identify whether current farmer quorum
+                        // is supposed to vote on txn Txn is intended
+                        // to be validated by current validator
+                        let _backpressure = self.job_scheduler.calculate_back_pressure();
+                        //Delegation Principle need to be done
+                        let votes_result = self
+                            .job_scheduler
+                            .get_local_pool()
+                            .run_sync_job(move || {
+                                let votes = validated_txns
+                                    .par_iter()
+                                    .map_with(
+                                        receiver_farmer_id,
+                                        |receiver_farmer_id: &mut Vec<u8>, txn| {
+                                            let mut vote = None;
+                                            let new_txn = txn.0.clone();
+                                            if let Ok(txn_bytes) = bincode::serialize(&new_txn) {
+                                                if let Ok(signature) = sig_provider
+                                                    .generate_partial_signature(txn_bytes)
                                                 {
-                                                    if let Ok(signature) = sig_provider
-                                                        .generate_partial_signature(txn_bytes)
-                                                    {
-                                                        vote = Some(Vote {
-                                                            farmer_id: receiver_farmer_id.clone(),
-                                                            farmer_node_id,
-                                                            signature,
-                                                            txn: new_txn,
-                                                            quorum_public_key: quorum_public_key
-                                                                .clone(),
-                                                            quorum_threshold:
-                                                                farmer_quorum_threshold,
-                                                            execution_result: None,
-                                                            is_txn_valid: txn.1.is_err(),
-                                                        });
-                                                    }
+                                                    vote = Some(Vote {
+                                                        farmer_id: receiver_farmer_id.clone(),
+                                                        farmer_node_id,
+                                                        signature,
+                                                        txn: new_txn,
+                                                        quorum_public_key: quorum_public_key
+                                                            .clone(),
+                                                        quorum_threshold: farmer_quorum_threshold,
+                                                        execution_result: None,
+                                                        is_txn_valid: txn.1.is_err(),
+                                                    });
                                                 }
-                                                vote
-                                            },
-                                        )
-                                        .collect::<Vec<Option<Vote>>>();
-                                    votes
-                                })
-                                .join();
-                            if let Ok(votes) = votes_result {
-                                rt.block_on(async {
-                                    self.events_tx
-                                        .send(
-                                            Event::ProcessedVotes(JobResult::Votes((
-                                                votes,
-                                                farmer_quorum_threshold,
-                                            )))
-                                            .into(),
-                                        )
-                                        .await
-                                        .map_err(|err| {
-                                            NodeError::Other(format!(
-                                                "failed to send processed votes: {err}"
-                                            ))
-                                        })
-                                })?;
-                            }
-                        },
-                        Job::CertifyTxn((
-                            sig_provider,
-                            votes,
-                            txn_id,
-                            farmer_quorum_key,
-                            farmer_id,
-                            txn,
-                            farmer_quorum_threshold,
-                        )) => {
-                            let mut vote_shares: HashMap<bool, BTreeMap<NodeIdx, Vec<u8>>> =
-                                HashMap::new();
-                            for v in votes.iter() {
-                                if let Some(votes) = vote_shares.get_mut(&v.is_txn_valid) {
-                                    votes.insert(v.farmer_node_id, v.signature.clone());
-                                } else {
-                                    let sig_shares_map: BTreeMap<NodeIdx, Vec<u8>> =
-                                        vec![(v.farmer_node_id, v.signature.clone())]
-                                            .into_iter()
-                                            .collect();
-                                    vote_shares.insert(v.is_txn_valid, sig_shares_map);
-                                }
-                            }
-                            let validated_txns: Vec<_> = self
-                                .validator_core_manager
-                                .validate(
-                                    &self.vrrbdb_read_handle.state_store_values(),
-                                    vec![txn.clone()],
-                                )
-                                .into_iter()
-                                .collect();
-                            let validated = validated_txns.par_iter().any(|x| x.0.id() == txn.id());
-                            let most_votes_share = vote_shares
-                                .iter()
-                                .max_by_key(|(_, votes_map)| votes_map.len())
-                                .map(|(key, votes_map)| (*key, votes_map.clone()));
-                            if validated {
-                                if let Some((is_txn_valid, votes_map)) = most_votes_share {
-                                    let result = sig_provider.generate_quorum_signature(
-                                        farmer_quorum_threshold as u16,
-                                        votes_map.clone(),
-                                    );
-                                    if let Ok(threshold_signature) = result {
-                                        rt.block_on(async {
-                                            self.events_tx
-                                                .send(
-                                                    Event::CertifiedTxn(JobResult::CertifiedTxn(
-                                                        votes.clone(),
-                                                        threshold_signature,
-                                                        txn_id.clone(),
-                                                        farmer_quorum_key.clone(),
-                                                        farmer_id.clone(),
-                                                        Box::new(txn.clone()),
-                                                        is_txn_valid,
-                                                    ))
-                                                    .into(),
-                                                )
-                                                .await
-                                                .map_err(|err| {
-                                                    NodeError::Other(format!(
-                                                        "failed to send certified txn: {err}"
-                                                    ))
-                                                })
-                                        })?;
-                                    } else {
-                                        error!("Quorum signature generation failed");
-                                    }
-                                }
+                                            }
+                                            vote
+                                        },
+                                    )
+                                    .collect::<Vec<Option<Vote>>>();
+                                votes
+                            })
+                            .join();
+                        if let Ok(votes) = votes_result {
+                            rt.block_on(async {
+                                self.events_tx
+                                    .send(
+                                        Event::ProcessedVotes(JobResult::Votes((
+                                            votes,
+                                            farmer_quorum_threshold,
+                                        )))
+                                        .into(),
+                                    )
+                                    .await
+                                    .map_err(|err| {
+                                        NodeError::Other(format!(
+                                            "failed to send processed votes: {err}"
+                                        ))
+                                    })
+                            })?;
+                        }
+                    },
+                    Job::CertifyTxn((
+                        sig_provider,
+                        votes,
+                        txn_id,
+                        farmer_quorum_key,
+                        farmer_id,
+                        txn,
+                        farmer_quorum_threshold,
+                    )) => {
+                        let mut vote_shares: HashMap<bool, BTreeMap<NodeIdx, Vec<u8>>> =
+                            HashMap::new();
+                        for v in votes.iter() {
+                            if let Some(votes) = vote_shares.get_mut(&v.is_txn_valid) {
+                                votes.insert(v.farmer_node_id, v.signature.clone());
                             } else {
-                                error!("Penalize Farmer for wrong votes by sending Wrong Vote event to CR Quorum");
+                                let sig_shares_map: BTreeMap<NodeIdx, Vec<u8>> =
+                                    vec![(v.farmer_node_id, v.signature.clone())]
+                                        .into_iter()
+                                        .collect();
+                                vote_shares.insert(v.is_txn_valid, sig_shares_map);
                             }
-                        },
-                        // Job `SignConvergenceBlock` signs the  block hash and
-                        // generates a partial signature for the block
-                        Job::SignConvergenceBlock(sig_provider, block) => {
-                            if let Ok(block_hash_bytes) = hex::decode(block.hash.clone()) {
-                                if let Ok(signature) =
-                                    sig_provider.generate_partial_signature(block_hash_bytes)
-                                {
-                                    let secret_share_opt = sig_provider
+                        }
+                        let validated_txns: Vec<_> = self
+                            .validator_core_manager
+                            .validate(
+                                &self.vrrbdb_read_handle.state_store_values(),
+                                vec![txn.clone()],
+                            )
+                            .into_iter()
+                            .collect();
+                        let validated = validated_txns.par_iter().any(|x| x.0.id() == txn.id());
+                        let most_votes_share = vote_shares
+                            .iter()
+                            .max_by_key(|(_, votes_map)| votes_map.len())
+                            .map(|(key, votes_map)| (*key, votes_map.clone()));
+                        if validated {
+                            if let Some((is_txn_valid, votes_map)) = most_votes_share {
+                                let result = sig_provider.generate_quorum_signature(
+                                    farmer_quorum_threshold as u16,
+                                    votes_map.clone(),
+                                );
+                                if let Ok(threshold_signature) = result {
+                                    rt.block_on(async {
+                                        self.events_tx
+                                            .send(
+                                                Event::CertifiedTxn(JobResult::CertifiedTxn(
+                                                    votes.clone(),
+                                                    threshold_signature,
+                                                    txn_id.clone(),
+                                                    farmer_quorum_key.clone(),
+                                                    farmer_id.clone(),
+                                                    Box::new(txn.clone()),
+                                                    is_txn_valid,
+                                                ))
+                                                .into(),
+                                            )
+                                            .await
+                                            .map_err(|err| {
+                                                NodeError::Other(format!(
+                                                    "failed to send certified txn: {err}"
+                                                ))
+                                            })
+                                    })?;
+                                } else {
+                                    error!("Quorum signature generation failed");
+                                }
+                            }
+                        } else {
+                            error!("Penalize Farmer for wrong votes by sending Wrong Vote event to CR Quorum");
+                        }
+                    },
+                    // Job `SignConvergenceBlock` signs the  block hash and
+                    // generates a partial signature for the block
+                    Job::SignConvergenceBlock(sig_provider, block) => {
+                        if let Ok(block_hash_bytes) = hex::decode(block.hash.clone()) {
+                            if let Ok(signature) =
+                                sig_provider.generate_partial_signature(block_hash_bytes)
+                            {
+                                let secret_share_opt = sig_provider
                                     .dkg_state
                                     .read()
                                     .map(|dkg_state| dkg_state.secret_key_share.clone())
                                     .map_err(|err| NodeError::Other(format!("dkg_state lock was returned in a poisoned state: {err}")))?;
-                                    if let Some(secret_share) = secret_share_opt {
-                                        rt.block_on(async {
+                                if let Some(secret_share) = secret_share_opt {
+                                    rt.block_on(async {
                                             self.events_tx
                                                 .send(
                                                     Event::ConvergenceBlockPartialSign(
@@ -291,14 +284,12 @@ impl JobSchedulerController {
                                                     ))
                                                 })
                                         })?;
-                                    }
                                 }
                             }
-                        },
-                    }
+                        }
+                    },
                 }
             }
         }
-        Ok(())
     }
 }

--- a/crates/node/src/services/scheduler.rs
+++ b/crates/node/src/services/scheduler.rs
@@ -253,11 +253,12 @@ impl JobSchedulerController {
                             if let Ok(signature) =
                                 sig_provider.generate_partial_signature(block_hash_bytes)
                             {
-                                if let Ok(Some(secret_share)) = sig_provider
+                                let secret_share_opt = sig_provider
                                     .dkg_state
                                     .read()
                                     .map(|dkg_state| dkg_state.secret_key_share.clone())
-                                {
+                                    .map_err(|err| NodeError::Other(format!("dkg_state lock was returned in a poisoned state: {err}")))?;
+                                if let Some(secret_share) = secret_share_opt {
                                     self.events_tx
                                         .send(
                                             Event::ConvergenceBlockPartialSign(


### PR DESCRIPTION
Closes #361 

Fixes an instance where async work was being done in a non-async function that had unused `Futures`. Making the function `async` created an instance of `async move` in a closure where a new `std::thread` was trying to take ownership. This change makes this logic safe by using a `tokio::runtime` inside of the function to keep the process synchronous to the new thread that is spawned and takes ownership.