### PR TITLE
Set default run attribute on Cargo.toml to run vrrb by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 authors = ["VRRB Labs <info@vrrb.io>"]
 edition = "2021"
 readme = "README.md"
+default-run = "vrrb"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
This is to preserve old behavior while maintaining the other binaries.