### PR TITLE
feat: Update `Quorum` struct, handle `EventElected` Quorum, and trigger `DKGInitiate`,`HandleAcks`,`GenerateKeySet` event

### DIFF
--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -9,7 +9,7 @@ mod tests {
         net::SocketAddr,
     };
 
-    use primitives::Address;
+    use primitives::{Address, RaptorUdpPort};
     use sha256::digest;
     use vrrb_core::{claim::Claim, keypair::KeyPair};
 
@@ -19,6 +19,8 @@ mod tests {
     fn it_works() {
         assert_eq!(2 + 2, 4);
     }
+
+    pub(crate) const TEST_PORT_NUMBER : RaptorUdpPort = 1023;
 
     #[test]
     fn not_enough_claims() {
@@ -31,7 +33,7 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
@@ -39,7 +41,7 @@ mod tests {
                 public_key,
                 Address::new(public_key),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 signature,
             )
             .unwrap();
@@ -79,7 +81,7 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
@@ -87,7 +89,7 @@ mod tests {
                 public_key,
                 Address::new(public_key),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 signature,
             )
             .unwrap();
@@ -122,7 +124,7 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
@@ -130,7 +132,7 @@ mod tests {
                 public_key,
                 Address::new(public_key),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 signature,
             )
             .unwrap();
@@ -162,7 +164,7 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
@@ -170,7 +172,7 @@ mod tests {
                 public_key,
                 Address::new(public_key),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 signature,
             )
             .unwrap();
@@ -206,7 +208,7 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
@@ -214,7 +216,7 @@ mod tests {
                 public_key,
                 Address::new(public_key),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 signature,
             )
             .unwrap();
@@ -250,7 +252,7 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
@@ -258,7 +260,7 @@ mod tests {
                 public_key,
                 Address::new(public_key),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 signature,
             )
             .unwrap();
@@ -298,7 +300,7 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
@@ -306,7 +308,7 @@ mod tests {
                 public_key,
                 Address::new(public_key),
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 signature,
             )
             .unwrap();

--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -31,11 +31,18 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
+                1023,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                1023,
+                signature,
+            )
+            .unwrap();
 
             //let claim_box = Box::new(claim);
             dummy_claims.push(claim);
@@ -72,11 +79,18 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
+                1023,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                1023,
+                signature,
+            )
+            .unwrap();
 
             dummy_claims.push(claim);
         });
@@ -108,11 +122,18 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
+                1023,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                1023,
+                signature,
+            )
+            .unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -141,11 +162,18 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
+                1023,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                1023,
+                signature,
+            )
+            .unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -178,11 +206,18 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
+                1023,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                1023,
+                signature,
+            )
+            .unwrap();
             dummy_claims.push(claim);
         });
 
@@ -215,11 +250,18 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
+                1023,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                1023,
+                signature,
+            )
+            .unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -256,11 +298,18 @@ mod tests {
             let signature = Claim::signature_for_valid_claim(
                 public_key.clone(),
                 ip_address,
+                1023,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                1023,
+                signature,
+            )
+            .unwrap();
             //let boxed_claim = Box::new(claim);
             dummy_claims1.push(claim.clone());
             dummy_claims2.push(claim.clone());

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,11 +1,33 @@
 use std::net::SocketAddr;
 
 use block::{
-    header::BlockHeader, Block, BlockHash, Certificate, ConvergenceBlock, ProposalBlock, RefHash,
+    header::BlockHeader,
+    Block,
+    BlockHash,
+    Certificate,
+    ConvergenceBlock,
+    ProposalBlock,
+    RefHash,
 };
 use ethereum_types::U256;
 use mempool::TxnRecord;
-use primitives::{Address, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx, PartCommitmentBytes, PublicKeyShareVec, QuorumPublicKey, QuorumSize, RawSignature, Round, Seed, SenderId};
+use primitives::{
+    AckBytes,
+    Address,
+    CurrentNodeId,
+    Epoch,
+    FarmerQuorumThreshold,
+    NodeId,
+    NodeIdx,
+    PartCommitmentBytes,
+    PublicKeyShareVec,
+    QuorumPublicKey,
+    QuorumSize,
+    RawSignature,
+    Round,
+    Seed,
+    SenderId,
+};
 use quorum::quorum::Quorum;
 use serde::{Deserialize, Serialize};
 use vrrb_core::{
@@ -129,13 +151,19 @@ pub enum Event {
     /// message has been received from the network, and has to be recorded
     /// in the part message store.
     PartMessage(SenderId, PartCommitmentBytes),
-    /// `SendPartMessage(u16,Vec<u8>)` is an event that is triggered when part message has been received from the network,
-    /// and has to be recorded in the part message store.
+    /// `SendPartMessage(u16,Vec<u8>)` is an event that is triggered when part
+    /// message has been received from the network, and has to be recorded
+    /// in the part message store.
     SendPartMessage(SenderId, PartCommitmentBytes),
 
-    /// `SendAck(u16,u16,Vec<u8>)` is an event that is triggered when part commitment has been acknowledged by the
-    /// current node ,it has to be broadcasted to the other members of the Elected Quorum.
-    SendAck(u16, u16, Vec<u8>),
+    /// `Ack(CurrentNodeId, SenderId, AckBytes)` is an event that is triggered
+    /// when ack has been recieved for committment
+    Ack(CurrentNodeId, SenderId, AckBytes),
+
+    /// `SendAck(NodeId,SenderId,AckBytes)` is an event that is triggered when
+    /// part commitment has been acknowledged by the current node ,it has to
+    /// be broadcasted to the other members of the Elected Quorum.
+    SendAck(CurrentNodeId, SenderId, AckBytes),
 
     /// `HandleAllAcks` is an event that is triggered to handle all the
     /// acknowledgments of partial commitments given by Nodes elected for

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,28 +1,13 @@
 use std::net::SocketAddr;
 
 use block::{
-    header::BlockHeader,
-    Block,
-    BlockHash,
-    Certificate,
-    ConvergenceBlock,
-    ProposalBlock,
-    RefHash,
+    header::BlockHeader, Block, BlockHash, Certificate, ConvergenceBlock, ProposalBlock, RefHash,
 };
 use ethereum_types::U256;
 use mempool::TxnRecord;
 use primitives::{
-    Address,
-    Epoch,
-    FarmerQuorumThreshold,
-    NodeId,
-    NodeIdx,
-    PublicKeyShareVec,
-    QuorumPublicKey,
-    QuorumSize,
-    RawSignature,
-    Round,
-    Seed,
+    Address, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx, PublicKeyShareVec, QuorumPublicKey,
+    QuorumSize, RawSignature, Round, Seed,
 };
 use quorum::quorum::Quorum;
 use serde::{Deserialize, Serialize};
@@ -147,10 +132,12 @@ pub enum Event {
     /// message has been received from the network, and has to be recorded
     /// in the part message store.
     PartMessage(u16, Vec<u8>),
+    /// `SendPartMessage(u16,Vec<u8>)` is an event that is triggered when part message has been received from the network,
+    /// and has to be recorded in the part message store.
+    SendPartMessage(u16, Vec<u8>),
 
-    /// `SendAck(u16,u16,Vec<u8>)` is an event that is triggered when part
-    /// commitment has been acknowledged by the current node ,it has to be
-    /// broadcasted to the other members of the Elected Quorum.
+    /// `SendAck(u16,u16,Vec<u8>)` is an event that is triggered when part commitment has been acknowledged by the
+    /// current node ,it has to be broadcasted to the other members of the Elected Quorum.
     SendAck(u16, u16, Vec<u8>),
 
     /// `HandleAllAcks` is an event that is triggered to handle all the

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,13 +1,28 @@
 use std::net::SocketAddr;
 
 use block::{
-    header::BlockHeader, Block, BlockHash, Certificate, ConvergenceBlock, ProposalBlock, RefHash,
+    header::BlockHeader,
+    Block,
+    BlockHash,
+    Certificate,
+    ConvergenceBlock,
+    ProposalBlock,
+    RefHash,
 };
 use ethereum_types::U256;
 use mempool::TxnRecord;
 use primitives::{
-    Address, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx, PublicKeyShareVec, QuorumPublicKey,
-    QuorumSize, RawSignature, Round, Seed,
+    Address,
+    Epoch,
+    FarmerQuorumThreshold,
+    NodeId,
+    NodeIdx,
+    PublicKeyShareVec,
+    QuorumPublicKey,
+    QuorumSize,
+    RawSignature,
+    Round,
+    Seed,
 };
 use quorum::quorum::Quorum;
 use serde::{Deserialize, Serialize};

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -5,10 +5,7 @@ use block::{
 };
 use ethereum_types::U256;
 use mempool::TxnRecord;
-use primitives::{
-    Address, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx, PublicKeyShareVec, QuorumPublicKey,
-    QuorumSize, RawSignature, Round, Seed,
-};
+use primitives::{Address, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx, PartCommitmentBytes, PublicKeyShareVec, QuorumPublicKey, QuorumSize, RawSignature, Round, Seed, SenderId};
 use quorum::quorum::Quorum;
 use serde::{Deserialize, Serialize};
 use vrrb_core::{
@@ -126,15 +123,15 @@ pub enum Event {
     /// `AckPartCommitment(u16)` is an event that is triggered when part
     /// commitment has been received from the network, and now it has to be
     /// acknowledged
-    AckPartCommitment(u16),
+    AckPartCommitment(SenderId),
 
     /// `PartMessage(u16,Vec<u8>)` is an event that is triggered when part
     /// message has been received from the network, and has to be recorded
     /// in the part message store.
-    PartMessage(u16, Vec<u8>),
+    PartMessage(SenderId, PartCommitmentBytes),
     /// `SendPartMessage(u16,Vec<u8>)` is an event that is triggered when part message has been received from the network,
     /// and has to be recorded in the part message store.
-    SendPartMessage(u16, Vec<u8>),
+    SendPartMessage(SenderId, PartCommitmentBytes),
 
     /// `SendAck(u16,u16,Vec<u8>)` is an event that is triggered when part commitment has been acknowledged by the
     /// current node ,it has to be broadcasted to the other members of the Elected Quorum.

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,28 +1,13 @@
 use std::net::SocketAddr;
 
 use block::{
-    header::BlockHeader,
-    Block,
-    BlockHash,
-    Certificate,
-    ConvergenceBlock,
-    ProposalBlock,
-    RefHash,
+    header::BlockHeader, Block, BlockHash, Certificate, ConvergenceBlock, ProposalBlock, RefHash,
 };
 use ethereum_types::U256;
 use mempool::TxnRecord;
 use primitives::{
-    Address,
-    Epoch,
-    FarmerQuorumThreshold,
-    NodeId,
-    NodeIdx,
-    PublicKeyShareVec,
-    QuorumPublicKey,
-    QuorumSize,
-    RawSignature,
-    Round,
-    Seed,
+    Address, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx, PublicKeyShareVec, QuorumPublicKey,
+    QuorumSize, RawSignature, Round, Seed,
 };
 use quorum::quorum::Quorum;
 use serde::{Deserialize, Serialize};

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -25,16 +25,10 @@ mod tests {
     };
 
     use crate::test_helpers::{
-        build_single_proposal_block,
-        build_single_proposal_block_from_txns,
-        create_and_sign_message,
-        create_miner,
-        create_miner_from_keypair,
-        create_miner_from_keypair_and_dag,
-        create_miner_from_keypair_return_dag,
-        create_miner_return_dag,
-        create_txns,
-        mine_genesis,
+        build_single_proposal_block, build_single_proposal_block_from_txns,
+        create_and_sign_message, create_miner, create_miner_from_keypair,
+        create_miner_from_keypair_and_dag, create_miner_from_keypair_return_dag,
+        create_miner_return_dag, create_txns, mine_genesis,
     };
 
     #[test]
@@ -45,6 +39,7 @@ mod tests {
         let signature = Claim::signature_for_valid_claim(
             kp.miner_kp.1.clone(),
             ip_address.clone(),
+            1023,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
@@ -52,6 +47,7 @@ mod tests {
             kp.miner_kp.1.clone(),
             address.clone(),
             ip_address,
+            1023,
             signature,
         )
         .unwrap();

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -30,7 +30,7 @@ mod tests {
         create_miner_from_keypair_and_dag, create_miner_from_keypair_return_dag,
         create_miner_return_dag, create_txns, mine_genesis,
     };
-
+  pub (crate) const TEST_PORT_NUMBER:u16=1023;
     #[test]
     fn test_create_miner() {
         let kp = Keypair::random();
@@ -39,7 +39,7 @@ mod tests {
         let signature = Claim::signature_for_valid_claim(
             kp.miner_kp.1.clone(),
             ip_address.clone(),
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
@@ -47,7 +47,7 @@ mod tests {
             kp.miner_kp.1.clone(),
             address.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             signature,
         )
         .unwrap();

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -23,6 +23,7 @@ use crate::{result::MinerError, Miner, MinerConfig};
 /// Move this into primitives and call it simply `BlockDag`
 pub type MinerDag = Arc<RwLock<BullDag<Block, String>>>;
 
+pub (crate) const TEST_PORT_NUMBER:u16=1023;
 /// Helper function to create a random Miner.
 pub fn create_miner() -> Miner {
     let (secret_key, public_key) = create_keypair();
@@ -32,7 +33,7 @@ pub fn create_miner() -> Miner {
         secret_key,
         public_key,
         ip_address,
-        raptor_port: 1023,
+        raptor_port: TEST_PORT_NUMBER,
         dag,
     };
     Miner::new(config).unwrap()
@@ -46,7 +47,7 @@ pub fn create_miner_from_keypair(kp: &Keypair) -> Miner {
     let config = MinerConfig {
         secret_key,
         ip_address,
-        raptor_port: 1023,
+        raptor_port: TEST_PORT_NUMBER,
         public_key,
         dag,
     };
@@ -178,9 +179,9 @@ pub fn create_claims(n: usize) -> impl Iterator<Item = (U256, Claim)> {
         let addr = create_address(&pk);
         let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
         let signature =
-            Claim::signature_for_valid_claim(pk, ip_address, 1023, sk.secret_bytes().to_vec())
+            Claim::signature_for_valid_claim(pk, ip_address, TEST_PORT_NUMBER, sk.secret_bytes().to_vec())
                 .unwrap();
-        let claim = create_claim(&pk, &addr, ip_address, 1023, signature);
+        let claim = create_claim(&pk, &addr, ip_address, TEST_PORT_NUMBER, signature);
         (claim.hash, claim)
     })
 }
@@ -254,11 +255,11 @@ pub fn build_multiple_proposal_blocks_single_round(
             let signature = Claim::signature_for_valid_claim(
                 public_key,
                 ip_address,
-                1023,
+                TEST_PORT_NUMBER,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim = Claim::new(public_key, address, ip_address, 1023, signature).unwrap();
+            let claim = Claim::new(public_key, address, ip_address, TEST_PORT_NUMBER, signature).unwrap();
             let prop = build_single_proposal_block(
                 last_block_hash.clone(),
                 n_txns,

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -4,12 +4,7 @@ use std::{
 };
 
 use block::{
-    invalid::InvalidBlockErrorReason,
-    Block,
-    GenesisBlock,
-    InnerBlock,
-    ProposalBlock,
-    TxnList,
+    invalid::InvalidBlockErrorReason, Block, GenesisBlock, InnerBlock, ProposalBlock, TxnList,
 };
 use bulldag::{graph::BullDag, vertex::Vertex};
 use ethereum_types::U256;
@@ -37,6 +32,7 @@ pub fn create_miner() -> Miner {
         secret_key,
         public_key,
         ip_address,
+        raptor_port: 1023,
         dag,
     };
     Miner::new(config).unwrap()
@@ -50,6 +46,7 @@ pub fn create_miner_from_keypair(kp: &Keypair) -> Miner {
     let config = MinerConfig {
         secret_key,
         ip_address,
+        raptor_port: 1023,
         public_key,
         dag,
     };
@@ -85,9 +82,10 @@ pub fn create_claim(
     pk: &PublicKey,
     addr: &Address,
     ip_address: SocketAddr,
+    raptor_port: u16,
     signature: String,
 ) -> Claim {
-    Claim::new(*pk, addr.clone(), ip_address, signature).unwrap()
+    Claim::new(*pk, addr.clone(), ip_address, raptor_port, signature).unwrap()
 }
 
 /// Helper function to create a random message and signature
@@ -180,8 +178,9 @@ pub fn create_claims(n: usize) -> impl Iterator<Item = (U256, Claim)> {
         let addr = create_address(&pk);
         let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
         let signature =
-            Claim::signature_for_valid_claim(pk, ip_address, sk.secret_bytes().to_vec()).unwrap();
-        let claim = create_claim(&pk, &addr, ip_address, signature);
+            Claim::signature_for_valid_claim(pk, ip_address, 1023, sk.secret_bytes().to_vec())
+                .unwrap();
+        let claim = create_claim(&pk, &addr, ip_address, 1023, signature);
         (claim.hash, claim)
     })
 }
@@ -255,10 +254,11 @@ pub fn build_multiple_proposal_blocks_single_round(
             let signature = Claim::signature_for_valid_claim(
                 public_key,
                 ip_address,
+                1023,
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim = Claim::new(public_key, address, ip_address, signature).unwrap();
+            let claim = Claim::new(public_key, address, ip_address, 1023, signature).unwrap();
             let prop = build_single_proposal_block(
                 last_block_hash.clone(),
                 n_txns,

--- a/crates/node/src/components/dkg_module.rs
+++ b/crates/node/src/components/dkg_module.rs
@@ -10,16 +10,8 @@ use events::{Event, EventMessage, EventPublisher, SyncPeerData};
 use hbbft::crypto::{PublicKey, SecretKeyShare};
 use laminar::{Config, Packet, Socket, SocketEvent};
 use primitives::{
-    NodeIdx,
-    NodeType,
-    NodeTypeBytes,
-    PKShareBytes,
-    PayloadBytes,
-    QuorumPublicKey,
-    QuorumType,
-    RawSignature,
-    REGISTER_REQUEST,
-    RETRIEVE_PEERS_REQUEST,
+    NodeIdx, NodeType, NodeTypeBytes, PKShareBytes, PayloadBytes, QuorumPublicKey, QuorumType,
+    RawSignature, REGISTER_REQUEST, RETRIEVE_PEERS_REQUEST,
 };
 use rand::{distributions::Alphanumeric, Rng};
 use serde::{Deserialize, Serialize};
@@ -442,7 +434,7 @@ impl Handler<EventMessage> for DkgModule {
                                     let _ = self
                                         .broadcast_events_tx
                                         .send(
-                                            Event::PartMessage(node_idx, part_committment_bytes)
+                                            Event::SendPartMessage(node_idx, part_committment_bytes)
                                                 .into(),
                                         )
                                         .await.map_err(|e| {

--- a/crates/node/src/components/dkg_module.rs
+++ b/crates/node/src/components/dkg_module.rs
@@ -7,14 +7,26 @@ use dkg_engine::{
     types::{config::ThresholdConfig, DkgEngine, DkgResult},
 };
 use events::{Event, EventMessage, EventPublisher, SyncPeerData};
-use hbbft::crypto::{PublicKey, SecretKeyShare};
+use hbbft::{
+    crypto::{PublicKey, SecretKeyShare},
+    sync_key_gen::Ack,
+};
 use laminar::{Config, Packet, Socket, SocketEvent};
 use primitives::{
-    NodeIdx, NodeType, NodeTypeBytes, PKShareBytes, PayloadBytes, QuorumPublicKey, QuorumType,
-    RawSignature, REGISTER_REQUEST, RETRIEVE_PEERS_REQUEST,
+    NodeIdx,
+    NodeType,
+    NodeTypeBytes,
+    PKShareBytes,
+    PayloadBytes,
+    QuorumPublicKey,
+    QuorumType,
+    RawSignature,
+    REGISTER_REQUEST,
+    RETRIEVE_PEERS_REQUEST,
 };
 use rand::{distributions::Alphanumeric, Rng};
 use serde::{Deserialize, Serialize};
+use sha2::digest::typenum::Pow;
 use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler, TheaterError};
 use tracing::error;
@@ -466,6 +478,16 @@ impl Handler<EventMessage> for DkgModule {
                         .entry(node_idx)
                         .or_insert_with(|| part_committment);
                 };
+                let _ = self
+                        .broadcast_events_tx
+                        .send(
+                            Event::AckPartCommitment(node_idx)
+                                .into(),
+                        )
+                        .await.map_err(|e| {
+                            error!("Error occured while sending part message to broadcast event channel {:?}", e);
+                            TheaterError::Other(format!("{e:?}"))
+                        });
             },
             Event::AckPartCommitment(sender_id) => {
                 if self
@@ -497,6 +519,16 @@ impl Handler<EventMessage> for DkgModule {
                                         });
                                     };
                                 }
+                                let quorum_size = self.dkg_engine.threshold_config.upper_bound;
+                                if self.dkg_engine.dkg_state.ack_message_store.len()
+                                    == quorum_size.pow(2) as usize
+                                    && self.dkg_engine.dkg_state.public_key_set.is_none()
+                                {
+                                    let _ = self.broadcast_events_tx.send(Event::HandleAllAcks.into()).await.map_err(|e| {
+                                        error!("Error occured while sending ack message to broadcast event channel {:?}", e);
+                                        TheaterError::Other(format!("{e:?}"))
+                                    });
+                                }
                             },
                             _ => {
                                 error!("Error occured while acknowledging partial commitment for node {:?}", sender_id);
@@ -510,11 +542,61 @@ impl Handler<EventMessage> for DkgModule {
                     error!("Part Committment for Node idx {:?} missing", sender_id);
                 }
             },
+            Event::Ack(current_node_id, sender_id, ack_bytes) => {
+                if self
+                    .dkg_engine
+                    .dkg_state
+                    .ack_message_store
+                    .contains_key(&(current_node_id, sender_id))
+                {
+                    error!(
+                        "Part Committment for Node idx {:?} already acknowledge",
+                        sender_id
+                    );
+                } else {
+                    let ack_result = bincode::deserialize::<Ack>(&ack_bytes);
+                    if let Ok(ack) = ack_result {
+                        if self
+                            .dkg_engine
+                            .dkg_state
+                            .ack_message_store
+                            .contains_key(&(current_node_id, sender_id))
+                        {
+                            if self
+                                .dkg_engine
+                                .dkg_state
+                                .ack_message_store
+                                .insert((current_node_id, sender_id), ack)
+                                .is_some()
+                            {
+                                let quorum_size = self.dkg_engine.threshold_config.upper_bound;
+                                if self.dkg_engine.dkg_state.ack_message_store.len()
+                                    == quorum_size.pow(2) as usize
+                                    && self.dkg_engine.dkg_state.public_key_set.is_none()
+                                {
+                                    let _ = self.broadcast_events_tx.send(Event::HandleAllAcks.into()).await.map_err(|e| {
+                                        error!("Error occurred while sending ack message to broadcast event channel: {:?}", e);
+                                        TheaterError::Other(format!("{:?}", e))
+                                    });
+                                }
+                            }
+                        }
+                    } else {
+                        error!(
+                            "Deserialization failed for ack_bytes for {:?}, {:?} pair",
+                            current_node_id, sender_id
+                        );
+                    }
+                }
+            },
             Event::HandleAllAcks => {
                 let result = self.dkg_engine.handle_ack_messages();
                 match result {
                     Ok(status) => {
-                        info!("DKG Handle All Acks status {:?}", status);
+                        let _ = self.broadcast_events_tx.send(Event::GenerateKeySet.into()).await.map_err(|e| {
+                            error!("Error occurred while sending ack message to broadcast event channel: {:?}", e);
+                            TheaterError::Other(format!("{:?}", e))
+                        });
                     },
                     Err(e) => {
                         error!("Error occured while handling all the acks {:?}", e);

--- a/crates/node/src/components/election_module.rs
+++ b/crates/node/src/components/election_module.rs
@@ -33,8 +33,8 @@ pub struct MinerElection;
 #[derive(Clone, Debug)]
 pub struct QuorumElection;
 
-pub struct ElectionModuleConfig<D: Database> {
-    pub db_read_handle: VrrbDbReadHandle<D>,
+pub struct ElectionModuleConfig {
+    pub db_read_handle: VrrbDbReadHandle,
     pub events_tx: EventPublisher,
     pub local_claim: Claim,
 }
@@ -46,26 +46,23 @@ pub struct ElectionResult {
     pub node_id: NodeId,
 }
 
-pub struct ElectionModule<E, T, D>
-where
-    E: ElectionType,
-    T: ElectionOutcome,
-    D: Database,
+pub struct ElectionModule<E, T>
+    where
+        E: ElectionType,
+        T: ElectionOutcome,
 {
     _election_type: E,
     status: ActorState,
     id: ActorId,
     _label: ActorLabel,
-    pub db_read_handle: VrrbDbReadHandle<D>,
+    pub db_read_handle: VrrbDbReadHandle,
     pub local_claim: Claim,
     pub outcome: Option<T>,
     pub events_tx: EventPublisher,
 }
 
-impl<D: Database> ElectionModule<MinerElection, MinerElectionResult, D> {
-    pub fn new(
-        config: ElectionModuleConfig<D>,
-    ) -> ElectionModule<MinerElection, MinerElectionResult, D> {
+impl ElectionModule<MinerElection, MinerElectionResult> {
+    pub fn new(config: ElectionModuleConfig) -> ElectionModule<MinerElection, MinerElectionResult> {
         ElectionModule {
             _election_type: MinerElection,
             status: ActorState::Stopped,
@@ -83,10 +80,10 @@ impl<D: Database> ElectionModule<MinerElection, MinerElectionResult, D> {
     }
 }
 
-impl<D: Database> ElectionModule<QuorumElection, QuorumElectionResult, D> {
+impl ElectionModule<QuorumElection, QuorumElectionResult> {
     pub fn new(
-        config: ElectionModuleConfig<D>,
-    ) -> ElectionModule<QuorumElection, QuorumElectionResult, D> {
+        config: ElectionModuleConfig,
+    ) -> ElectionModule<QuorumElection, QuorumElectionResult> {
         ElectionModule {
             _election_type: QuorumElection,
             status: ActorState::Stopped,
@@ -103,7 +100,6 @@ impl<D: Database> ElectionModule<QuorumElection, QuorumElectionResult, D> {
         String::from("Quorum Election Module")
     }
 }
-
 impl ElectionType for MinerElection {}
 impl ElectionType for QuorumElection {}
 
@@ -111,7 +107,7 @@ impl ElectionOutcome for MinerElectionResult {}
 impl ElectionOutcome for QuorumElectionResult {}
 
 #[async_trait]
-impl<D: Database> Handler<EventMessage> for ElectionModule<MinerElection, MinerElectionResult, D> {
+impl Handler<EventMessage> for ElectionModule<MinerElection, MinerElectionResult> {
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -160,9 +156,7 @@ impl<D: Database> Handler<EventMessage> for ElectionModule<MinerElection, MinerE
 }
 
 #[async_trait]
-impl<D: Database> Handler<EventMessage>
-    for ElectionModule<QuorumElection, QuorumElectionResult, D>
-{
+impl Handler<EventMessage> for ElectionModule<QuorumElection, QuorumElectionResult> {
     fn id(&self) -> ActorId {
         self.id.clone()
     }

--- a/crates/node/src/components/election_module.rs
+++ b/crates/node/src/components/election_module.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use block::header::BlockHeader;
 use ethereum_types::U256;
 use events::{Event, EventMessage, EventPublisher};
+use patriecia::Database;
 use primitives::NodeId;
 use quorum::{
     election::Election,
@@ -32,8 +33,8 @@ pub struct MinerElection;
 #[derive(Clone, Debug)]
 pub struct QuorumElection;
 
-pub struct ElectionModuleConfig {
-    pub db_read_handle: VrrbDbReadHandle,
+pub struct ElectionModuleConfig<D: Database> {
+    pub db_read_handle: VrrbDbReadHandle<D>,
     pub events_tx: EventPublisher,
     pub local_claim: Claim,
 }
@@ -45,23 +46,26 @@ pub struct ElectionResult {
     pub node_id: NodeId,
 }
 
-pub struct ElectionModule<E, T>
+pub struct ElectionModule<E, T, D>
 where
     E: ElectionType,
     T: ElectionOutcome,
+    D: Database,
 {
     _election_type: E,
     status: ActorState,
     id: ActorId,
     _label: ActorLabel,
-    pub db_read_handle: VrrbDbReadHandle,
+    pub db_read_handle: VrrbDbReadHandle<D>,
     pub local_claim: Claim,
     pub outcome: Option<T>,
     pub events_tx: EventPublisher,
 }
 
-impl ElectionModule<MinerElection, MinerElectionResult> {
-    pub fn new(config: ElectionModuleConfig) -> ElectionModule<MinerElection, MinerElectionResult> {
+impl<D: Database> ElectionModule<MinerElection, MinerElectionResult, D> {
+    pub fn new(
+        config: ElectionModuleConfig<D>,
+    ) -> ElectionModule<MinerElection, MinerElectionResult, D> {
         ElectionModule {
             _election_type: MinerElection,
             status: ActorState::Stopped,
@@ -79,10 +83,10 @@ impl ElectionModule<MinerElection, MinerElectionResult> {
     }
 }
 
-impl ElectionModule<QuorumElection, QuorumElectionResult> {
+impl<D: Database> ElectionModule<QuorumElection, QuorumElectionResult, D> {
     pub fn new(
-        config: ElectionModuleConfig,
-    ) -> ElectionModule<QuorumElection, QuorumElectionResult> {
+        config: ElectionModuleConfig<D>,
+    ) -> ElectionModule<QuorumElection, QuorumElectionResult, D> {
         ElectionModule {
             _election_type: QuorumElection,
             status: ActorState::Stopped,
@@ -107,7 +111,7 @@ impl ElectionOutcome for MinerElectionResult {}
 impl ElectionOutcome for QuorumElectionResult {}
 
 #[async_trait]
-impl Handler<EventMessage> for ElectionModule<MinerElection, MinerElectionResult> {
+impl<D: Database> Handler<EventMessage> for ElectionModule<MinerElection, MinerElectionResult, D> {
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -156,7 +160,9 @@ impl Handler<EventMessage> for ElectionModule<MinerElection, MinerElectionResult
 }
 
 #[async_trait]
-impl Handler<EventMessage> for ElectionModule<QuorumElection, QuorumElectionResult> {
+impl<D: Database> Handler<EventMessage>
+    for ElectionModule<QuorumElection, QuorumElectionResult, D>
+{
     fn id(&self) -> ActorId {
         self.id.clone()
     }

--- a/crates/node/src/components/farmer_module.rs
+++ b/crates/node/src/components/farmer_module.rs
@@ -365,7 +365,7 @@ mod tests {
         let db = VrrbDb::new(db_config);
         let vrrbdb_read_handle = db.read_handle();
 
-        let mut job_scheduler = JobSchedulerController::<RocksDbAdapter>::new(
+        let mut job_scheduler = JobSchedulerController::new(
             vec![0],
             events_tx,
             sync_jobs_receiver,

--- a/crates/node/src/components/farmer_module.rs
+++ b/crates/node/src/components/farmer_module.rs
@@ -291,7 +291,7 @@ mod tests {
     use primitives::Address;
     use secp256k1::Message;
     use signer::signer::SignatureProvider;
-    use storage::vrrbdb::{VrrbDb, VrrbDbConfig};
+    use storage::vrrbdb::{RocksDbAdapter, VrrbDb, VrrbDbConfig};
     use theater::{Actor, ActorImpl, ActorState};
     use validator::validator_core_manager::ValidatorCoreManager;
     use vrrb_core::{
@@ -365,7 +365,7 @@ mod tests {
         let db = VrrbDb::new(db_config);
         let vrrbdb_read_handle = db.read_handle();
 
-        let mut job_scheduler = JobSchedulerController::new(
+        let mut job_scheduler = JobSchedulerController::<RocksDbAdapter>::new(
             vec![0],
             events_tx,
             sync_jobs_receiver,

--- a/crates/node/src/components/harvester_module.rs
+++ b/crates/node/src/components/harvester_module.rs
@@ -110,14 +110,13 @@ pub const BLOCK_CERTIFICATES_CACHE_LIMIT: usize = 5;
 ///   executed by the Scheduler.
 /// * `async_jobs_sender`: A Sender object used to send asynchronous jobs to be
 ///   executed by the Scheduler.
-
-pub struct HarvesterModule<D: Database> {
+pub struct HarvesterModule {
     pub quorum_certified_txns: Vec<QuorumCertifiedTxn>,
     pub certified_txns_filter: Bloom,
     pub votes_pool: DashMap<(TransactionDigest, String), Vec<Vote>>,
     pub group_public_key: GroupPublicKey,
     pub sig_provider: Option<SignatureProvider>,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
     pub convergence_block_certificates:
         Cache<BlockHash, HashSet<(NodeIdx, PublicKeyShare, RawSignature)>>,
     pub harvester_id: NodeIdx,
@@ -133,7 +132,7 @@ pub struct HarvesterModule<D: Database> {
     pub keypair: KeyPair,
 }
 
-impl<D: Database> HarvesterModule<D> {
+impl HarvesterModule {
     pub fn new(
         certified_txns_filter: Bloom,
         sig_provider: Option<SignatureProvider>,
@@ -144,7 +143,7 @@ impl<D: Database> HarvesterModule<D> {
         dag: Arc<RwLock<BullDag<Block, String>>>,
         sync_jobs_sender: Sender<Job>,
         async_jobs_sender: Sender<Job>,
-        vrrbdb_read_handle: VrrbDbReadHandle<D>,
+        vrrbdb_read_handle: VrrbDbReadHandle,
         keypair: KeyPair,
         harvester_id: NodeIdx,
     ) -> Self {
@@ -223,7 +222,7 @@ impl<D: Database> HarvesterModule<D> {
 }
 
 #[async_trait]
-impl<D: Database> Handler<EventMessage> for HarvesterModule<D> {
+impl Handler<EventMessage> for HarvesterModule {
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -634,7 +633,7 @@ mod tests {
 
         let vrrbdb_read_handle = db.read_handle();
 
-        let harvester_swarm_module = HarvesterModule::<RocksDbAdapter>::new(
+        let harvester_swarm_module = HarvesterModule::new(
             Bloom::new(10000),
             None,
             vec![],

--- a/crates/node/src/components/harvester_module.rs
+++ b/crates/node/src/components/harvester_module.rs
@@ -10,12 +10,9 @@ use crossbeam_channel::Sender;
 use dashmap::DashMap;
 use events::{Event, EventMessage, EventPublisher, JobResult, Vote};
 use hbbft::crypto::{PublicKeyShare, SignatureShare};
+use patriecia::Database;
 use primitives::{
-    GroupPublicKey,
-    HarvesterQuorumThreshold,
-    NodeIdx,
-    QuorumThreshold,
-    RawSignature,
+    GroupPublicKey, HarvesterQuorumThreshold, NodeIdx, QuorumThreshold, RawSignature,
 };
 use ritelinked::LinkedHashMap;
 use signer::signer::{SignatureProvider, Signer};
@@ -110,13 +107,13 @@ pub const BLOCK_CERTIFICATES_CACHE_LIMIT: usize = 5;
 /// * `async_jobs_sender`: A Sender object used to send asynchronous jobs to be
 ///   executed by the Scheduler.
 
-pub struct HarvesterModule {
+pub struct HarvesterModule<D: Database> {
     pub quorum_certified_txns: Vec<QuorumCertifiedTxn>,
     pub certified_txns_filter: Bloom,
     pub votes_pool: DashMap<(TransactionDigest, String), Vec<Vote>>,
     pub group_public_key: GroupPublicKey,
     pub sig_provider: Option<SignatureProvider>,
-    pub vrrbdb_read_handle: VrrbDbReadHandle,
+    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
     pub convergence_block_certificates:
         Cache<BlockHash, HashSet<(NodeIdx, PublicKeyShare, RawSignature)>>,
     pub harvester_id: NodeIdx,
@@ -132,7 +129,7 @@ pub struct HarvesterModule {
     pub keypair: KeyPair,
 }
 
-impl HarvesterModule {
+impl<D: Database> HarvesterModule<D> {
     pub fn new(
         certified_txns_filter: Bloom,
         sig_provider: Option<SignatureProvider>,
@@ -143,7 +140,7 @@ impl HarvesterModule {
         dag: Arc<RwLock<BullDag<Block, String>>>,
         sync_jobs_sender: Sender<Job>,
         async_jobs_sender: Sender<Job>,
-        vrrbdb_read_handle: VrrbDbReadHandle,
+        vrrbdb_read_handle: VrrbDbReadHandle<D>,
         keypair: KeyPair,
         harvester_id: NodeIdx,
     ) -> Self {
@@ -222,7 +219,7 @@ impl HarvesterModule {
 }
 
 #[async_trait]
-impl Handler<EventMessage> for HarvesterModule {
+impl<D: Database> Handler<EventMessage> for HarvesterModule<D> {
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -603,7 +600,7 @@ mod tests {
     use events::{Event, EventMessage, JobResult, DEFAULT_BUFFER};
     use lazy_static::lazy_static;
     use primitives::Address;
-    use storage::vrrbdb::{VrrbDb, VrrbDbConfig};
+    use storage::vrrbdb::{RocksDbAdapter, VrrbDb, VrrbDbConfig};
     use theater::{Actor, ActorImpl, ActorState};
     use vrrb_core::{account::Account, bloom::Bloom, keypair::Keypair};
 
@@ -633,7 +630,7 @@ mod tests {
 
         let vrrbdb_read_handle = db.read_handle();
 
-        let harvester_swarm_module = HarvesterModule::new(
+        let harvester_swarm_module = HarvesterModule::<RocksDbAdapter>::new(
             Bloom::new(10000),
             None,
             vec![],

--- a/crates/node/src/components/harvester_module.rs
+++ b/crates/node/src/components/harvester_module.rs
@@ -12,7 +12,11 @@ use events::{Event, EventMessage, EventPublisher, JobResult, Vote};
 use hbbft::crypto::{PublicKeyShare, SignatureShare};
 use patriecia::Database;
 use primitives::{
-    GroupPublicKey, HarvesterQuorumThreshold, NodeIdx, QuorumThreshold, RawSignature,
+    GroupPublicKey,
+    HarvesterQuorumThreshold,
+    NodeIdx,
+    QuorumThreshold,
+    RawSignature,
 };
 use ritelinked::LinkedHashMap;
 use signer::signer::{SignatureProvider, Signer};

--- a/crates/node/src/components/mining_module.rs
+++ b/crates/node/src/components/mining_module.rs
@@ -5,31 +5,32 @@ use block::ProposalBlock;
 use events::{Event, EventMessage, EventPublisher};
 use mempool::MempoolReadHandleFactory;
 use miner::{conflict_resolver::Resolver, Miner};
+use patriecia::Database;
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler};
 use vrrb_core::txn::Txn;
 
-pub struct MiningModule {
+pub struct MiningModule<D: Database> {
     status: ActorState,
     label: ActorLabel,
     id: ActorId,
     events_tx: EventPublisher,
     miner: Miner,
-    _vrrbdb_read_handle: VrrbDbReadHandle,
+    _vrrbdb_read_handle: VrrbDbReadHandle<D>,
     _mempool_read_handle_factory: MempoolReadHandleFactory,
 }
 
 #[derive(Debug, Clone)]
-pub struct MiningModuleConfig {
+pub struct MiningModuleConfig<D: Database> {
     pub events_tx: EventPublisher,
     pub miner: Miner,
-    pub vrrbdb_read_handle: VrrbDbReadHandle,
+    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
 }
 
-impl MiningModule {
-    pub fn new(cfg: MiningModuleConfig) -> Self {
+impl<D: Database> MiningModule<D> {
+    pub fn new(cfg: MiningModuleConfig<D>) -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             label: String::from("Miner"),
@@ -41,7 +42,7 @@ impl MiningModule {
         }
     }
 }
-impl MiningModule {
+impl<D: Database> MiningModule<D> {
     fn _take_snapshot_until_cutoff(&self, cutoff_idx: usize) -> Vec<Txn> {
         let mut handle = self._mempool_read_handle_factory.handle();
 
@@ -59,7 +60,7 @@ impl MiningModule {
 }
 
 #[async_trait]
-impl Handler<EventMessage> for MiningModule {
+impl<D: Database> Handler<EventMessage> for MiningModule<D> {
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -145,4 +146,4 @@ impl Handler<EventMessage> for MiningModule {
 }
 
 // TODO: figure out how to avoid this
-unsafe impl Send for MiningModule {}
+unsafe impl<D: Database> Send for MiningModule<D> {}

--- a/crates/node/src/components/mining_module.rs
+++ b/crates/node/src/components/mining_module.rs
@@ -11,26 +11,26 @@ use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler};
 use vrrb_core::txn::Txn;
 
-pub struct MiningModule<D: Database> {
+pub struct MiningModule {
     status: ActorState,
     label: ActorLabel,
     id: ActorId,
     events_tx: EventPublisher,
     miner: Miner,
-    _vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    _vrrbdb_read_handle: VrrbDbReadHandle,
     _mempool_read_handle_factory: MempoolReadHandleFactory,
 }
 
 #[derive(Debug, Clone)]
-pub struct MiningModuleConfig<D: Database> {
+pub struct MiningModuleConfig {
     pub events_tx: EventPublisher,
     pub miner: Miner,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
 }
 
-impl<D: Database> MiningModule<D> {
-    pub fn new(cfg: MiningModuleConfig<D>) -> Self {
+impl MiningModule {
+    pub fn new(cfg: MiningModuleConfig) -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             label: String::from("Miner"),
@@ -42,7 +42,7 @@ impl<D: Database> MiningModule<D> {
         }
     }
 }
-impl<D: Database> MiningModule<D> {
+impl MiningModule {
     fn _take_snapshot_until_cutoff(&self, cutoff_idx: usize) -> Vec<Txn> {
         let mut handle = self._mempool_read_handle_factory.handle();
 
@@ -60,7 +60,7 @@ impl<D: Database> MiningModule<D> {
 }
 
 #[async_trait]
-impl<D: Database> Handler<EventMessage> for MiningModule<D> {
+impl Handler<EventMessage> for MiningModule {
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -146,4 +146,4 @@ impl<D: Database> Handler<EventMessage> for MiningModule<D> {
 }
 
 // TODO: figure out how to avoid this
-unsafe impl<D: Database> Send for MiningModule<D> {}
+unsafe impl Send for MiningModule {}

--- a/crates/node/src/components/network/module.rs
+++ b/crates/node/src/components/network/module.rs
@@ -280,14 +280,14 @@ impl NetworkModule {
 }
 
 #[derive(Debug)]
-pub struct NetworkModuleComponentConfig<D: Database> {
+pub struct NetworkModuleComponentConfig {
     pub config: NodeConfig,
 
     // TODO: remove this attribute
     pub node_id: NodeId,
     pub events_tx: EventPublisher,
     pub network_events_rx: EventSubscriber,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
 }
 
 #[derive(Debug, Clone)]
@@ -299,12 +299,11 @@ pub struct NetworkModuleComponentResolvedData {
 }
 
 #[async_trait]
-impl<D: Database + 'static>
-    RuntimeComponent<NetworkModuleComponentConfig<D>, NetworkModuleComponentResolvedData>
-    for NetworkModule
+impl RuntimeComponent<NetworkModuleComponentConfig, NetworkModuleComponentResolvedData>
+for NetworkModule
 {
     async fn setup(
-        args: NetworkModuleComponentConfig<D>,
+        args: NetworkModuleComponentConfig,
     ) -> crate::Result<RuntimeComponentHandle<NetworkModuleComponentResolvedData>> {
         let mut network_events_rx = args.network_events_rx;
 

--- a/crates/node/src/components/network/module.rs
+++ b/crates/node/src/components/network/module.rs
@@ -7,6 +7,7 @@ use dyswarm::{
 };
 use events::{Event, EventMessage, EventPublisher, EventSubscriber};
 use kademlia_dht::{Key, Node as KademliaNode, NodeData, NodeType as KNodeType};
+use patriecia::Database;
 use primitives::{KademliaPeerId, NodeId, NodeType};
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::info;
@@ -281,14 +282,14 @@ impl NetworkModule {
 }
 
 #[derive(Debug)]
-pub struct NetworkModuleComponentConfig {
+pub struct NetworkModuleComponentConfig<D: Database> {
     pub config: NodeConfig,
 
     // TODO: remove this attribute
     pub node_id: NodeId,
     pub events_tx: EventPublisher,
     pub network_events_rx: EventSubscriber,
-    pub vrrbdb_read_handle: VrrbDbReadHandle,
+    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
 }
 
 #[derive(Debug, Clone)]
@@ -300,11 +301,12 @@ pub struct NetworkModuleComponentResolvedData {
 }
 
 #[async_trait]
-impl RuntimeComponent<NetworkModuleComponentConfig, NetworkModuleComponentResolvedData>
+impl<D: Database + 'static>
+    RuntimeComponent<NetworkModuleComponentConfig<D>, NetworkModuleComponentResolvedData>
     for NetworkModule
 {
     async fn setup(
-        args: NetworkModuleComponentConfig,
+        args: NetworkModuleComponentConfig<D>,
     ) -> crate::Result<RuntimeComponentHandle<NetworkModuleComponentResolvedData>> {
         let mut network_events_rx = args.network_events_rx;
 

--- a/crates/node/src/components/network/network_event.rs
+++ b/crates/node/src/components/network/network_event.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use events::Vote;
 use mempool::TxnRecord;
-use primitives::{FarmerQuorumThreshold, KademliaPeerId, NodeId, NodeType, PeerId};
+use primitives::{FarmerQuorumThreshold, KademliaPeerId, NodeId, NodeType, PartCommitmentBytes, PeerId, SenderId};
 use serde::{Deserialize, Serialize};
 use vrrb_core::claim::Claim;
 
@@ -106,6 +106,8 @@ pub enum NetworkEvent {
     ForwardedTxn(TxnRecord),
 
     Ping(NodeId),
+
+    PartMessage(SenderId,PartCommitmentBytes),
 
     #[default]
     Empty,

--- a/crates/node/src/components/network/network_event.rs
+++ b/crates/node/src/components/network/network_event.rs
@@ -2,7 +2,17 @@ use std::net::SocketAddr;
 
 use events::Vote;
 use mempool::TxnRecord;
-use primitives::{FarmerQuorumThreshold, KademliaPeerId, NodeId, NodeType, PartCommitmentBytes, PeerId, SenderId};
+use primitives::{
+    AckBytes,
+    CurrentNodeId,
+    FarmerQuorumThreshold,
+    KademliaPeerId,
+    NodeId,
+    NodeType,
+    PartCommitmentBytes,
+    PeerId,
+    SenderId,
+};
 use serde::{Deserialize, Serialize};
 use vrrb_core::claim::Claim;
 
@@ -107,7 +117,9 @@ pub enum NetworkEvent {
 
     Ping(NodeId),
 
-    PartMessage(SenderId,PartCommitmentBytes),
+    PartMessage(SenderId, PartCommitmentBytes),
+
+    Ack(CurrentNodeId, SenderId, AckBytes),
 
     #[default]
     Empty,

--- a/crates/node/src/components/network/network_handler.rs
+++ b/crates/node/src/components/network/network_handler.rs
@@ -59,7 +59,18 @@ impl dyswarm::server::Handler<NetworkEvent> for DyswarmHandler {
                     );
                 }
             },
-
+            NetworkEvent::Ack(current_node_id, sender_id, ack_bytes) => {
+                if let Err(err) = self
+                    .events_tx
+                    .send(Event::Ack(current_node_id, sender_id, ack_bytes).into())
+                    .await
+                {
+                    error!(
+                        "Error occurred while sending event to dkg module: {:?}",
+                        err
+                    );
+                }
+            },
             _ => {},
         }
 

--- a/crates/node/src/components/network/network_handler.rs
+++ b/crates/node/src/components/network/network_handler.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use dyswarm::types::Message as DyswarmMessage;
 use events::{Event, EventPublisher};
 use primitives::NodeId;
+use tracing::error;
 
 use crate::{components::network::NetworkEvent, NodeError};
 
@@ -45,6 +46,18 @@ impl dyswarm::server::Handler<NetworkEvent> for DyswarmHandler {
                     .send(evt.into())
                     .await
                     .map_err(NodeError::from)?;
+            },
+            NetworkEvent::PartMessage(sender_id, part_committment) => {
+                if let Err(err) = self
+                    .events_tx
+                    .send(Event::PartMessage(sender_id, part_committment).into())
+                    .await
+                {
+                    error!(
+                        "Error occurred while sending event to dkg module: {:?}",
+                        err
+                    );
+                }
             },
 
             _ => {},

--- a/crates/node/src/components/scheduler.rs
+++ b/crates/node/src/components/scheduler.rs
@@ -48,13 +48,13 @@ use crate::NodeError;
 /// JobSchedulerController to retrieve data from the database as needed for its
 /// job scheduling tasks. The specific implementation and functionality of
 /// VrrbDbReadHandle would depend on
-pub struct JobSchedulerController<D: Database> {
+pub struct JobSchedulerController{
     pub job_scheduler: JobScheduler,
     events_tx: EventPublisher,
     sync_jobs_receiver: Receiver<Job>,
     _async_jobs_receiver: Receiver<Job>,
     pub validator_core_manager: ValidatorCoreManager,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
 }
 
 pub enum Job {
@@ -82,14 +82,14 @@ pub enum Job {
     SignConvergenceBlock(SignatureProvider, ConvergenceBlock),
 }
 
-impl<D: Database> JobSchedulerController<D> {
+impl JobSchedulerController {
     pub fn new(
         peer_id: PeerID,
         events_tx: EventPublisher,
         sync_jobs_receiver: Receiver<Job>,
         async_jobs_receiver: Receiver<Job>,
         validator_core_manager: ValidatorCoreManager,
-        vrrbdb_read_handle: VrrbDbReadHandle<D>,
+        vrrbdb_read_handle: VrrbDbReadHandle,
     ) -> Self {
         Self {
             job_scheduler: JobScheduler::new(peer_id),

--- a/crates/node/src/components/scheduler.rs
+++ b/crates/node/src/components/scheduler.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::Receiver;
 use events::{Event, EventPublisher, JobResult, Vote};
 use job_scheduler::JobScheduler;
 use mempool::TxnRecord;
+use patriecia::Database;
 use primitives::{base::PeerId as PeerID, ByteVec, FarmerQuorumThreshold, NodeIdx};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use signer::signer::{SignatureProvider, Signer};
@@ -47,13 +48,13 @@ use crate::NodeError;
 /// JobSchedulerController to retrieve data from the database as needed for its
 /// job scheduling tasks. The specific implementation and functionality of
 /// VrrbDbReadHandle would depend on
-pub struct JobSchedulerController {
+pub struct JobSchedulerController<D: Database> {
     pub job_scheduler: JobScheduler,
     events_tx: EventPublisher,
     sync_jobs_receiver: Receiver<Job>,
     _async_jobs_receiver: Receiver<Job>,
     pub validator_core_manager: ValidatorCoreManager,
-    pub vrrbdb_read_handle: VrrbDbReadHandle,
+    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
 }
 
 pub enum Job {
@@ -81,14 +82,14 @@ pub enum Job {
     SignConvergenceBlock(SignatureProvider, ConvergenceBlock),
 }
 
-impl JobSchedulerController {
+impl<D: Database> JobSchedulerController<D> {
     pub fn new(
         peer_id: PeerID,
         events_tx: EventPublisher,
         sync_jobs_receiver: Receiver<Job>,
         async_jobs_receiver: Receiver<Job>,
         validator_core_manager: ValidatorCoreManager,
-        vrrbdb_read_handle: VrrbDbReadHandle,
+        vrrbdb_read_handle: VrrbDbReadHandle<D>,
     ) -> Self {
         Self {
             job_scheduler: JobScheduler::new(peer_id),

--- a/crates/node/src/components/state_module.rs
+++ b/crates/node/src/components/state_module.rs
@@ -262,8 +262,8 @@ impl FromTxn for HashSet<StateUpdate> {
 
 /// Provides a convenient configuration struct for buildin a
 /// StateModule
-pub struct StateModuleConfig<D: Database> {
-    pub db: VrrbDb<D>,
+pub struct StateModuleConfig {
+    pub db: VrrbDb,
     pub events_tx: EventPublisher,
     pub dag: Arc<RwLock<BullDag<Block, String>>>,
 }
@@ -273,8 +273,8 @@ pub struct StateModuleConfig<D: Database> {
 /// necessary to transition the network's global state from
 /// t to t+1.
 #[derive(Debug)]
-pub struct StateModule<D: Database> {
-    db: VrrbDb<D>,
+pub struct StateModule {
+    db: VrrbDb,
     status: ActorState,
     _label: ActorLabel,
     id: ActorId,
@@ -285,8 +285,8 @@ pub struct StateModule<D: Database> {
 /// StateModule manages all state persistence and updates within VrrbNodes
 /// it runs as an indepdendant module such that it can be enabled and disabled
 /// as necessary.
-impl<D: Database> StateModule<D> {
-    pub fn new(config: StateModuleConfig<D>) -> Self {
+impl StateModule {
+    pub fn new(config: StateModuleConfig) -> Self {
         Self {
             db: config.db,
             events_tx: config.events_tx,
@@ -298,7 +298,7 @@ impl<D: Database> StateModule<D> {
     }
 }
 
-impl<D: Database> StateModule<D> {
+impl StateModule {
     fn name(&self) -> String {
         String::from("State")
     }
@@ -314,7 +314,7 @@ impl<D: Database> StateModule<D> {
     /// Produces the read handle for the VrrbDb instance in this
     /// struct. VrrbDbReadHandle provides a ReadHandleFactory for
     /// each of the StateStore, TransactionStore and ClaimStore.
-    pub fn read_handle(&self) -> VrrbDbReadHandle<D> {
+    pub fn read_handle(&self) -> VrrbDbReadHandle {
         self.db.read_handle()
     }
 
@@ -444,7 +444,7 @@ impl<D: Database> StateModule<D> {
 
     /// Returns a read handle for the StateStore to be able to read
     /// values from it.
-    fn _get_state_store_handle(&self) -> StateStoreReadHandle<D> {
+    fn _get_state_store_handle(&self) -> StateStoreReadHandle {
         self.db.state_store_factory().handle()
     }
 
@@ -552,7 +552,7 @@ fn consolidate_update_args(updates: HashSet<UpdateArgs>) -> HashMap<Address, Upd
 }
 
 #[async_trait]
-impl<D: Database> Handler<EventMessage> for StateModule<D> {
+impl Handler<EventMessage> for StateModule {
     fn id(&self) -> ActorId {
         self.id.clone()
     }
@@ -640,18 +640,17 @@ pub struct StateModuleComponentConfig {
 }
 
 #[async_trait]
-impl<D: Database + 'static> RuntimeComponent<StateModuleComponentConfig, VrrbDbReadHandle<D>>
-    for StateModule<D>
-{
+impl RuntimeComponent<StateModuleComponentConfig, VrrbDbReadHandle> for StateModule {
+
     async fn setup(
         args: StateModuleComponentConfig,
-    ) -> crate::Result<RuntimeComponentHandle<VrrbDbReadHandle<D>>> {
+    ) -> crate::Result<RuntimeComponentHandle<VrrbDbReadHandle>> {
         let dag = args.dag;
         let events_tx = args.events_tx;
         let mut state_events_rx = args.state_events_rx;
         let node_config = args.node_config;
 
-        let mut vrrbdb_config: VrrbDbConfig<D> = VrrbDbConfig::default();
+        let mut vrrbdb_config: VrrbDbConfig = VrrbDbConfig::default();
 
         if node_config.db_path() != &vrrbdb_config.path {
             vrrbdb_config.with_path(node_config.db_path().to_path_buf());
@@ -716,7 +715,7 @@ mod tests {
 
         let (events_tx, _) = tokio::sync::mpsc::channel(DEFAULT_BUFFER);
 
-        let db_config: VrrbDbConfig<MemoryDB> = VrrbDbConfig::default();
+        let db_config: VrrbDbConfig = VrrbDbConfig::default();
 
         let dag: Arc<RwLock<BullDag<Block, String>>> = Arc::new(RwLock::new(BullDag::new()));
 
@@ -750,7 +749,7 @@ mod tests {
         let _temp_dir_path = env::temp_dir().join("state.json");
 
         let (events_tx, _) = tokio::sync::mpsc::channel(DEFAULT_BUFFER);
-        let db_config: VrrbDbConfig<MemoryDB> = VrrbDbConfig::default();
+        let db_config: VrrbDbConfig = VrrbDbConfig::default();
 
         let db = VrrbDb::new(db_config);
 
@@ -788,7 +787,7 @@ mod tests {
 
         let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(DEFAULT_BUFFER);
 
-        let db_config: VrrbDbConfig<MemoryDB> = VrrbDbConfig::default();
+        let db_config: VrrbDbConfig = VrrbDbConfig::default();
 
         let db = VrrbDb::new(db_config);
 

--- a/crates/node/src/components/state_module.rs
+++ b/crates/node/src/components/state_module.rs
@@ -703,7 +703,10 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        produce_accounts, produce_convergence_block, produce_genesis_block, produce_proposal_blocks,
+        produce_accounts,
+        produce_convergence_block,
+        produce_genesis_block,
+        produce_proposal_blocks,
     };
 
     #[tokio::test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -3,10 +3,7 @@ use std::net::SocketAddr;
 use events::{
     Event,
     Event::{FetchPeers, PullCandidatesForElection},
-    EventMessage,
-    EventPublisher,
-    EventRouter,
-    Topic,
+    EventMessage, EventPublisher, EventRouter, Topic,
 };
 use primitives::{KademliaPeerId, NodeType};
 use telemetry::info;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -3,7 +3,10 @@ use std::net::SocketAddr;
 use events::{
     Event,
     Event::{FetchPeers, PullCandidatesForElection},
-    EventMessage, EventPublisher, EventRouter, Topic,
+    EventMessage,
+    EventPublisher,
+    EventRouter,
+    Topic,
 };
 use primitives::{KademliaPeerId, NodeType};
 use telemetry::info;

--- a/crates/node/src/runtime.rs
+++ b/crates/node/src/runtime.rs
@@ -9,7 +9,12 @@ use block::Block;
 use bulldag::graph::BullDag;
 use crossbeam_channel::Sender;
 use events::{
-    Event, Event::BroadcastClaim, EventMessage, EventPublisher, EventRouter, EventSubscriber,
+    Event,
+    Event::BroadcastClaim,
+    EventMessage,
+    EventPublisher,
+    EventRouter,
+    EventSubscriber,
     DEFAULT_BUFFER,
 };
 use mempool::MempoolReadHandleFactory;
@@ -30,8 +35,12 @@ use crate::{
         dag_module::DagModule,
         dkg_module::{self, DkgModuleConfig},
         election_module::{
-            ElectionModule, ElectionModuleConfig, MinerElection, MinerElectionResult,
-            QuorumElection, QuorumElectionResult,
+            ElectionModule,
+            ElectionModuleConfig,
+            MinerElection,
+            MinerElectionResult,
+            QuorumElection,
+            QuorumElectionResult,
         },
         farmer_module::{self, PULL_TXN_BATCH_SIZE},
         harvester_module,
@@ -43,7 +52,8 @@ use crate::{
         state_module::{StateModule, StateModuleComponentConfig},
     },
     result::{NodeError, Result},
-    RuntimeComponent, RuntimeComponents,
+    RuntimeComponent,
+    RuntimeComponents,
 };
 
 pub async fn setup_runtime_components(

--- a/crates/node/src/runtime.rs
+++ b/crates/node/src/runtime.rs
@@ -9,12 +9,7 @@ use block::Block;
 use bulldag::graph::BullDag;
 use crossbeam_channel::Sender;
 use events::{
-    Event,
-    Event::BroadcastClaim,
-    EventMessage,
-    EventPublisher,
-    EventRouter,
-    EventSubscriber,
+    Event, Event::BroadcastClaim, EventMessage, EventPublisher, EventRouter, EventSubscriber,
     DEFAULT_BUFFER,
 };
 use mempool::MempoolReadHandleFactory;
@@ -35,12 +30,8 @@ use crate::{
         dag_module::DagModule,
         dkg_module::{self, DkgModuleConfig},
         election_module::{
-            ElectionModule,
-            ElectionModuleConfig,
-            MinerElection,
-            MinerElectionResult,
-            QuorumElection,
-            QuorumElectionResult,
+            ElectionModule, ElectionModuleConfig, MinerElection, MinerElectionResult,
+            QuorumElection, QuorumElectionResult,
         },
         farmer_module::{self, PULL_TXN_BATCH_SIZE},
         harvester_module,
@@ -52,8 +43,7 @@ use crate::{
         state_module::{StateModule, StateModuleComponentConfig},
     },
     result::{NodeError, Result},
-    RuntimeComponent,
-    RuntimeComponents,
+    RuntimeComponent, RuntimeComponents,
 };
 
 pub async fn setup_runtime_components(
@@ -144,6 +134,7 @@ pub async fn setup_runtime_components(
     let signature = Claim::signature_for_valid_claim(
         public_key,
         config.public_ip_address,
+        config.raptorq_gossip_address.port(),
         config
             .keypair
             .get_miner_secret_key()
@@ -155,6 +146,7 @@ pub async fn setup_runtime_components(
         public_key,
         Address::new(public_key),
         config.public_ip_address,
+        config.raptorq_gossip_address.port(),
         signature,
     )
     .map_err(NodeError::from)?;
@@ -318,6 +310,7 @@ fn setup_mining_module<D: Database + 'static>(
         secret_key: *miner_secret_key,
         public_key: *miner_public_key,
         ip_address: config.public_ip_address,
+        raptor_port: config.raptorq_gossip_address.port(),
         dag,
     };
 

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -105,11 +105,12 @@ fn produce_random_claims(n: usize) -> HashSet<Claim> {
             let signature = Claim::signature_for_valid_claim(
                 kp.miner_kp.1,
                 ip_address,
+                1023,
                 kp.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
 
-            Claim::new(kp.miner_kp.1, address, ip_address, signature).unwrap()
+            Claim::new(kp.miner_kp.1, address, ip_address, 1023, signature).unwrap()
         })
         .collect()
 }
@@ -160,11 +161,12 @@ pub fn produce_proposal_blocks(
             let signature = Claim::signature_for_valid_claim(
                 kp.miner_kp.1,
                 ip_address,
+                1023,
                 kp.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
 
-            let from = Claim::new(kp.miner_kp.1, address, ip_address, signature).unwrap();
+            let from = Claim::new(kp.miner_kp.1, address, ip_address, 1023, signature).unwrap();
             let txs = produce_random_txs(&accounts);
             let claims = produce_random_claims(ntx);
 
@@ -302,8 +304,8 @@ pub(crate) fn create_dag_module() -> DagModule {
     let addr = create_address(&pk);
     let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
     let signature =
-        Claim::signature_for_valid_claim(pk, ip_address, sk.secret_bytes().to_vec()).unwrap();
-    let claim = create_claim(&pk, &addr, ip_address, signature);
+        Claim::signature_for_valid_claim(pk, ip_address, 1023, sk.secret_bytes().to_vec()).unwrap();
+    let claim = create_claim(&pk, &addr, ip_address, 1023, signature);
     let (events_tx, _) = tokio::sync::mpsc::channel(events::DEFAULT_BUFFER);
 
     DagModule::new(miner.dag, events_tx, claim)

--- a/crates/primitives/src/base.rs
+++ b/crates/primitives/src/base.rs
@@ -62,6 +62,8 @@ pub type QuorumPublicKey = ByteVec;
 pub type PKShareBytes = ByteVec;
 pub type PayloadBytes = ByteVec;
 pub type PartCommitmentBytes = ByteVec;
+pub type AckBytes = ByteVec;
 pub type SenderId = u16;
+pub type CurrentNodeId = u16;
 
 pub type LastBlockHeight = u128;

--- a/crates/primitives/src/base.rs
+++ b/crates/primitives/src/base.rs
@@ -61,4 +61,7 @@ pub type NodeTypeBytes = ByteVec;
 pub type QuorumPublicKey = ByteVec;
 pub type PKShareBytes = ByteVec;
 pub type PayloadBytes = ByteVec;
+pub type PartCommitmentBytes = ByteVec;
+pub type SenderId = u16;
+
 pub type LastBlockHeight = u128;

--- a/crates/primitives/src/base.rs
+++ b/crates/primitives/src/base.rs
@@ -24,6 +24,7 @@ pub const DEFAULT_CONNECTION_TIMEOUT_IN_SECS: u64 = 2;
 pub const RAPTOR_DECODER_CACHE_LIMIT: usize = 10000;
 pub const RAPTOR_DECODER_CACHE_TTL_IN_SECS: u64 = 1800000;
 
+pub type RaptorUdpPort = u16;
 pub type ByteVec = Vec<u8>;
 pub type ByteSlice<'a> = &'a [u8];
 pub type PayloadHash = ByteVec;

--- a/crates/storage/vrrbdb/Cargo.toml
+++ b/crates/storage/vrrbdb/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { workspace = true }
 serial_test = { workspace = true }
 telemetry = { workspace = true }
 ethereum-types = { workspace = true }
+rand = "0.8.5"
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
+++ b/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
@@ -1,18 +1,20 @@
 use std::collections::HashMap;
 
 use lr_trie::{InnerTrieWrapper, ReadHandleFactory};
-use patriecia::{inner::InnerTrie, Database};
+use patriecia::inner::InnerTrie;
 use primitives::NodeId;
 use storage_utils::{Result, StorageError};
 use vrrb_core::claim::Claim;
 
+use crate::RocksDbAdapter;
+
 #[derive(Debug, Clone)]
-pub struct ClaimStoreReadHandle<D: Database> {
-    inner: InnerTrieWrapper<D>,
+pub struct ClaimStoreReadHandle {
+    inner: InnerTrieWrapper<RocksDbAdapter>,
 }
 
-impl<D: Database> ClaimStoreReadHandle<D> {
-    pub fn new(inner: InnerTrieWrapper<D>) -> Self {
+impl ClaimStoreReadHandle {
+    pub fn new(inner: InnerTrieWrapper<RocksDbAdapter>) -> Self {
         Self { inner }
     }
 
@@ -66,16 +68,16 @@ impl<D: Database> ClaimStoreReadHandle<D> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ClaimStoreReadHandleFactory<D: Database> {
-    inner: ReadHandleFactory<InnerTrie<D>>,
+pub struct ClaimStoreReadHandleFactory {
+    inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>,
 }
 
-impl<D: Database> ClaimStoreReadHandleFactory<D> {
-    pub fn new(inner: ReadHandleFactory<InnerTrie<D>>) -> Self {
+impl ClaimStoreReadHandleFactory {
+    pub fn new(inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>) -> Self {
         Self { inner }
     }
 
-    pub fn handle(&self) -> ClaimStoreReadHandle<D> {
+    pub fn handle(&self) -> ClaimStoreReadHandle {
         let handle = self
             .inner
             .handle()

--- a/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
+++ b/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
@@ -1,20 +1,18 @@
 use std::collections::HashMap;
 
 use lr_trie::{InnerTrieWrapper, ReadHandleFactory};
-use patriecia::inner::InnerTrie;
+use patriecia::{inner::InnerTrie, Database};
 use primitives::NodeId;
 use storage_utils::{Result, StorageError};
 use vrrb_core::claim::Claim;
 
-use crate::RocksDbAdapter;
-
 #[derive(Debug, Clone)]
-pub struct ClaimStoreReadHandle {
-    inner: InnerTrieWrapper<RocksDbAdapter>,
+pub struct ClaimStoreReadHandle<D: Database> {
+    inner: InnerTrieWrapper<D>,
 }
 
-impl ClaimStoreReadHandle {
-    pub fn new(inner: InnerTrieWrapper<RocksDbAdapter>) -> Self {
+impl<D: Database> ClaimStoreReadHandle<D> {
+    pub fn new(inner: InnerTrieWrapper<D>) -> Self {
         Self { inner }
     }
 
@@ -68,16 +66,16 @@ impl ClaimStoreReadHandle {
 }
 
 #[derive(Debug, Clone)]
-pub struct ClaimStoreReadHandleFactory {
-    inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>,
+pub struct ClaimStoreReadHandleFactory<D: Database> {
+    inner: ReadHandleFactory<InnerTrie<D>>,
 }
 
-impl ClaimStoreReadHandleFactory {
-    pub fn new(inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>) -> Self {
+impl<D: Database> ClaimStoreReadHandleFactory<D> {
+    pub fn new(inner: ReadHandleFactory<InnerTrie<D>>) -> Self {
         Self { inner }
     }
 
-    pub fn handle(&self) -> ClaimStoreReadHandle {
+    pub fn handle(&self) -> ClaimStoreReadHandle<D> {
         let handle = self
             .inner
             .handle()

--- a/crates/storage/vrrbdb/src/claim_store/mod.rs
+++ b/crates/storage/vrrbdb/src/claim_store/mod.rs
@@ -1,11 +1,10 @@
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 use ethereum_types::U256;
 use lr_trie::{LeftRightTrie, H256};
+use patriecia::Database;
 use storage_utils::{Result, StorageError};
 use vrrb_core::claim::Claim;
-
-use crate::RocksDbAdapter;
 
 mod claim_store_rh;
 pub use claim_store_rh::*;
@@ -13,39 +12,24 @@ pub use claim_store_rh::*;
 pub type Claims = Vec<Claim>;
 pub type FailedClaimUpdates = Vec<(U256, Claims, Result<()>)>;
 
-#[derive(Debug, Clone)]
-pub struct ClaimStore {
-    trie: LeftRightTrie<'static, U256, Claim, RocksDbAdapter>,
+#[derive(Debug, Clone, Default)]
+pub struct ClaimStore<D: Database> {
+    trie: LeftRightTrie<'static, U256, Claim, D>,
 }
 
-impl Default for ClaimStore {
-    fn default() -> Self {
-        let db_path = storage_utils::get_node_data_dir()
-            .unwrap_or_default()
-            .join("db")
-            .join("claim");
-
-        let db_adapter = RocksDbAdapter::new(db_path, "claim").unwrap_or_default();
-
-        let trie = LeftRightTrie::new(Arc::new(db_adapter));
-
-        Self { trie }
-    }
-}
-
-impl ClaimStore {
+impl<D: Database> ClaimStore<D> {
     /// Returns new, empty instance of ClaimDb
     pub fn new(path: &Path) -> Self {
         let path = path.join("claims");
         let db_adapter = RocksDbAdapter::new(path, "claim").unwrap_or_default();
-        let trie = LeftRightTrie::new(Arc::new(db_adapter));
+     let trie = LeftRightTrie::new(Arc::new(db_adapter));
 
         Self { trie }
     }
 
     /// Returns new ReadHandle to the VrrDb data. As long as the returned value
     /// lives, no write to the database will be committed.
-    pub fn read_handle(&self) -> ClaimStoreReadHandle {
+    pub fn read_handle(&self) -> ClaimStoreReadHandle<D> {
         let inner = self.trie.handle();
         ClaimStoreReadHandle::new(inner)
     }
@@ -122,7 +106,7 @@ impl ClaimStore {
 
     /// Retain returns new ClaimDb with which all Claims that fulfill `filter`
     /// cloned to it.
-    pub fn retain<F>(&self, _filter: F) -> ClaimStore
+    pub fn retain<F>(&self, _filter: F) -> ClaimStore<D>
     where
         F: FnMut(&Claim) -> bool,
     {
@@ -277,7 +261,7 @@ impl ClaimStore {
         self.trie.extend(claims)
     }
 
-    pub fn factory(&self) -> ClaimStoreReadHandleFactory {
+    pub fn factory(&self) -> ClaimStoreReadHandleFactory<D> {
         let inner = self.trie.factory();
 
         ClaimStoreReadHandleFactory::new(inner)

--- a/crates/storage/vrrbdb/src/rocksdb_adapter.rs
+++ b/crates/storage/vrrbdb/src/rocksdb_adapter.rs
@@ -1,9 +1,8 @@
 use patriecia::db::Database;
 use primitives::{get_vrrb_environment, Environment, DEFAULT_VRRB_DB_PATH};
-use rand::Rng;
 use rocksdb::{DB, DEFAULT_COLUMN_FAMILY_NAME};
 use storage_utils::{get_node_data_dir, StorageError};
-use telemetry::{error, info};
+use telemetry::error;
 
 #[derive(Debug)]
 pub struct RocksDbAdapter {
@@ -103,9 +102,6 @@ impl Default for RocksDbAdapter {
         options.set_error_if_exists(false);
         options.create_if_missing(true);
         options.create_missing_column_families(true);
-        let id = generate_random_id();
-        let path = create_unique_db_path(&id);
-        let cf = create_unique_cf(&id);
 
         // TODO: fix this unwrap
         let db = new_db_instance(
@@ -118,21 +114,8 @@ impl Default for RocksDbAdapter {
         Self {
             db,
             column: DEFAULT_COLUMN_FAMILY_NAME.to_string(),
-       }
+        }
     }
-}
-fn generate_random_id() -> String {
-    let mut rng = rand::thread_rng();
-
-    (0..5)
-        .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
-        .collect()
-}
-fn create_unique_db_path(id: &str) -> String {
-    format!("{}{}", DEFAULT_VRRB_DB_PATH, id)
-}
-fn create_unique_cf(id: &str) -> String {
-    format!("{}{}", DEFAULT_COLUMN_FAMILY_NAME, id)
 }
 
 impl Database for RocksDbAdapter {

--- a/crates/storage/vrrbdb/src/rocksdb_adapter.rs
+++ b/crates/storage/vrrbdb/src/rocksdb_adapter.rs
@@ -1,8 +1,9 @@
 use patriecia::db::Database;
 use primitives::{get_vrrb_environment, Environment, DEFAULT_VRRB_DB_PATH};
+use rand::Rng;
 use rocksdb::{DB, DEFAULT_COLUMN_FAMILY_NAME};
 use storage_utils::{get_node_data_dir, StorageError};
-use telemetry::error;
+use telemetry::{error, info};
 
 #[derive(Debug)]
 pub struct RocksDbAdapter {
@@ -102,6 +103,9 @@ impl Default for RocksDbAdapter {
         options.set_error_if_exists(false);
         options.create_if_missing(true);
         options.create_missing_column_families(true);
+        let id = generate_random_id();
+        let path = create_unique_db_path(&id);
+        let cf = create_unique_cf(&id);
 
         // TODO: fix this unwrap
         let db = new_db_instance(
@@ -114,8 +118,21 @@ impl Default for RocksDbAdapter {
         Self {
             db,
             column: DEFAULT_COLUMN_FAMILY_NAME.to_string(),
-        }
+       }
     }
+}
+fn generate_random_id() -> String {
+    let mut rng = rand::thread_rng();
+
+    (0..5)
+        .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
+        .collect()
+}
+fn create_unique_db_path(id: &str) -> String {
+    format!("{}{}", DEFAULT_VRRB_DB_PATH, id)
+}
+fn create_unique_cf(id: &str) -> String {
+    format!("{}{}", DEFAULT_COLUMN_FAMILY_NAME, id)
 }
 
 impl Database for RocksDbAdapter {

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -1,11 +1,10 @@
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use lr_trie::{LeftRightTrie, H256};
+use patriecia::Database;
 use primitives::Address;
 use storage_utils::{Result, StorageError};
 use vrrb_core::account::{Account, UpdateArgs};
-
-use crate::RocksDbAdapter;
 
 mod state_store_rh;
 pub use state_store_rh::*;
@@ -13,32 +12,15 @@ pub use state_store_rh::*;
 pub type Accounts = Vec<Account>;
 pub type FailedAccountUpdates = Vec<(Address, Vec<UpdateArgs>, Result<()>)>;
 
-#[derive(Debug, Clone)]
-pub struct StateStore {
-    trie: LeftRightTrie<'static, Address, Account, RocksDbAdapter>,
+#[derive(Debug, Clone, Default)]
+pub struct StateStore<D: Database> {
+    trie: LeftRightTrie<'static, Address, Account, D>,
 }
 
-impl Default for StateStore {
-    fn default() -> Self {
-        let db_path = storage_utils::get_node_data_dir()
-            .unwrap_or_default()
-            .join("db")
-            .join("state");
-
-        let db_adapter = RocksDbAdapter::new(db_path, "state").unwrap_or_default();
-
-        let trie = LeftRightTrie::new(Arc::new(db_adapter));
-
-        Self { trie }
-    }
-}
-
-impl StateStore {
+impl<D: Database> StateStore<D> {
     /// Returns new, empty instance of StateDb
 
-    pub fn new(path: &Path) -> Self {
-        let path = path.join("state");
-        let db_adapter = RocksDbAdapter::new(path, "state").unwrap_or_default();
+    pub fn new(db_adapter: D) -> Self {
         let trie = LeftRightTrie::new(Arc::new(db_adapter));
 
         Self { trie }
@@ -46,7 +28,7 @@ impl StateStore {
 
     /// Returns new ReadHandle to the VrrDb data. As long as the returned value
     /// lives, no write to the database will be committed.
-    pub fn read_handle(&self) -> StateStoreReadHandle {
+    pub fn read_handle(&self) -> StateStoreReadHandle<D> {
         let inner = self.trie.handle();
         StateStoreReadHandle::new(inner)
     }
@@ -132,7 +114,7 @@ impl StateStore {
 
     /// Retain returns new StateDb with which all Accounts that fulfill `filter`
     /// cloned to it.
-    pub fn retain<F>(&self, _filter: F) -> StateStore
+    pub fn retain<F>(&self, _filter: F) -> StateStore<D>
     where
         F: FnMut(&Account) -> bool,
     {
@@ -284,7 +266,7 @@ impl StateStore {
         self.trie.extend(accounts)
     }
 
-    pub fn factory(&self) -> StateStoreReadHandleFactory {
+    pub fn factory(&self) -> StateStoreReadHandleFactory<D> {
         let inner = self.trie.factory();
 
         StateStoreReadHandleFactory::new(inner)

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -1,10 +1,11 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use lr_trie::{LeftRightTrie, H256};
-use patriecia::Database;
 use primitives::Address;
 use storage_utils::{Result, StorageError};
 use vrrb_core::account::{Account, UpdateArgs};
+
+use crate::RocksDbAdapter;
 
 mod state_store_rh;
 pub use state_store_rh::*;
@@ -12,15 +13,32 @@ pub use state_store_rh::*;
 pub type Accounts = Vec<Account>;
 pub type FailedAccountUpdates = Vec<(Address, Vec<UpdateArgs>, Result<()>)>;
 
-#[derive(Debug, Clone, Default)]
-pub struct StateStore<D: Database> {
-    trie: LeftRightTrie<'static, Address, Account, D>,
+#[derive(Debug, Clone)]
+pub struct StateStore {
+    trie: LeftRightTrie<'static, Address, Account, RocksDbAdapter>,
 }
 
-impl<D: Database> StateStore<D> {
+impl Default for StateStore {
+    fn default() -> Self {
+        let db_path = storage_utils::get_node_data_dir()
+            .unwrap_or_default()
+            .join("db")
+            .join("state");
+
+        let db_adapter = RocksDbAdapter::new(db_path, "state").unwrap_or_default();
+
+        let trie = LeftRightTrie::new(Arc::new(db_adapter));
+
+        Self { trie }
+    }
+}
+
+impl StateStore {
     /// Returns new, empty instance of StateDb
 
-    pub fn new(db_adapter: D) -> Self {
+    pub fn new(path: &Path) -> Self {
+        let path = path.join("state");
+        let db_adapter = RocksDbAdapter::new(path, "state").unwrap_or_default();
         let trie = LeftRightTrie::new(Arc::new(db_adapter));
 
         Self { trie }
@@ -28,7 +46,7 @@ impl<D: Database> StateStore<D> {
 
     /// Returns new ReadHandle to the VrrDb data. As long as the returned value
     /// lives, no write to the database will be committed.
-    pub fn read_handle(&self) -> StateStoreReadHandle<D> {
+    pub fn read_handle(&self) -> StateStoreReadHandle {
         let inner = self.trie.handle();
         StateStoreReadHandle::new(inner)
     }
@@ -114,9 +132,9 @@ impl<D: Database> StateStore<D> {
 
     /// Retain returns new StateDb with which all Accounts that fulfill `filter`
     /// cloned to it.
-    pub fn retain<F>(&self, _filter: F) -> StateStore<D>
-    where
-        F: FnMut(&Account) -> bool,
+    pub fn retain<F>(&self, _filter: F) -> StateStore
+        where
+            F: FnMut(&Account) -> bool,
     {
         todo!()
         // let mut subdb = StateStore::new(self.);
@@ -266,7 +284,7 @@ impl<D: Database> StateStore<D> {
         self.trie.extend(accounts)
     }
 
-    pub fn factory(&self) -> StateStoreReadHandleFactory<D> {
+    pub fn factory(&self) -> StateStoreReadHandleFactory {
         let inner = self.trie.factory();
 
         StateStoreReadHandleFactory::new(inner)

--- a/crates/storage/vrrbdb/src/state_store/state_store_rh.rs
+++ b/crates/storage/vrrbdb/src/state_store/state_store_rh.rs
@@ -1,18 +1,20 @@
 use std::collections::HashMap;
 
 use lr_trie::{InnerTrieWrapper, ReadHandleFactory};
-use patriecia::{inner::InnerTrie, Database};
+use patriecia::inner::InnerTrie;
 use primitives::Address;
 use storage_utils::{Result, StorageError};
 use vrrb_core::account::Account;
 
+use crate::RocksDbAdapter;
+
 #[derive(Debug, Clone)]
-pub struct StateStoreReadHandle<D: Database> {
-    inner: InnerTrieWrapper<D>,
+pub struct StateStoreReadHandle {
+    inner: InnerTrieWrapper<RocksDbAdapter>,
 }
 
-impl<D: Database> StateStoreReadHandle<D> {
-    pub fn new(inner: InnerTrieWrapper<D>) -> Self {
+impl StateStoreReadHandle {
+    pub fn new(inner: InnerTrieWrapper<RocksDbAdapter>) -> Self {
         Self { inner }
     }
 
@@ -66,16 +68,16 @@ impl<D: Database> StateStoreReadHandle<D> {
 }
 
 #[derive(Debug, Clone)]
-pub struct StateStoreReadHandleFactory<D: Database> {
-    inner: ReadHandleFactory<InnerTrie<D>>,
+pub struct StateStoreReadHandleFactory {
+    inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>,
 }
 
-impl<D: Database> StateStoreReadHandleFactory<D> {
-    pub fn new(inner: ReadHandleFactory<InnerTrie<D>>) -> Self {
+impl StateStoreReadHandleFactory {
+    pub fn new(inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>) -> Self {
         Self { inner }
     }
 
-    pub fn handle(&self) -> StateStoreReadHandle<D> {
+    pub fn handle(&self) -> StateStoreReadHandle {
         let handle = self
             .inner
             .handle()

--- a/crates/storage/vrrbdb/src/state_store/state_store_rh.rs
+++ b/crates/storage/vrrbdb/src/state_store/state_store_rh.rs
@@ -1,20 +1,18 @@
 use std::collections::HashMap;
 
 use lr_trie::{InnerTrieWrapper, ReadHandleFactory};
-use patriecia::inner::InnerTrie;
+use patriecia::{inner::InnerTrie, Database};
 use primitives::Address;
 use storage_utils::{Result, StorageError};
 use vrrb_core::account::Account;
 
-use crate::RocksDbAdapter;
-
 #[derive(Debug, Clone)]
-pub struct StateStoreReadHandle {
-    inner: InnerTrieWrapper<RocksDbAdapter>,
+pub struct StateStoreReadHandle<D: Database> {
+    inner: InnerTrieWrapper<D>,
 }
 
-impl StateStoreReadHandle {
-    pub fn new(inner: InnerTrieWrapper<RocksDbAdapter>) -> Self {
+impl<D: Database> StateStoreReadHandle<D> {
+    pub fn new(inner: InnerTrieWrapper<D>) -> Self {
         Self { inner }
     }
 
@@ -68,16 +66,16 @@ impl StateStoreReadHandle {
 }
 
 #[derive(Debug, Clone)]
-pub struct StateStoreReadHandleFactory {
-    inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>,
+pub struct StateStoreReadHandleFactory<D: Database> {
+    inner: ReadHandleFactory<InnerTrie<D>>,
 }
 
-impl StateStoreReadHandleFactory {
-    pub fn new(inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>) -> Self {
+impl<D: Database> StateStoreReadHandleFactory<D> {
+    pub fn new(inner: ReadHandleFactory<InnerTrie<D>>) -> Self {
         Self { inner }
     }
 
-    pub fn handle(&self) -> StateStoreReadHandle {
+    pub fn handle(&self) -> StateStoreReadHandle<D> {
         let handle = self
             .inner
             .handle()

--- a/crates/storage/vrrbdb/src/transaction_store/mod.rs
+++ b/crates/storage/vrrbdb/src/transaction_store/mod.rs
@@ -1,45 +1,27 @@
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 use lr_trie::{LeftRightTrie, Proof, H256};
+use patriecia::Database;
 use storage_utils::Result;
 use vrrb_core::txn::{TransactionDigest, Txn};
-
-use crate::RocksDbAdapter;
 
 mod transaction_store_rh;
 pub use transaction_store_rh::*;
 
-#[derive(Debug, Clone)]
-pub struct TransactionStore {
-    trie: LeftRightTrie<'static, TransactionDigest, Txn, RocksDbAdapter>,
+#[derive(Debug, Clone, Default)]
+pub struct TransactionStore<D: Database> {
+    trie: LeftRightTrie<'static, TransactionDigest, Txn, D>,
 }
 
-impl Default for TransactionStore {
-    fn default() -> Self {
-        let db_path = storage_utils::get_node_data_dir()
-            .unwrap_or_default()
-            .join("db")
-            .join("transactions");
-
-        let db_adapter = RocksDbAdapter::new(db_path, "transactions").unwrap_or_default();
-
-        let trie = LeftRightTrie::new(Arc::new(db_adapter));
-
-        Self { trie }
-    }
-}
-
-impl TransactionStore {
+impl<D: Database> TransactionStore<D> {
     /// Returns new, empty instance of TransactionStore
-    pub fn new(path: &Path) -> Self {
-        let path = path.join("transactions");
-        let db_adapter = RocksDbAdapter::new(path, "transactions").unwrap_or_default();
+    pub fn new(db_adapter: D) -> Self {
         let trie = LeftRightTrie::new(Arc::new(db_adapter));
 
         Self { trie }
     }
 
-    pub fn factory(&self) -> TransactionStoreReadHandleFactory {
+    pub fn factory(&self) -> TransactionStoreReadHandleFactory<D> {
         let inner = self.trie.factory();
 
         TransactionStoreReadHandleFactory::new(inner)
@@ -49,7 +31,7 @@ impl TransactionStore {
         self.trie.publish();
     }
 
-    pub fn read_handle(&self) -> TransactionStoreReadHandle {
+    pub fn read_handle(&self) -> TransactionStoreReadHandle<D> {
         let inner = self.trie.handle();
         TransactionStoreReadHandle::new(inner)
     }

--- a/crates/storage/vrrbdb/src/transaction_store/transaction_store_rh.rs
+++ b/crates/storage/vrrbdb/src/transaction_store/transaction_store_rh.rs
@@ -1,19 +1,17 @@
 use std::collections::HashMap;
 
 use lr_trie::{InnerTrieWrapper, ReadHandleFactory};
-use patriecia::inner::InnerTrie;
+use patriecia::{inner::InnerTrie, Database};
 use storage_utils::{Result, StorageError};
 use vrrb_core::txn::{TransactionDigest, Txn};
 
-use crate::RocksDbAdapter;
-
 #[derive(Debug, Clone)]
-pub struct TransactionStoreReadHandle {
-    inner: InnerTrieWrapper<RocksDbAdapter>,
+pub struct TransactionStoreReadHandle<D: Database> {
+    inner: InnerTrieWrapper<D>,
 }
 
-impl TransactionStoreReadHandle {
-    pub fn new(inner: InnerTrieWrapper<RocksDbAdapter>) -> Self {
+impl<D: Database> TransactionStoreReadHandle<D> {
+    pub fn new(inner: InnerTrieWrapper<D>) -> Self {
         Self { inner }
     }
 
@@ -62,16 +60,16 @@ impl TransactionStoreReadHandle {
 }
 
 #[derive(Debug, Clone)]
-pub struct TransactionStoreReadHandleFactory {
-    inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>,
+pub struct TransactionStoreReadHandleFactory<D: Database> {
+    inner: ReadHandleFactory<InnerTrie<D>>,
 }
 
-impl TransactionStoreReadHandleFactory {
-    pub fn new(inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>) -> Self {
+impl<D: Database> TransactionStoreReadHandleFactory<D> {
+    pub fn new(inner: ReadHandleFactory<InnerTrie<D>>) -> Self {
         Self { inner }
     }
 
-    pub fn handle(&self) -> TransactionStoreReadHandle {
+    pub fn handle(&self) -> TransactionStoreReadHandle<D> {
         let handle = self
             .inner
             .handle()

--- a/crates/storage/vrrbdb/src/transaction_store/transaction_store_rh.rs
+++ b/crates/storage/vrrbdb/src/transaction_store/transaction_store_rh.rs
@@ -1,17 +1,19 @@
 use std::collections::HashMap;
 
 use lr_trie::{InnerTrieWrapper, ReadHandleFactory};
-use patriecia::{inner::InnerTrie, Database};
+use patriecia::inner::InnerTrie;
 use storage_utils::{Result, StorageError};
 use vrrb_core::txn::{TransactionDigest, Txn};
 
+use crate::RocksDbAdapter;
+
 #[derive(Debug, Clone)]
-pub struct TransactionStoreReadHandle<D: Database> {
-    inner: InnerTrieWrapper<D>,
+pub struct TransactionStoreReadHandle {
+    inner: InnerTrieWrapper<RocksDbAdapter>,
 }
 
-impl<D: Database> TransactionStoreReadHandle<D> {
-    pub fn new(inner: InnerTrieWrapper<D>) -> Self {
+impl TransactionStoreReadHandle {
+    pub fn new(inner: InnerTrieWrapper<RocksDbAdapter>) -> Self {
         Self { inner }
     }
 
@@ -60,16 +62,16 @@ impl<D: Database> TransactionStoreReadHandle<D> {
 }
 
 #[derive(Debug, Clone)]
-pub struct TransactionStoreReadHandleFactory<D: Database> {
-    inner: ReadHandleFactory<InnerTrie<D>>,
+pub struct TransactionStoreReadHandleFactory {
+    inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>,
 }
 
-impl<D: Database> TransactionStoreReadHandleFactory<D> {
-    pub fn new(inner: ReadHandleFactory<InnerTrie<D>>) -> Self {
+impl TransactionStoreReadHandleFactory {
+    pub fn new(inner: ReadHandleFactory<InnerTrie<RocksDbAdapter>>) -> Self {
         Self { inner }
     }
 
-    pub fn handle(&self) -> TransactionStoreReadHandle<D> {
+    pub fn handle(&self) -> TransactionStoreReadHandle {
         let handle = self
             .inner
             .handle()

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -13,8 +13,13 @@ use vrrb_core::{
 };
 
 use crate::{
-    ClaimStore, ClaimStoreReadHandleFactory, StateStore, StateStoreReadHandleFactory,
-    TransactionStore, TransactionStoreReadHandleFactory, VrrbDbReadHandle,
+    ClaimStore,
+    ClaimStoreReadHandleFactory,
+    StateStore,
+    StateStoreReadHandleFactory,
+    TransactionStore,
+    TransactionStoreReadHandleFactory,
+    VrrbDbReadHandle,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use patriecia::Database;
 use primitives::{Address, NodeId};
 use vrrb_core::{
     account::Account,
@@ -15,17 +14,17 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub struct VrrbDbReadHandle<D: Database> {
-    state_store_handle_factory: StateStoreReadHandleFactory<D>,
-    transaction_store_handle_factory: TransactionStoreReadHandleFactory<D>,
-    claim_store_handle_factory: ClaimStoreReadHandleFactory<D>,
+pub struct VrrbDbReadHandle {
+    state_store_handle_factory: StateStoreReadHandleFactory,
+    transaction_store_handle_factory: TransactionStoreReadHandleFactory,
+    claim_store_handle_factory: ClaimStoreReadHandleFactory,
 }
 
-impl<D: Database> VrrbDbReadHandle<D> {
+impl VrrbDbReadHandle {
     pub fn new(
-        state_store_handle_factory: StateStoreReadHandleFactory<D>,
-        transaction_store_handle_factory: TransactionStoreReadHandleFactory<D>,
-        claim_store_handle_factory: ClaimStoreReadHandleFactory<D>,
+        state_store_handle_factory: StateStoreReadHandleFactory,
+        transaction_store_handle_factory: TransactionStoreReadHandleFactory,
+        claim_store_handle_factory: ClaimStoreReadHandleFactory,
     ) -> Self {
         Self {
             state_store_handle_factory,

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -9,7 +9,9 @@ use vrrb_core::{
 };
 
 use crate::{
-    ClaimStoreReadHandleFactory, StateStoreReadHandleFactory, TransactionStoreReadHandleFactory,
+    ClaimStoreReadHandleFactory,
+    StateStoreReadHandleFactory,
+    TransactionStoreReadHandleFactory,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use patriecia::Database;
 use primitives::{Address, NodeId};
 use vrrb_core::{
     account::Account,
@@ -8,23 +9,21 @@ use vrrb_core::{
 };
 
 use crate::{
-    ClaimStoreReadHandleFactory,
-    StateStoreReadHandleFactory,
-    TransactionStoreReadHandleFactory,
+    ClaimStoreReadHandleFactory, StateStoreReadHandleFactory, TransactionStoreReadHandleFactory,
 };
 
 #[derive(Debug, Clone)]
-pub struct VrrbDbReadHandle {
-    state_store_handle_factory: StateStoreReadHandleFactory,
-    transaction_store_handle_factory: TransactionStoreReadHandleFactory,
-    claim_store_handle_factory: ClaimStoreReadHandleFactory,
+pub struct VrrbDbReadHandle<D: Database> {
+    state_store_handle_factory: StateStoreReadHandleFactory<D>,
+    transaction_store_handle_factory: TransactionStoreReadHandleFactory<D>,
+    claim_store_handle_factory: ClaimStoreReadHandleFactory<D>,
 }
 
-impl VrrbDbReadHandle {
+impl<D: Database> VrrbDbReadHandle<D> {
     pub fn new(
-        state_store_handle_factory: StateStoreReadHandleFactory,
-        transaction_store_handle_factory: TransactionStoreReadHandleFactory,
-        claim_store_handle_factory: ClaimStoreReadHandleFactory,
+        state_store_handle_factory: StateStoreReadHandleFactory<D>,
+        transaction_store_handle_factory: TransactionStoreReadHandleFactory<D>,
+        claim_store_handle_factory: ClaimStoreReadHandleFactory<D>,
     ) -> Self {
         Self {
             state_store_handle_factory,

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -78,6 +78,7 @@ pub fn _generate_random_claim() -> Claim {
     let signature = Claim::signature_for_valid_claim(
         public_key,
         ip_address,
+        1023,
         keypair.get_miner_secret_key().secret_bytes().to_vec(),
     )
     .unwrap();
@@ -85,6 +86,7 @@ pub fn _generate_random_claim() -> Claim {
         public_key,
         Address::new(public_key),
         ip_address.clone(),
+        1023,
         signature,
     )
     .unwrap()

--- a/crates/storage/vrrbdb/tests/test_claim_store.rs
+++ b/crates/storage/vrrbdb/tests/test_claim_store.rs
@@ -1,3 +1,4 @@
+use patriecia::MemoryDB;
 use vrrbdb::{VrrbDb, VrrbDbConfig};
 
 mod common;
@@ -7,7 +8,7 @@ use serial_test::serial;
 #[test]
 #[serial]
 fn claims_can_be_added() {
-    let mut db = VrrbDb::new(VrrbDbConfig::default());
+    let mut db = VrrbDb::<MemoryDB>::new(VrrbDbConfig::default());
 
     let claim1 = _generate_random_claim();
     let claim2 = _generate_random_claim();

--- a/crates/storage/vrrbdb/tests/test_claim_store.rs
+++ b/crates/storage/vrrbdb/tests/test_claim_store.rs
@@ -8,8 +8,7 @@ use serial_test::serial;
 #[test]
 #[serial]
 fn claims_can_be_added() {
-    let mut db = VrrbDb::<MemoryDB>::new(VrrbDbConfig::default());
-
+    let mut db = VrrbDb::new(VrrbDbConfig::default());
     let claim1 = _generate_random_claim();
     let claim2 = _generate_random_claim();
     let claim3 = _generate_random_claim();

--- a/crates/storage/vrrbdb/tests/test_state_store.rs
+++ b/crates/storage/vrrbdb/tests/test_state_store.rs
@@ -1,3 +1,4 @@
+use patriecia::MemoryDB;
 use vrrb_core::account::{Account, AccountDigests};
 use vrrbdb::{VrrbDb, VrrbDbConfig};
 
@@ -8,7 +9,7 @@ use serial_test::serial;
 #[test]
 #[serial]
 fn accounts_can_be_added() {
-    let mut db = VrrbDb::new(VrrbDbConfig::default());
+    let mut db = VrrbDb::<MemoryDB>::new(VrrbDbConfig::default());
 
     let (_, addr1) = _generate_random_address();
     let (_, addr2) = _generate_random_address();

--- a/crates/storage/vrrbdb/tests/test_state_store.rs
+++ b/crates/storage/vrrbdb/tests/test_state_store.rs
@@ -9,7 +9,7 @@ use serial_test::serial;
 #[test]
 #[serial]
 fn accounts_can_be_added() {
-    let mut db = VrrbDb::<MemoryDB>::new(VrrbDbConfig::default());
+    let mut db = VrrbDb::new(VrrbDbConfig::default());
 
     let (_, addr1) = _generate_random_address();
     let (_, addr2) = _generate_random_address();

--- a/crates/storage/vrrbdb/tests/test_transaction_store.rs
+++ b/crates/storage/vrrbdb/tests/test_transaction_store.rs
@@ -1,5 +1,6 @@
 use std::env;
 
+use patriecia::MemoryDB;
 use serial_test::serial;
 use vrrbdb::{VrrbDb, VrrbDbConfig};
 mod common;
@@ -12,12 +13,11 @@ fn transactions_can_be_added() {
     let temp_dir_path = env::temp_dir();
     let state_backup_path = temp_dir_path.join(format!("{}", _generate_random_string()));
 
-    let mut db = VrrbDb::new(VrrbDbConfig {
+    let mut db = VrrbDb::<MemoryDB>::new(VrrbDbConfig {
         path: state_backup_path,
-        state_store_path: None,
-        transaction_store_path: None,
-        event_store_path: None,
-        claim_store_path: None,
+        state_store_backing_db: None,
+        transaction_store_backing_db: None,
+        claim_store_backing_db: None,
     });
 
     let txn1 = _generate_random_valid_transaction();

--- a/crates/storage/vrrbdb/tests/test_transaction_store.rs
+++ b/crates/storage/vrrbdb/tests/test_transaction_store.rs
@@ -13,11 +13,12 @@ fn transactions_can_be_added() {
     let temp_dir_path = env::temp_dir();
     let state_backup_path = temp_dir_path.join(format!("{}", _generate_random_string()));
 
-    let mut db = VrrbDb::<MemoryDB>::new(VrrbDbConfig {
+    let mut db = VrrbDb::new(VrrbDbConfig {
         path: state_backup_path,
-        state_store_backing_db: None,
-        transaction_store_backing_db: None,
-        claim_store_backing_db: None,
+        state_store_path: None,
+        transaction_store_path: None,
+        event_store_path: None,
+        claim_store_path: None,
     });
 
     let txn1 = _generate_random_valid_transaction();

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -375,6 +375,7 @@ impl Ownable for Claim {
 mod tests {
     use super::*;
     use crate::keypair::KeyPair;
+    pub (crate) const TEST_PORT_NUMBER: u16 = 1023;
 
     #[test]
     fn should_create_new_claim() {
@@ -385,13 +386,13 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let result = hasher.finalize();
         let hash = U256::from_big_endian(&result[..]);
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
@@ -401,12 +402,12 @@ mod tests {
             hash,
             eligibility: Eligibility::None,
             ip_address: "127.0.0.1:8080".parse().unwrap(),
-            raptor_port: 1023,
+            raptor_port: TEST_PORT_NUMBER,
             signature: signature.clone(),
             stake: 0,
             stake_txns: vec![],
         };
-        let claim = Claim::new(public_key, address, ip_address, 1023, signature).unwrap();
+        let claim = Claim::new(public_key, address, ip_address, TEST_PORT_NUMBER, signature).unwrap();
         assert_eq!(test_claim, claim);
     }
 
@@ -419,26 +420,26 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key.clone(), address, ip_address, 1023, signature).unwrap();
+            Claim::new(public_key.clone(), address, ip_address, TEST_PORT_NUMBER, signature).unwrap();
 
         let ip_address_new = "127.0.0.1:8081".parse::<SocketAddr>().unwrap();
         let mut hasher_new = Sha256::new();
         hasher_new.update(public_key.to_string().clone());
         hasher_new.update(ip_address_new.to_string().clone());
-        hasher_new.update(1023.to_string());
+        hasher_new.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address_new,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
@@ -456,15 +457,15 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let claim = Claim::new(public_key, address, ip_address, 1023, signature).unwrap();
+        let claim = Claim::new(public_key, address, ip_address, TEST_PORT_NUMBER, signature).unwrap();
         assert_eq!(0, claim.get_stake());
     }
 
@@ -477,16 +478,16 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key.clone(), address, ip_address, 1023, signature).unwrap();
+            Claim::new(public_key.clone(), address, ip_address, TEST_PORT_NUMBER, signature).unwrap();
         assert_eq!(0, claim.get_stake_txns().len());
     }
 
@@ -499,13 +500,13 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let result = hasher.finalize();
         let hash = U256::from_big_endian(&result[..]);
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
@@ -516,7 +517,7 @@ mod tests {
         });
 
         let test_election_result = U256(xor_val);
-        let claim = Claim::new(public_key, address, ip_address, 1023, signature).unwrap();
+        let claim = Claim::new(public_key, address, ip_address, TEST_PORT_NUMBER, signature).unwrap();
 
         let election_result = claim.get_election_result(seed);
 
@@ -532,16 +533,16 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key, address.clone(), ip_address, 1023, signature).unwrap();
+            Claim::new(public_key, address.clone(), ip_address, TEST_PORT_NUMBER, signature).unwrap();
 
         let amount = StakeUpdate::Add(10_000u128);
 
@@ -567,16 +568,16 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key, address.clone(), ip_address, 1023, signature).unwrap();
+            Claim::new(public_key, address.clone(), ip_address, TEST_PORT_NUMBER, signature).unwrap();
 
         let amount = StakeUpdate::Add(10_000u128);
 
@@ -604,11 +605,11 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
@@ -616,7 +617,7 @@ mod tests {
             public_key,
             address.clone(),
             ip_address.clone(),
-            1023,
+            TEST_PORT_NUMBER,
             signature,
         )
         .unwrap();
@@ -647,16 +648,16 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key, address.clone(), ip_address, 1023, signature).unwrap();
+            Claim::new(public_key, address.clone(), ip_address, TEST_PORT_NUMBER, signature).unwrap();
         let amount = StakeUpdate::Add(10_000u128);
         let mut stake = Stake::new(
             amount,
@@ -699,16 +700,16 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key, address.clone(), ip_address, 1023, signature).unwrap();
+            Claim::new(public_key, address.clone(), ip_address, TEST_PORT_NUMBER, signature).unwrap();
 
         let amount = StakeUpdate::Withdrawal(5_000u128);
         let mut stake = Stake::new(
@@ -736,16 +737,16 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key, address.clone(), ip_address, 1023, signature).unwrap();
+            Claim::new(public_key, address.clone(), ip_address, TEST_PORT_NUMBER, signature).unwrap();
 
         let amount = StakeUpdate::Add(10_000u128);
 
@@ -790,16 +791,16 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key, address.clone(), ip_address, 1023, signature).unwrap();
+            Claim::new(public_key, address.clone(), ip_address, TEST_PORT_NUMBER, signature).unwrap();
 
         let amount = StakeUpdate::Slash(25u8);
         let mut stake = Stake::new(
@@ -827,16 +828,16 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string().clone());
         hasher.update(ip_address.to_string().clone());
-        hasher.update(1023.to_string());
+        hasher.update(TEST_PORT_NUMBER.to_string());
         let signature = Claim::signature_for_valid_claim(
             public_key.clone(),
             ip_address,
-            1023,
+            TEST_PORT_NUMBER,
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
         let mut claim =
-            Claim::new(public_key, address.clone(), ip_address, 1023, signature).unwrap();
+            Claim::new(public_key, address.clone(), ip_address, TEST_PORT_NUMBER, signature).unwrap();
         let amount = StakeUpdate::Add(10_000u128);
 
         let mut stake = Stake::new(

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -177,7 +177,7 @@ impl Claim {
     /// a `Result` type, which can either be `Ok(())` if the signature is valid,
     /// or an `Err(ClaimError)` if the signature is invalid.
     pub fn is_valid_claim(msg_hash: &[u8], signature: String, pub_key: Vec<u8>) -> Result<()> {
-        Keypair::verify_ecdsa_sign(signature, msg_hash, pub_key).map_err(ClaimError::from)
+       Keypair::verify_ecdsa_sign(signature, msg_hash, pub_key).map_err(ClaimError::from)
     }
 
     /// This function updates the IP address of a claim and verifies its
@@ -204,10 +204,12 @@ impl Claim {
         signature: String,
         public_key: PublicKey,
         ip_address: SocketAddr,
+        raptor_port: u16,
     ) -> Result<()> {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string());
         hasher.update(ip_address.to_string());
+        hasher.update(raptor_port.to_string());
         let result = hasher.finalize();
         let hash = U256::from_big_endian(&result[..]);
         let mut msg_hash: Vec<u8> = Vec::new();
@@ -443,7 +445,7 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let status = claim.update_claim_socketaddr(signature, public_key, ip_address_new);
+        let status = claim.update_claim_socketaddr(signature, public_key, ip_address_new,TEST_PORT_NUMBER);
         assert!(status.is_ok());
         assert_eq!(claim.ip_address, ip_address_new);
     }

--- a/crates/vrrb_grpc/Cargo.toml
+++ b/crates/vrrb_grpc/Cargo.toml
@@ -33,3 +33,4 @@ secp256k1 = { workspace = true }
 hex = { workspace = true }
 telemetry = { workspace = true }
 tokio = { workspace = true }
+patriecia = { workspace = true }

--- a/crates/vrrb_grpc/src/node_read.rs
+++ b/crates/vrrb_grpc/src/node_read.rs
@@ -6,13 +6,10 @@ use events::EventPublisher;
 use mempool::MempoolReadHandleFactory;
 use node_read_service::v1::{
     node_read_service_server::{NodeReadService, NodeReadServiceServer},
-    GetFullMempoolRequest,
-    GetFullMempoolResponse,
-    GetNodeTypeRequest,
-    GetNodeTypeResponse,
-    Token as NodeToken,
-    TransactionRecord,
+    GetFullMempoolRequest, GetFullMempoolResponse, GetNodeTypeRequest, GetNodeTypeResponse,
+    Token as NodeToken, TransactionRecord,
 };
+use patriecia::Database;
 use primitives::NodeType;
 use serde::{Deserialize, Serialize};
 use storage::vrrbdb::VrrbDbReadHandle;
@@ -78,21 +75,21 @@ impl From<RpcTransactionRecord> for TransactionRecord {
 }
 
 #[derive(Debug)]
-pub struct NodeRead {
+pub struct NodeRead<D: Database> {
     pub node_type: NodeType,
-    pub vrrbdb_read_handle: VrrbDbReadHandle,
+    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
     pub events_tx: EventPublisher,
 }
 
-impl NodeRead {
-    pub fn init(self) -> NodeReadServiceServer<NodeRead> {
+impl<D: Database + 'static> NodeRead<D> {
+    pub fn init(self) -> NodeReadServiceServer<NodeRead<D>> {
         NodeReadServiceServer::new(self)
     }
 }
 
 #[tonic::async_trait]
-impl NodeReadService for NodeRead {
+impl<D: Database + 'static> NodeReadService for NodeRead<D> {
     async fn get_node_type(
         &self,
         _request: Request<GetNodeTypeRequest>,

--- a/crates/vrrb_grpc/src/node_read.rs
+++ b/crates/vrrb_grpc/src/node_read.rs
@@ -13,7 +13,6 @@ use node_read_service::v1::{
     Token as NodeToken,
     TransactionRecord,
 };
-use patriecia::Database;
 use primitives::NodeType;
 use serde::{Deserialize, Serialize};
 use storage::vrrbdb::VrrbDbReadHandle;
@@ -79,21 +78,21 @@ impl From<RpcTransactionRecord> for TransactionRecord {
 }
 
 #[derive(Debug)]
-pub struct NodeRead<D: Database> {
+pub struct NodeRead {
     pub node_type: NodeType,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
     pub events_tx: EventPublisher,
 }
 
-impl<D: Database + 'static> NodeRead<D> {
-    pub fn init(self) -> NodeReadServiceServer<NodeRead<D>> {
+impl NodeRead {
+    pub fn init(self) -> NodeReadServiceServer<NodeRead> {
         NodeReadServiceServer::new(self)
     }
 }
 
 #[tonic::async_trait]
-impl<D: Database + 'static> NodeReadService for NodeRead<D> {
+impl NodeReadService for NodeRead {
     async fn get_node_type(
         &self,
         _request: Request<GetNodeTypeRequest>,

--- a/crates/vrrb_grpc/src/node_read.rs
+++ b/crates/vrrb_grpc/src/node_read.rs
@@ -6,8 +6,12 @@ use events::EventPublisher;
 use mempool::MempoolReadHandleFactory;
 use node_read_service::v1::{
     node_read_service_server::{NodeReadService, NodeReadServiceServer},
-    GetFullMempoolRequest, GetFullMempoolResponse, GetNodeTypeRequest, GetNodeTypeResponse,
-    Token as NodeToken, TransactionRecord,
+    GetFullMempoolRequest,
+    GetFullMempoolResponse,
+    GetNodeTypeRequest,
+    GetNodeTypeResponse,
+    Token as NodeToken,
+    TransactionRecord,
 };
 use patriecia::Database;
 use primitives::NodeType;

--- a/crates/vrrb_grpc/src/node_write.rs
+++ b/crates/vrrb_grpc/src/node_write.rs
@@ -10,7 +10,6 @@ use node_write_service::v1::{
     Token as NodeToken,
     TransactionRecord,
 };
-use patriecia::Database;
 use primitives::NodeType;
 use secp256k1::{ecdsa::Signature, PublicKey};
 use serde::{Deserialize, Serialize};
@@ -109,21 +108,21 @@ impl From<CreateTransactionRequest> for NewTxnArgs {
 }
 
 #[derive(Debug)]
-pub struct NodeWrite<D: Database> {
+pub struct NodeWrite {
     pub node_type: NodeType,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
     pub events_tx: EventPublisher,
 }
 
-impl<D: Database + 'static> NodeWrite<D> {
-    pub fn init(self) -> NodeWriteServiceServer<NodeWrite<D>> {
+impl NodeWrite {
+    pub fn init(self) -> NodeWriteServiceServer<NodeWrite> {
         NodeWriteServiceServer::new(self)
     }
 }
 
 #[tonic::async_trait]
-impl<D: Database + 'static> NodeWriteService for NodeWrite<D> {
+impl NodeWriteService for NodeWrite {
     async fn create_transaction(
         &self,
         request: Request<CreateTransactionRequest>,

--- a/crates/vrrb_grpc/src/node_write.rs
+++ b/crates/vrrb_grpc/src/node_write.rs
@@ -6,7 +6,9 @@ use events::{Event, EventPublisher};
 use mempool::MempoolReadHandleFactory;
 use node_write_service::v1::{
     node_write_service_server::{NodeWriteService, NodeWriteServiceServer},
-    CreateTransactionRequest, Token as NodeToken, TransactionRecord,
+    CreateTransactionRequest,
+    Token as NodeToken,
+    TransactionRecord,
 };
 use patriecia::Database;
 use primitives::NodeType;

--- a/crates/vrrb_grpc/src/server.rs
+++ b/crates/vrrb_grpc/src/server.rs
@@ -7,7 +7,6 @@ use std::{
 
 use events::{EventPublisher, DEFAULT_BUFFER};
 use mempool::{LeftRightMempool, MempoolReadHandleFactory};
-use patriecia::Database;
 use primitives::NodeType;
 use storage::vrrbdb::{VrrbDb, VrrbDbConfig, VrrbDbReadHandle};
 use tokio::sync::mpsc::channel;
@@ -17,9 +16,9 @@ use tonic_reflection;
 use crate::{node_read::NodeRead, node_write::NodeWrite};
 
 #[derive(Debug, Clone)]
-pub struct GrpcServerConfig<D: Database> {
+pub struct GrpcServerConfig {
     pub address: SocketAddr,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
     pub node_type: NodeType,
     pub events_tx: EventPublisher,
@@ -29,9 +28,7 @@ pub struct GrpcServerConfig<D: Database> {
 pub struct GrpcServer;
 
 impl GrpcServer {
-    pub async fn run<D: Database + 'static>(
-        config: &GrpcServerConfig<D>,
-    ) -> anyhow::Result<SocketAddr> {
+    pub async fn run(config: &GrpcServerConfig) -> anyhow::Result<SocketAddr> {
         let addr = config.address;
 
         let reflection_service = tonic_reflection::server::Builder::configure()
@@ -75,8 +72,8 @@ impl GrpcServer {
 
 // NOTE: I feel like this needs discussion, default db_path here would be
 // different then the actual?
-impl<D: Database> Default for GrpcServerConfig<D> {
-    fn default() -> GrpcServerConfig<D> {
+impl Default for GrpcServerConfig {
+    fn default() -> GrpcServerConfig {
         let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50051);
         let mut vrrbdb_config = VrrbDbConfig::default();
 

--- a/crates/vrrb_rpc/Cargo.toml
+++ b/crates/vrrb_rpc/Cargo.toml
@@ -28,6 +28,7 @@ events = { workspace = true }
 secp256k1 = { workspace = true }
 sha256 = { workspace = true }
 sha2 = { workspace = true }
+patriecia = { workspace = true }
 
 [dev-dependencies]
 hyper = { workspace = true }

--- a/crates/vrrb_rpc/src/rpc/server.rs
+++ b/crates/vrrb_rpc/src/rpc/server.rs
@@ -3,7 +3,6 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use events::{EventPublisher, DEFAULT_BUFFER};
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use mempool::{LeftRightMempool, MempoolReadHandleFactory};
-use patriecia::Database;
 use primitives::NodeType;
 use storage::vrrbdb::{VrrbDb, VrrbDbConfig, VrrbDbReadHandle};
 use tokio::sync::mpsc::channel;
@@ -11,9 +10,9 @@ use tokio::sync::mpsc::channel;
 use crate::rpc::{api::RpcApiServer, server_impl::RpcServerImpl};
 
 #[derive(Debug, Clone)]
-pub struct JsonRpcServerConfig<D: Database> {
+pub struct JsonRpcServerConfig {
     pub address: SocketAddr,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
     pub node_type: NodeType,
     pub events_tx: EventPublisher,
@@ -23,9 +22,7 @@ pub struct JsonRpcServerConfig<D: Database> {
 pub struct JsonRpcServer;
 
 impl JsonRpcServer {
-    pub async fn run<D: Database + 'static>(
-        config: &JsonRpcServerConfig<D>,
-    ) -> anyhow::Result<(ServerHandle, SocketAddr)> {
+    pub async fn run(config: &JsonRpcServerConfig) -> anyhow::Result<(ServerHandle, SocketAddr)> {
         let server = ServerBuilder::default().build(config.address).await?;
 
         let server_impl = RpcServerImpl {
@@ -45,8 +42,8 @@ impl JsonRpcServer {
     }
 }
 
-impl<D: Database + Default> Default for JsonRpcServerConfig<D> {
-    fn default() -> JsonRpcServerConfig<D> {
+impl Default for JsonRpcServerConfig {
+    fn default() -> JsonRpcServerConfig {
         let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9293);
         let mut vrrbdb_config = VrrbDbConfig::default();
 

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use events::{Event, EventPublisher};
 use jsonrpsee::core::Error;
 use mempool::MempoolReadHandleFactory;
-use patriecia::Database;
 use primitives::{Address, NodeType};
 use secp256k1::{Message, SecretKey};
 use sha2::{Digest, Sha256};
@@ -23,15 +22,15 @@ use super::{
 use crate::rpc::api::{FullStateSnapshot, RpcTransactionDigest, RpcTransactionRecord};
 
 #[derive(Debug, Clone)]
-pub struct RpcServerImpl<D: Database> {
+pub struct RpcServerImpl {
     pub node_type: NodeType,
-    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
+    pub vrrbdb_read_handle: VrrbDbReadHandle,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
     pub events_tx: EventPublisher,
 }
 
 #[async_trait]
-impl<D: Database + 'static> RpcApiServer for RpcServerImpl<D> {
+impl RpcApiServer for RpcServerImpl {
     async fn get_full_state(&self) -> Result<FullStateSnapshot, Error> {
         let values = self.vrrbdb_read_handle.state_store_values();
 

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use events::{Event, EventPublisher};
 use jsonrpsee::core::Error;
 use mempool::MempoolReadHandleFactory;
+use patriecia::Database;
 use primitives::{Address, NodeType};
 use secp256k1::{Message, SecretKey};
 use sha2::{Digest, Sha256};
@@ -22,15 +23,15 @@ use super::{
 use crate::rpc::api::{FullStateSnapshot, RpcTransactionDigest, RpcTransactionRecord};
 
 #[derive(Debug, Clone)]
-pub struct RpcServerImpl {
+pub struct RpcServerImpl<D: Database> {
     pub node_type: NodeType,
-    pub vrrbdb_read_handle: VrrbDbReadHandle,
+    pub vrrbdb_read_handle: VrrbDbReadHandle<D>,
     pub mempool_read_handle_factory: MempoolReadHandleFactory,
     pub events_tx: EventPublisher,
 }
 
 #[async_trait]
-impl RpcApiServer for RpcServerImpl {
+impl<D: Database + 'static> RpcApiServer for RpcServerImpl<D> {
     async fn get_full_state(&self) -> Result<FullStateSnapshot, Error> {
         let values = self.vrrbdb_read_handle.state_store_values();
 

--- a/crates/vrrb_rpc/tests/rpc.rs
+++ b/crates/vrrb_rpc/tests/rpc.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, net::SocketAddr};
 
 use events::{EventMessage, DEFAULT_BUFFER};
+use patriecia::MemoryDB;
 use primitives::{generate_mock_account_keypair, Address};
 use secp256k1::Message;
 use tokio::sync::mpsc::channel;
@@ -22,7 +23,7 @@ async fn server_can_publish_transactions_to_be_created() {
     let (events_tx, _events_rx) = channel::<EventMessage>(DEFAULT_BUFFER);
 
     // Set up RPC Server to accept connection from client
-    let mut json_rpc_server_config = JsonRpcServerConfig::default();
+    let mut json_rpc_server_config = JsonRpcServerConfig::<MemoryDB>::default();
     json_rpc_server_config.events_tx = events_tx;
 
     let (handle, rpc_server_address) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();

--- a/crates/vrrb_rpc/tests/rpc.rs
+++ b/crates/vrrb_rpc/tests/rpc.rs
@@ -23,7 +23,7 @@ async fn server_can_publish_transactions_to_be_created() {
     let (events_tx, _events_rx) = channel::<EventMessage>(DEFAULT_BUFFER);
 
     // Set up RPC Server to accept connection from client
-    let mut json_rpc_server_config = JsonRpcServerConfig::<MemoryDB>::default();
+    let mut json_rpc_server_config = JsonRpcServerConfig::default();
     json_rpc_server_config.events_tx = events_tx;
 
     let (handle, rpc_server_address) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -38,6 +38,7 @@ utils = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
 sha2 = { workspace = true }
+patriecia = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/wallet/tests/wallet_rpc_tests.rs
+++ b/crates/wallet/tests/wallet_rpc_tests.rs
@@ -17,7 +17,7 @@ pub async fn create_wallet_with_rpc_client() {
         .expect("Unable to create Socket Address");
 
     // Set up RPC Server to accept connection from client
-    let json_rpc_server_config = JsonRpcServerConfig::<MemoryDB>::default();
+    let json_rpc_server_config = JsonRpcServerConfig::default();
 
     let (server_handle, _) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();
 
@@ -38,7 +38,7 @@ pub async fn wallet_sends_txn_to_rpc_server() {
     let (events_tx, _events_rx) = channel(100);
 
     // Set up RPC Server to accept connection from client
-    let mut json_rpc_server_config = JsonRpcServerConfig::<MemoryDB>::default();
+    let mut json_rpc_server_config = JsonRpcServerConfig::default();
     json_rpc_server_config.events_tx = events_tx;
 
     let (handle, socket_addr) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();
@@ -90,7 +90,7 @@ pub async fn wallet_sends_create_account_request_to_rpc_server() {
     let (events_tx, _events_rx) = channel(100);
 
     // Set up RPC Server to accept connection from client
-    let mut json_rpc_server_config = JsonRpcServerConfig::<MemoryDB>::default();
+    let mut json_rpc_server_config = JsonRpcServerConfig::default();
     json_rpc_server_config.events_tx = events_tx;
 
     let (handle, socket_addr) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();

--- a/crates/wallet/tests/wallet_rpc_tests.rs
+++ b/crates/wallet/tests/wallet_rpc_tests.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use patriecia::MemoryDB;
 use primitives::Address;
 use secp256k1::{generate_keypair, PublicKey, Secp256k1, SecretKey};
 use serial_test::serial;
@@ -16,7 +17,7 @@ pub async fn create_wallet_with_rpc_client() {
         .expect("Unable to create Socket Address");
 
     // Set up RPC Server to accept connection from client
-    let json_rpc_server_config = JsonRpcServerConfig::default();
+    let json_rpc_server_config = JsonRpcServerConfig::<MemoryDB>::default();
 
     let (server_handle, _) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();
 
@@ -37,7 +38,7 @@ pub async fn wallet_sends_txn_to_rpc_server() {
     let (events_tx, _events_rx) = channel(100);
 
     // Set up RPC Server to accept connection from client
-    let mut json_rpc_server_config = JsonRpcServerConfig::default();
+    let mut json_rpc_server_config = JsonRpcServerConfig::<MemoryDB>::default();
     json_rpc_server_config.events_tx = events_tx;
 
     let (handle, socket_addr) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();
@@ -89,7 +90,7 @@ pub async fn wallet_sends_create_account_request_to_rpc_server() {
     let (events_tx, _events_rx) = channel(100);
 
     // Set up RPC Server to accept connection from client
-    let mut json_rpc_server_config = JsonRpcServerConfig::default();
+    let mut json_rpc_server_config = JsonRpcServerConfig::<MemoryDB>::default();
     json_rpc_server_config.events_tx = events_tx;
 
     let (handle, socket_addr) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();


### PR DESCRIPTION
This pull request includes the following updates:

- Update Quorum struct: The Quorum struct is modified to include IP address and Raptor ports. This enhancement allows for improved network communication and connectivity.

- Handle EventElected Quorum at Broadcast Engine: The Broadcast Engine is now equipped to handle the EventElected Quorum. This ensures that when a quorum is elected, the peer list is promptly updated with the latest information.

- Trigger DKGInitiate event: Once the peer list is updated, the DKGInitiate event is triggered. This event initiates the Distributed Key Generation process, enabling secure and efficient cryptographic operations.

- Trigger HandleAcks events once sufficient acks for commitments are received from peers
 ( No of acks=QuorumSize^2),then triggers Generate KeySet

