### PR TITLE
fix: add `rustup run nightly` to `cargo` invocation in pre-commit script

### DIFF
--- a/infra/scripts/pre-commit.sh
+++ b/infra/scripts/pre-commit.sh
@@ -8,7 +8,7 @@ echo 'Formatting...'
  for rust_file in $(git diff --name-only --cached | grep ".*\.rs$"); do
 
     if test -e "$rust_file"; then
-        cargo fmt -- "$rust_file"
+        rustup run nightly cargo fmt -- "$rust_file"
         git add "$rust_file"
     fi
  done


### PR DESCRIPTION
Fixes warnings that occur due to nightly only features in the formatting step of the pre-commit script