### PR TITLE
Refactor network component to account for quorum configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ udp2p = { git = "https://github.com/ASmithOWL/udp2p" }
 theater = { git = "https://github.com/vrrb-io/theater" }
 hbbft = { git = "https://github.com/vrrb-io/hbbft", branch = "master" }
 bulldag = { git = "https://github.com/vrrb-io/bulldag", branch = "main" }
-kademlia-dht = { git = "https://github.com/vrrb-io/kademlia-dht-rs", branch = "feat-metadata-includes-node-type" }
+kademlia-dht = { git = "https://github.com/vrrb-io/kademlia-dht-rs" }
 rendezvous_dht = { git = "https://github.com/vrrb-io/rendezvous_dht" }
 messr = { git = "https://github.com/vrrb-io/messr" }
 decentrust = { git = "https://github.com/vrrb-io/decentrust", branch = "main" }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -9,16 +9,7 @@ use block::{
     ProposalBlock,
     RefHash,
 };
-use primitives::{
-    Address,
-    Epoch,
-    NodeId,
-    NodeIdx,
-    PublicKeyShareVec,
-    RawSignature,
-    Round,
-    Seed,
-};
+use primitives::{Address, Epoch, NodeId, NodeIdx, PublicKeyShareVec, RawSignature, Round, Seed};
 use serde::{Deserialize, Serialize};
 use vrrb_core::{
     claim::Claim,
@@ -118,6 +109,12 @@ pub enum Event {
     /// parameter contains a list of socket addresses of the peers
     /// that failed to synchronize their address.
     PeerSyncFailed(Vec<SocketAddr>),
+
+    /// `BlockCreated(Block)` is an event that occurs whenever a block of any
+    /// kind is created
+    BlockCreated(Block),
+
+    GenesisQuorumMembersAvailable,
 
     // TODO: refactor all the events below
     // ==========================================================================

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -3,12 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use block::{
-    Block,
-    GenesisBlock,
-    InnerBlock,
-    ProposalBlock,
-};
+use block::{Block, GenesisBlock, InnerBlock, ProposalBlock};
 use bulldag::{graph::BullDag, vertex::Vertex};
 use ethereum_types::U256;
 use primitives::{Address, PublicKey, SecretKey, Signature};

--- a/crates/node/src/network/handler.rs
+++ b/crates/node/src/network/handler.rs
@@ -1,0 +1,115 @@
+use std::{collections::HashMap, net::SocketAddr, ops::AddAssign};
+
+use async_trait::async_trait;
+use dyswarm::{
+    client::{BroadcastArgs, BroadcastConfig},
+    server::ServerConfig,
+};
+use events::{Event, EventMessage, EventPublisher, EventSubscriber};
+use kademlia_dht::{Key, Node as KademliaNode, NodeData};
+use primitives::{KademliaPeerId, NodeId, NodeType};
+use storage::vrrbdb::VrrbDbReadHandle;
+use telemetry::info;
+use theater::{Actor, ActorId, ActorImpl, ActorLabel, ActorState, Handler, TheaterError};
+use tracing::Subscriber;
+use utils::payload::digest_data_to_bytes;
+use vrrb_config::{BootstrapQuorumConfig, NodeConfig, QuorumMembershipConfig};
+use vrrb_core::claim::Claim;
+
+use super::{NetworkEvent, NetworkModule};
+use crate::{
+    network::DyswarmHandler,
+    result::Result,
+    NodeError,
+    RuntimeComponent,
+    RuntimeComponentHandle,
+    DEFAULT_ERASURE_COUNT,
+};
+
+#[async_trait]
+impl Handler<EventMessage> for NetworkModule {
+    fn id(&self) -> ActorId {
+        self.id.clone()
+    }
+
+    fn label(&self) -> ActorLabel {
+        format!("Network::{}", self.id())
+    }
+
+    fn status(&self) -> ActorState {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, actor_status: ActorState) {
+        self.status = actor_status;
+    }
+
+    async fn handle(&mut self, event: EventMessage) -> theater::Result<ActorState> {
+        match event.into() {
+            Event::PeerJoined(peer_data) => {
+                info!("Storing peer information from {} in DHT", peer_data.node_id);
+
+                // TODO: revisit this insert method
+                self.kademlia_node.insert(
+                    peer_data.kademlia_peer_id,
+                    &peer_data.kademlia_liveness_addr.to_string(),
+                );
+
+                self.events_tx
+                    .send(Event::NodeAddedToPeerList(peer_data.clone()).into())
+                    .await
+                    .map_err(|err| TheaterError::Other(err.to_string()))?;
+
+                if let Some(quorum_config) = self.bootstrap_quorum_config.clone() {
+                    let node_id = peer_data.node_id;
+
+                    let quorum_member_ids = quorum_config
+                        .membership_config
+                        .quorum_members
+                        .iter()
+                        .cloned()
+                        .map(|membership| membership.member.node_id)
+                        .collect::<Vec<NodeId>>();
+
+                    if quorum_member_ids.contains(&node_id) {
+                        self.bootstrap_quorum_available_nodes.insert(node_id, true);
+                    }
+
+                    let available_nodes = self.bootstrap_quorum_available_nodes.clone();
+
+                    if available_nodes.iter().all(|(_, is_online)| *is_online) {
+                        info!("All quorum members are online. Triggering genesis quorum elections");
+
+                        self.events_tx
+                            .send(Event::GenesisQuorumMembersAvailable.into())
+                            .await
+                            .map_err(|err| TheaterError::Other(err.to_string()))?;
+                    }
+                }
+            },
+
+            Event::ClaimCreated(claim) => {
+                info!("Broadcasting claim to peers");
+                self.broadcast_claim(claim).await?;
+            },
+
+            Event::Stop => {
+                // NOTE: stop the kademlia node instance
+                self.node_ref().kill();
+                return Ok(ActorState::Stopped);
+            },
+            Event::NoOp => {},
+            _ => {},
+        }
+
+        Ok(ActorState::Running)
+    }
+
+    fn on_stop(&self) {
+        info!(
+            "{}-{} received stop signal. Stopping",
+            self.label(),
+            self.id(),
+        );
+    }
+}

--- a/crates/node/src/network/mod.rs
+++ b/crates/node/src/network/mod.rs
@@ -1,7 +1,9 @@
-mod module;
+mod component;
+mod handler;
 mod network_event;
 mod network_event_handler;
 
-pub use module::*;
+pub use component::*;
+pub use handler::*;
 pub use network_event::*;
 pub use network_event_handler::*;

--- a/crates/node/src/network/network_event_handler.rs
+++ b/crates/node/src/network/network_event_handler.rs
@@ -40,6 +40,9 @@ impl dyswarm::server::Handler<NetworkEvent> for DyswarmHandler {
                     kademlia_liveness_addr,
                 });
 
+                // TODO: once all known peers have been joined, send a `NetworkReady` event so a
+                // dkg can be started and the first quorums can be formed
+
                 self.events_tx
                     .send(evt.into())
                     .await

--- a/crates/node/src/runtime.rs
+++ b/crates/node/src/runtime.rs
@@ -78,6 +78,7 @@ pub async fn setup_runtime_components(
         network_events_rx,
         vrrbdb_read_handle: state_read_handle.clone(),
         bootstrap_quorum_config: config.bootstrap_quorum_config.clone(),
+        membership_config: config.quorum_config.clone(),
     })
     .await?;
 


### PR DESCRIPTION
Refactors the node's networking component to accept bootstrap quorum configuration to start a genesis quorum formation to create and validate a genesis block.