### PR TITLE
Setup Claim broadcasting on node startup

### DIFF
--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -109,6 +109,9 @@ pub enum Event {
     /// then has to be broadcasted.
     ClaimCreated(Claim),
 
+    /// `ClaimReceived(Claim)` represents a claim emitted by another node
+    ClaimReceived(Claim),
+
     /// `ClaimAbandoned(String,Vec<u8>)` represents a claim that turned out to
     /// be invalid.
     ClaimAbandoned(NodeId, Claim),

--- a/crates/node/src/components/harvester_module.rs
+++ b/crates/node/src/components/harvester_module.rs
@@ -577,9 +577,7 @@ impl Handler<EventMessage> for HarvesterModule {
                 }
             },
             Event::NoOp => {},
-            _ => {
-                error!("Unexpected event,Can only certify Txns and Convergence block,and can mine proposal block");
-            },
+            _ => {},
         }
 
         Ok(ActorState::Running)

--- a/crates/node/src/components/network/module.rs
+++ b/crates/node/src/components/network/module.rs
@@ -64,7 +64,7 @@ pub struct NetworkModuleConfig {
     pub events_tx: EventPublisher,
 }
 
-#[deprecated(note = "node types will be removed from kademlia-dh-rs soon")]
+#[deprecated(note = "node types will be removed from kademlia-dh-rs")]
 pub fn convert_node_type(node_type: NodeType) -> KNodeType {
     match node_type {
         NodeType::Bootstrap => KNodeType::Bootstrap,

--- a/crates/node/src/components/network/module.rs
+++ b/crates/node/src/components/network/module.rs
@@ -64,6 +64,7 @@ pub struct NetworkModuleConfig {
     pub events_tx: EventPublisher,
 }
 
+#[deprecated(note = "node types will be removed from kademlia-dh-rs soon")]
 pub fn convert_node_type(node_type: NodeType) -> KNodeType {
     match node_type {
         NodeType::Bootstrap => KNodeType::Bootstrap,

--- a/crates/node/src/components/state_module.rs
+++ b/crates/node/src/components/state_module.rs
@@ -835,7 +835,8 @@ mod tests {
 
     #[tokio::test]
     async fn vrrbdb_should_update_with_new_block() {
-        let db_config = VrrbDbConfig::default();
+        let path = std::env::temp_dir().join("db");
+        let db_config = VrrbDbConfig::default().with_path(path);
         let db = VrrbDb::new(db_config);
         let accounts: Vec<(Address, Account)> = produce_accounts(5);
         let dag: StateDag = Arc::new(RwLock::new(BullDag::new()));

--- a/crates/node/src/components/state_module.rs
+++ b/crates/node/src/components/state_module.rs
@@ -627,8 +627,8 @@ impl Handler<EventMessage> for StateModule {
             },
             Event::ClaimCreated(claim) => {},
             Event::ClaimReceived(claim) => {
-                dbg!(&claim.address);
-                telemetry::info!("Storing claim from: {:?}", claim.address);
+                // dbg!(&claim.address);
+                telemetry::info!("Storing claim from: {}", claim.address);
             },
             Event::NoOp => {},
             _ => {},

--- a/crates/node/src/components/state_module.rs
+++ b/crates/node/src/components/state_module.rs
@@ -627,7 +627,6 @@ impl Handler<EventMessage> for StateModule {
             },
             Event::ClaimCreated(claim) => {},
             Event::ClaimReceived(claim) => {
-                // dbg!(&claim.address);
                 telemetry::info!("Storing claim from: {}", claim.address);
             },
             Event::NoOp => {},

--- a/crates/node/src/components/state_module.rs
+++ b/crates/node/src/components/state_module.rs
@@ -13,7 +13,13 @@ use events::{Event, EventMessage, EventPublisher, EventSubscriber};
 use lr_trie::ReadHandleFactory;
 use patriecia::{db::MemoryDB, inner::InnerTrie};
 use primitives::Address;
-use storage::vrrbdb::{StateStoreReadHandle, VrrbDb, VrrbDbConfig, VrrbDbReadHandle};
+use storage::vrrbdb::{
+    RocksDbAdapter,
+    StateStoreReadHandle,
+    VrrbDb,
+    VrrbDbConfig,
+    VrrbDbReadHandle,
+};
 use telemetry::info;
 use theater::{Actor, ActorId, ActorImpl, ActorLabel, ActorState, Handler, TheaterError};
 use vrrb_config::NodeConfig;
@@ -618,6 +624,11 @@ impl Handler<EventMessage> for StateModule {
                 if let Err(err) = self.update_state(block_hash) {
                     telemetry::error!("error updating state: {}", err);
                 }
+            },
+            Event::ClaimCreated(claim) => {},
+            Event::ClaimReceived(claim) => {
+                dbg!(&claim.address);
+                telemetry::info!("Storing claim from: {:?}", claim.address);
             },
             Event::NoOp => {},
             _ => {},

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -48,6 +48,7 @@ pub struct Node {
 pub type UnboundedControlEventReceiver = UnboundedReceiver<Event>;
 
 impl Node {
+    #[telemetry::instrument(fields(node_id = config.id), skip_all)]
     pub async fn start(config: &NodeConfig) -> Result<Self> {
         // Copy the original config to avoid overwriting the original
         let config = config.clone();

--- a/crates/node/src/result.rs
+++ b/crates/node/src/result.rs
@@ -1,5 +1,6 @@
 use std::net::AddrParseError;
 
+use dyswarm::types::DyswarmError;
 use events::EventMessage;
 use miner::result::MinerError;
 use theater::TheaterError;
@@ -63,5 +64,11 @@ pub type Result<T> = std::result::Result<T, NodeError>;
 impl From<NodeError> for TheaterError {
     fn from(err: NodeError) -> Self {
         TheaterError::Other(err.to_string())
+    }
+}
+
+impl From<NodeError> for DyswarmError {
+    fn from(err: NodeError) -> Self {
+        DyswarmError::Other(err.to_string())
     }
 }

--- a/crates/storage/vrrbdb/src/claim_store/mod.rs
+++ b/crates/storage/vrrbdb/src/claim_store/mod.rs
@@ -36,7 +36,7 @@ impl Default for ClaimStore {
 impl ClaimStore {
     /// Returns new, empty instance of ClaimDb
     pub fn new(path: &Path) -> Self {
-        let path = path.join("claim");
+        let path = path.join("claims");
         let db_adapter = RocksDbAdapter::new(path, "claim").unwrap_or_default();
         let trie = LeftRightTrie::new(Arc::new(db_adapter));
 

--- a/crates/storage/vrrbdb/src/rocksdb_adapter.rs
+++ b/crates/storage/vrrbdb/src/rocksdb_adapter.rs
@@ -103,21 +103,17 @@ impl Default for RocksDbAdapter {
         options.create_if_missing(true);
         options.create_missing_column_families(true);
 
-        let db_result = new_db_instance(
+        // TODO: fix this unwrap
+        let db = new_db_instance(
             options,
             DEFAULT_VRRB_DB_PATH.into(),
             DEFAULT_COLUMN_FAMILY_NAME,
-        );
+        )
+        .unwrap();
 
-        match db_result {
-            Ok(db) => Self {
-                db,
-                column: DEFAULT_COLUMN_FAMILY_NAME.to_string(),
-            },
-            Err(e) => {
-                error!("Failed to create database: {}", e);
-                Self::default()
-            },
+        Self {
+            db,
+            column: DEFAULT_COLUMN_FAMILY_NAME.to_string(),
         }
     }
 }

--- a/crates/telemetry/src/subscriber.rs
+++ b/crates/telemetry/src/subscriber.rs
@@ -38,6 +38,7 @@ impl TelemetrySubscriber {
                 .with_writer(out)
                 .with_file(is_local_env)
                 .with_line_number(is_local_env)
+                .with_target(is_local_env)
                 .finish();
 
             sub.try_init()?;

--- a/examples/minichain.rs
+++ b/examples/minichain.rs
@@ -8,7 +8,7 @@ use telemetry::TelemetrySubscriber;
 
 #[tokio::main]
 async fn main() {
-    std::env::set_var("VRRB_ENVIRONMENT", "mainnet");
+    std::env::set_var("VRRB_ENVIRONMENT", "main");
     std::env::set_var("VRRB_PRETTY_PRINT_LOGS", "true");
 
     TelemetrySubscriber::init(std::io::stdout).unwrap();
@@ -17,6 +17,8 @@ async fn main() {
 
     let mut config = node::test_utils::create_mock_full_node_config();
     config.id = String::from("node-0");
+
+    dbg!(config.data_dir());
 
     let node_0 = Node::start(&config).await.unwrap();
 

--- a/examples/minichain.rs
+++ b/examples/minichain.rs
@@ -18,8 +18,6 @@ async fn main() {
     let mut config = node::test_utils::create_mock_full_node_config();
     config.id = String::from("node-0");
 
-    dbg!(config.data_dir());
-
     let node_0 = Node::start(&config).await.unwrap();
 
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);


### PR DESCRIPTION
Cleans up Claim broadcasting and sets it up to trigger on node startup.