### PR TITLE
fix: `nix-shell` fails pre-commit formatting hook

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,5 @@
 indent_style = "Block"
+unstable_features = true
 reorder_imports = true
 format_code_in_doc_comments = true
 format_macro_matchers = true
@@ -12,4 +13,3 @@ use_field_init_shorthand = true
 blank_lines_upper_bound = 2
 wrap_comments = true
 type_punctuation_density = "Wide"
-

--- a/infra/scripts/pre-commit.sh
+++ b/infra/scripts/pre-commit.sh
@@ -8,7 +8,7 @@ echo 'Formatting...'
  for rust_file in $(git diff --name-only --cached | grep ".*\.rs$"); do
 
     if test -e "$rust_file"; then
-        cargo +nightly fmt -- "$rust_file"
+        cargo fmt -- "$rust_file"
         git add "$rust_file"
     fi
  done


### PR DESCRIPTION
`nix-shell` fails pre-commit formatting hook by invoking `+nightly` toolchain feature. This fixes that by removing the toolchain arg and adding the `unstable_features` option in the `rustfmt.toml`

Closes #380 