### PR TITLE
Fix Low Hanging Clippy Issues

### DIFF
--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -299,7 +299,7 @@ pub async fn run(args: RunOpts) -> Result<()> {
 
 #[telemetry::instrument]
 async fn run_blocking(node_config: NodeConfig) -> Result<()> {
-    let mut vrrb_node = Node::start(&node_config)
+    let vrrb_node = Node::start(&node_config)
         .await
         .map_err(|_| CliError::Other(String::from("failed to listen for ctrl+c")))?;
 

--- a/crates/consensus/job_pool/src/pool.rs
+++ b/crates/consensus/job_pool/src/pool.rs
@@ -124,7 +124,7 @@ impl JobPool {
         if let Ok(mut workers_count) = self.state.jobs_count.lock() {
             if deadline.is_none() {
                 if let Ok(waiting_workers) = self.state.shutdown.wait(workers_count) {
-                    // this reassignment is never read, not sure what the intention is...
+                    //todo: this reassignment is never read, not sure what the intention is...
                     workers_count = waiting_workers;
                 };
             } else {

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -9,26 +9,20 @@ use block::{
     ProposalBlock,
     RefHash,
 };
-use ethereum_types::U256;
-use mempool::TxnRecord;
 use primitives::{
     Address,
     Epoch,
-    FarmerQuorumThreshold,
     NodeId,
     NodeIdx,
     PublicKeyShareVec,
-    QuorumPublicKey,
-    QuorumSize,
     RawSignature,
     Round,
     Seed,
 };
-use quorum::quorum::Quorum;
 use serde::{Deserialize, Serialize};
 use vrrb_core::{
     claim::Claim,
-    txn::{QuorumCertifiedTxn, TransactionDigest, Txn},
+    txn::{TransactionDigest, Txn},
 };
 
 use crate::event_data::*;

--- a/crates/events/src/event_data.rs
+++ b/crates/events/src/event_data.rs
@@ -11,7 +11,6 @@ use primitives::{
     NodeId,
     NodeIdx,
     NodeType,
-    PeerId,
     RawSignature,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -4,12 +4,10 @@ use std::{
 };
 
 use block::{
-    invalid::InvalidBlockErrorReason,
     Block,
     GenesisBlock,
     InnerBlock,
     ProposalBlock,
-    TxnList,
 };
 use bulldag::{graph::BullDag, vertex::Vertex};
 use ethereum_types::U256;

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -8,10 +8,7 @@ use tokio::task::JoinHandle;
 use vrrb_config::NodeConfig;
 use vrrb_rpc::rpc::{JsonRpcServer, JsonRpcServerConfig};
 
-use crate::{
-    result::{NodeError, Result},
-    RuntimeComponentHandle,
-};
+use crate::result::{NodeError, Result};
 
 pub async fn setup_rpc_api_server(
     config: &NodeConfig,

--- a/crates/node/src/consensus/consensus_component.rs
+++ b/crates/node/src/consensus/consensus_component.rs
@@ -1,22 +1,8 @@
-use std::collections::HashSet;
-
 use async_trait::async_trait;
-use block::{ProposalBlock, RefHash};
-use events::{Event, EventMessage, EventPublisher, EventSubscriber, Vote};
-use hbbft::crypto::PublicKeyShare;
-use primitives::{BlockHash, Epoch, FarmerQuorumThreshold, NodeIdx, RawSignature, Round};
-use ritelinked::LinkedHashMap;
-use signer::signer::SignatureProvider;
+use events::{EventPublisher, EventSubscriber};
 use storage::vrrbdb::VrrbDbReadHandle;
-use telemetry::info;
-use theater::{Actor, ActorId, ActorImpl, ActorLabel, ActorState, Handler};
+use theater::{Actor, ActorImpl};
 use vrrb_config::NodeConfig;
-use vrrb_core::{
-    bloom::Bloom,
-    claim::Claim,
-    keypair::Keypair,
-    txn::{QuorumCertifiedTxn, TransactionDigest},
-};
 
 use crate::{
     consensus::{ConsensusModule, ConsensusModuleConfig},

--- a/crates/node/src/consensus/quorum_component.rs
+++ b/crates/node/src/consensus/quorum_component.rs
@@ -3,15 +3,14 @@ use std::collections::{BTreeMap, HashMap};
 use async_trait::async_trait;
 use block::header::BlockHeader;
 use ethereum_types::U256;
-use events::{Event, EventMessage, EventPublisher, EventSubscriber, PeerData};
+use events::{EventPublisher, EventSubscriber};
 use primitives::NodeId;
 use quorum::{
     election::Election,
     quorum::{InvalidQuorum, Quorum},
 };
 use storage::vrrbdb::VrrbDbReadHandle;
-use telemetry::info;
-use theater::{Actor, ActorId, ActorImpl, ActorLabel, ActorState, Handler};
+use theater::{Actor, ActorId, ActorImpl, ActorState};
 use vrrb_config::{BootstrapQuorumConfig, NodeConfig, QuorumKind, QuorumMember};
 use vrrb_core::claim::{Claim, Eligibility};
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -16,11 +16,7 @@ use crate::{
     result::Result,
     runtime::setup_runtime_components,
     NodeError,
-    NodeState,
-    OptionalRuntimeHandle,
-    RaptorHandle,
     RuntimeComponentManager,
-    SchedulerHandle,
 };
 
 /// Node represents a member of the VRRB network and it is responsible for

--- a/crates/node/src/runtime_component.rs
+++ b/crates/node/src/runtime_component.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, thread};
 
 use tokio::task::JoinHandle;
-use vrrb_config::NodeConfig;
 
 use crate::Result;
 

--- a/crates/node/src/state_manager/state_manager.rs
+++ b/crates/node/src/state_manager/state_manager.rs
@@ -12,14 +12,14 @@ use mempool::LeftRightMempool;
 use primitives::Address;
 use storage::vrrbdb::{StateStoreReadHandle, VrrbDb, VrrbDbReadHandle};
 use telemetry::info;
-use theater::{Actor, ActorId, ActorState, Handler};
+use theater::{ActorId, ActorState};
 use vrrb_core::{
     account::{Account, AccountDigests, UpdateArgs},
     claim::Claim,
     txn::{Token, TransactionDigest, Txn},
 };
 
-use crate::{NodeError, Result, RuntimeComponent, RuntimeComponentHandle};
+use crate::{NodeError, Result};
 
 /// Provides a wrapper around the current rounds `ConvergenceBlock` and
 /// the `ProposalBlock`s that it is made up of. Provides a convenient

--- a/crates/vrrb_config/src/bootstrap.rs
+++ b/crates/vrrb_config/src/bootstrap.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use primitives::{KademliaPeerId, NodeId};
+use primitives::KademliaPeerId;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use derive_builder::Builder;
-use primitives::{KademliaPeerId, NodeId, NodeIdx, NodeType, PeerId, DEFAULT_VRRB_DATA_DIR_PATH};
+use primitives::{KademliaPeerId, NodeId, NodeIdx, NodeType, DEFAULT_VRRB_DATA_DIR_PATH};
 use serde::Deserialize;
 use uuid::Uuid;
 use vrrb_core::keypair::Keypair;

--- a/crates/wasm_cli/src/commands/validate/mod.rs
+++ b/crates/wasm_cli/src/commands/validate/mod.rs
@@ -44,12 +44,12 @@ pub fn run(opts: &ValidateOpts) -> Result<()> {
     }
 
     let mut extra_namespaces = vec![];
-    for key in w.imports.keys().into_iter() {
+    for key in w.imports.keys() {
         if !SUPPORTED_NAMESPACES.contains(&key.as_str()) {
             extra_namespaces.push(key);
         }
     }
-    if extra_namespaces.len() != 0 {
+    if !extra_namespaces.is_empty() {
         println!(
             "Found references to unexpected namespaces: {:?}",
             extra_namespaces

--- a/crates/wasm_cli/src/main.rs
+++ b/crates/wasm_cli/src/main.rs
@@ -10,10 +10,10 @@ fn main() -> Result<()> {
     // Process subcommand
     match &cli.cmd {
         Some(cli::WasmCommands::Describe(opts)) => {
-            commands::describe::run(&opts)?;
+            commands::describe::run(opts)?;
         },
         Some(cli::WasmCommands::Validate(opts)) => {
-            commands::validate::run(&opts)?;
+            commands::validate::run(opts)?;
         },
         None => {},
     }

--- a/crates/wasm_loader/src/wasm_loader.rs
+++ b/crates/wasm_loader/src/wasm_loader.rs
@@ -79,7 +79,7 @@ impl WasmLoaderBuilder {
         match &self.wasm_bytes {
             Some(b) => {
                 // Try to match the magic header bytes
-                if self.contains_magic(&b) {
+                if self.contains_magic(b) {
                     debug!("WASM header looks legit");
                     return Ok(());
                 } else {
@@ -106,7 +106,7 @@ impl WasmLoaderBuilder {
 
     /// Simple function to compare the first four bytes of an array with the
     /// well-known WASM magic string, '\0asm'.
-    fn contains_magic(&self, bytes: &Vec<u8>) -> bool {
+    fn contains_magic(&self, bytes: &[u8]) -> bool {
         let header = &bytes[0..4];
 
         debug!("WASM header missing: {:02x?}", header);
@@ -125,12 +125,12 @@ impl WasmLoaderBuilder {
         debug!("Checking for WAT");
         if let Some(wat) = &self.wat_text {
             debug!("Found WASM Text -- attempting to compile to WASM");
-            new.wasm_bytes = Some(wat2wasm(&wat)?.into_owned());
+            new.wasm_bytes = Some(wat2wasm(wat)?.into_owned());
             new.from_wat = Some(true);
         }
 
         if let Some(wasm) = &self.wasm_bytes {
-            for payload in Parser::new(constants::WASM_PARSE_OFFSET).parse_all(&wasm) {
+            for payload in Parser::new(constants::WASM_PARSE_OFFSET).parse_all(wasm) {
                 match payload {
                     Ok(p) => {
                         match p {


### PR DESCRIPTION
This corrects a number of low hanging clippy issues. Most unused imports in files that do not have commented code blocks so they won't be used in the future. A few suggested removals of mut, &, etc