### PR TITLE
fix: update `keccak_hash::H256` with `patriecia::H256`

### DIFF
--- a/crates/storage/lr_trie/src/inner_wrapper.rs
+++ b/crates/storage/lr_trie/src/inner_wrapper.rs
@@ -3,9 +3,8 @@ use std::{
     sync::Arc,
 };
 
-use keccak_hash::H256;
 pub use left_right::ReadHandleFactory;
-use patriecia::{db::Database, trie::Trie, InnerTrie, TrieIterator};
+use patriecia::{db::Database, trie::Trie, InnerTrie, TrieIterator, H256};
 use serde::{Deserialize, Serialize};
 
 use crate::{LeftRightTrieError, Result};

--- a/crates/storage/lr_trie/src/lib.rs
+++ b/crates/storage/lr_trie/src/lib.rs
@@ -1,6 +1,6 @@
 /// This crate contains a left-right wrapped, evmap-backed, Merkle-Patricia Trie
 /// heavily inspired by https://github.com/carver/eth-trie.rs which is a fork of https://github.com/citahub/cita-trie
-pub use keccak_hash::H256;
+pub use patriecia::H256;
 
 mod inner;
 mod inner_wrapper;

--- a/crates/storage/lr_trie/src/trie.rs
+++ b/crates/storage/lr_trie/src/trie.rs
@@ -4,10 +4,9 @@ use std::{
     sync::Arc,
 };
 
-use keccak_hash::H256;
 pub use left_right::ReadHandleFactory;
 use left_right::{ReadHandle, WriteHandle};
-use patriecia::{db::Database, inner::InnerTrie};
+use patriecia::{db::Database, inner::InnerTrie, H256};
 use serde::{Deserialize, Serialize};
 
 use crate::{InnerTrieWrapper, LeftRightTrieError, Operation, Proof, Result};


### PR DESCRIPTION
Makes use of `patriecia::serde_hash::H256` which is an adaptation of `keccak_hash::H256` that implements `serde`'s derived macros for `Serialize` & `Deserialize`. Handles breaking changes introduced by https://github.com/vrrb-io/patriecia/pull/15

Closes #400 